### PR TITLE
Skip middleware auth for login route

### DIFF
--- a/server/src/auth.middleware.ts
+++ b/server/src/auth.middleware.ts
@@ -11,6 +11,13 @@ export class AuthMiddleware implements NestMiddleware {
   constructor(private readonly authService: AuthService) { }
 
   async use(req: any, res: any, next: () => void) {
+    // skip for the login route
+    if (req.originalUrl.includes('login')) {
+      next();
+
+      return;
+    }
+
     req.session = false;
 
     const { token } = req.cookies;

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -110,8 +110,6 @@ export class AuthService {
    * @param      {string}  token   The token
    */
   public validateCurrentToken(token: string) {
-    const { CRM_IMPOSTER_ID } = this;
-
     return this.verifyCRMToken(token);
   }
 


### PR DESCRIPTION
The recently introduced middleware checked each request for a cookie with valid ZAP token. However, this does not need to happen for the initial request to the login route, which is used to acquire that ZAP token. I.e. this avoids a chicken and egg problem 🥚 🐔 ❓ 