### PR TITLE
15: add statecode, statuscode, dcp_visibility conditions to projects endpoint

### DIFF
--- a/server/src/projects/projects.controller.ts
+++ b/server/src/projects/projects.controller.ts
@@ -51,7 +51,7 @@ export class ProjectsController {
   serialize(records, opts?: object): Serializer {
 
     const ProjectsSerializer = new Serializer('projects', {
-      attributes: ['dcp_projectname', 'dcp_name', 'statecode', 'dcp_visibility', 'dcp_dcp_project_dcp_projectapplicant_Project', 'dcp_dcp_project_dcp_package_project'],
+      attributes: ['dcp_projectname', 'dcp_name', 'statecode', 'dcp_visibility', '_dcp_applicant_customer_value', 'dcp_dcp_project_dcp_projectapplicant_Project', 'dcp_dcp_project_dcp_package_project'],
       id: 'dcp_projectid',
       meta: { ...opts },
       keyForAttribute(key) {

--- a/server/src/projects/projects.service.ts
+++ b/server/src/projects/projects.service.ts
@@ -15,8 +15,15 @@ export class ProjectsService {
   public async findManyByContactId(contactId: string) {
     let results = null;
 
+    const applicantActiveStatusCode = '1';
+    const projectActiveStateCode = '0';
+    const packageVisibilityApplicantOnly = '717170002';
+    const packageVisibilityGeneralPublic = '717170003';
+    const projectVisibilityApplicantOnly = '717170002';
+    const projectVisibilityGeneralPublic = '717170003';
+
     try  {
-      results = await this.crmService.get(`dcp_projects?$filter=%20dcp_dcp_project_dcp_projectapplicant_Project/%20any(o:o/_dcp_applicant_customer_value%20eq%20%20%27${contactId}%27)%20&$expand=%20dcp_dcp_project_dcp_package_project,%20dcp_dcp_project_dcp_projectapplicant_Project`);
+      results = await this.crmService.get(`dcp_projects?$filter=dcp_dcp_project_dcp_projectapplicant_Project/any(o:o/_dcp_applicant_customer_value%20eq%20%27${contactId}%27)%20and%20(dcp_visibility%20eq%20${projectVisibilityApplicantOnly}%20or%20dcp_visibility%20eq%20${projectVisibilityGeneralPublic})&$expand=dcp_dcp_project_dcp_package_project($filter=%20statecode%20eq%20${projectActiveStateCode}%20and%20(dcp_visibility%20eq%20${packageVisibilityApplicantOnly}%20or%20dcp_visibility%20eq%20${packageVisibilityGeneralPublic})),dcp_dcp_project_dcp_projectapplicant_Project($filter=%20statecode%20eq%20${applicantActiveStatusCode})`);
     } catch(e) {
       const errorMessage = `Error finding projects by contact ID. ${e.message}`;
       console.log(errorMessage);


### PR DESCRIPTION
Add extra conditions to projects endpoint query -- outlined in issue #15 

**NOTE**: for primary applicant on a project I referred to `_dcp_applicantadministrator_customer_value` but there's also a `_dcp_applicant_customer_value` on dcp_project that might actually be the primary applicant field. Administrator might just refer to the person who was logged in to CRM. Need to clarify before merging