### PR TITLE
25:  Create sign-in landing page

### DIFF
--- a/client/app/routes/index.js
+++ b/client/app/routes/index.js
@@ -1,0 +1,4 @@
+import Route from '@ember/routing/route';
+
+export default class IndexRoute extends Route {
+}

--- a/client/app/templates/index.hbs
+++ b/client/app/templates/index.hbs
@@ -1,0 +1,51 @@
+<div class="grid-x grid-margin-x">
+  <div class="cell">
+
+    <h1 class="header-xlarge large-margin-bottom">
+      <strong>Sign in with your NYC.ID account to draft, submit, review, revise, file, and track your applications with the Department&nbsp;of City&nbsp;Planning.</strong>
+    </h1>
+
+  </div>
+  <div class="cell large-7">
+
+    <div class="callout">
+      <h4>
+        <FaIcon @icon="exclamation-triangle" @prefix="fas" class="text-gold tiny-margin-right" />
+        <b class="text-gold-muted">Before signing in&hellip;</b>
+      </h4>
+
+      <p class="text-large">
+        An informational meeting must be held with the Department&nbsp;of City&nbsp;Planning.
+        Only then will a project be created and assigned to you in this system.
+      </p>
+
+      <p class="text-large">
+        Your NYC.ID account must use the email address that is associated with this system.
+        If you're unsure which email address to use, please contact City Planning at
+        <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or <a href="tel:212-720-3300">212-720-3300</a>.
+      </p>
+
+      <p>
+        <a href="https://www1.nyc.gov/assets/nyc4d/html/services-nycid/user-features-benefits.shtml">What is NYC.ID?</a>
+      </p>
+
+    </div>
+
+  </div>
+  <div class="cell large-5">
+
+    <a href="/nycid.html" class="button large expanded">
+      <b>Sign In</b>
+      &nbsp;<FaIcon @icon="external-link-alt" @prefix="fas" @fixedWidth={{true}} />
+    </a>
+
+    <ul class="">
+      <li class="small-margin-bottom">For NYC.GOV credentials, select the "NYC Employees" option</li>
+      <li class="small-margin-bottom">For non-NYC.GOV email addresses, enter your existing NYC.ID credentials (you may need to create an NYC.ID account)</li>
+      <li class="small-margin-bottom">Once signed in, you'll be redirected back to this site, where you'll see your list of projects.</li>
+    </ul>
+
+  </div>
+</div>
+
+{{outlet}}

--- a/client/tests/unit/routes/index-test.js
+++ b/client/tests/unit/routes/index-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | index', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:index');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
This PR addresses #25  by adding the template and route for the sign-in landing page:
### Desktop  
![image](https://user-images.githubusercontent.com/5316367/78271356-0ee80280-74da-11ea-8a9c-891ced8fbee9.png)

### Mobile
![image](https://user-images.githubusercontent.com/5316367/78271643-625a5080-74da-11ea-828d-107998ff3249.png)

