### PR TITLE
15: fix projects endpoint query, move project statecode filtering

### DIFF
--- a/server/src/projects/projects.service.ts
+++ b/server/src/projects/projects.service.ts
@@ -23,7 +23,7 @@ export class ProjectsService {
     const projectVisibilityGeneralPublic = '717170003';
 
     try  {
-      results = await this.crmService.get(`dcp_projects?$filter=dcp_dcp_project_dcp_projectapplicant_Project/any(o:o/_dcp_applicant_customer_value%20eq%20%27${contactId}%27)%20and%20(dcp_visibility%20eq%20${projectVisibilityApplicantOnly}%20or%20dcp_visibility%20eq%20${projectVisibilityGeneralPublic})&$expand=dcp_dcp_project_dcp_package_project($filter=%20statecode%20eq%20${projectActiveStateCode}%20and%20(dcp_visibility%20eq%20${packageVisibilityApplicantOnly}%20or%20dcp_visibility%20eq%20${packageVisibilityGeneralPublic})),dcp_dcp_project_dcp_projectapplicant_Project($filter=%20statecode%20eq%20${applicantActiveStatusCode})`);
+      results = await this.crmService.get(`dcp_projects?$filter=dcp_dcp_project_dcp_projectapplicant_Project/any(o:o/_dcp_applicant_customer_value%20eq%20%27${contactId}%27)%20and%20(dcp_visibility%20eq%20${projectVisibilityApplicantOnly}%20or%20dcp_visibility%20eq%20${projectVisibilityGeneralPublic})%20and%20statecode%20eq%20${projectActiveStateCode}&$expand=dcp_dcp_project_dcp_package_project($filter=dcp_visibility%20eq%20${packageVisibilityApplicantOnly}%20or%20dcp_visibility%20eq%20${packageVisibilityGeneralPublic}),dcp_dcp_project_dcp_projectapplicant_Project($filter=%20statuscode%20eq%20${applicantActiveStatusCode})`);
     } catch(e) {
       const errorMessage = `Error finding projects by contact ID. ${e.message}`;
       console.log(errorMessage);


### PR DESCRIPTION
Fix minor errors in projects endpoint query -- move where we were filtering statecode for project and update statecode to statuscode for applicants.