### PR TITLE
14:  Add netlify configuration

### DIFF
--- a/client/netlify.toml
+++ b/client/netlify.toml
@@ -1,8 +1,0 @@
-[build]
-command = "HOST=https://applicant-portal-staging.herokuapp.com yarn build --environment=production"
-
-[context.master]
-command = "HOST=https://applicant-portal-staging.herokuapp.com yarn build --environment=production"
-
-[context.develop]
-command = "HOST=https://applicant-portal-staging.herokuapp.com yarn build --environment=production"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,20 @@
+[build]
+  base= "client/"
+  command = "yarn build --environment=production"
+
+# production
+[context.master]
+  environment = { HOST="https://applicant-portal.herokuapp.com/" }
+
+# staging
+[context.staging]
+  environment = { HOST="https://applicant-portal-staging.herokuapp.com" }
+
+# qa team
+[context.qa]
+  environment = { HOST="https://applicant-portal-qa.herokuapp.com" }
+
+# develop
+[context.develop]
+  environment = { HOST="https://applicant-portal-develop.herokuapp.com" }
+


### PR DESCRIPTION
This PR addresses #14 by adding the netlify configuration for:
- production
- staging
- qa
- develop

The `HOST` URLs referred to in this `netlify.toml` are heroku apps that have already been setup through the Heroku UI.  

![image](https://user-images.githubusercontent.com/5316367/78705890-2bba7680-78dc-11ea-8b42-0608a662dbdb.png)

Note:  Currently the Heroku develop and staging apps are both identical (didn't want to break it before the demo).