### PR TITLE
Improve code quality by preventing contactService call if no contactId present

### DIFF
--- a/server/src/app.controller.ts
+++ b/server/src/app.controller.ts
@@ -40,13 +40,13 @@ export class AppController {
   async getUser(@Session() session, @Res() res) {
     const { contactId } = session;
 
-    const contact = await this.contactService.findOneById(contactId);
-
     if (!contactId) {
       res.status(401).send({
         errors: ['Authentication required for this route'],
       });
     } else {
+      const contact = await this.contactService.findOneById(contactId);
+
       res.send(this.serialize([contact]));
     }
   }


### PR DESCRIPTION
This is a small code quality improvement. The contactService.findOneById(contactId)
method should never be called if contactId is not present.