### PR TITLE
Add logout component, route; migrate logic to new objects

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -43,7 +43,7 @@ module.exports = {
     'no-restricted-syntax': 1,
     'prefer-const': 1,
     'no-underscore-dangle': 0,
-    'no-use-before-define': 1,
+    'no-use-before-define': 0,
     'no-return-assign': 1,
     camelcase: 0,
     'class-methods-use-this': 0,

--- a/client/app/components/do-logout.hbs
+++ b/client/app/components/do-logout.hbs
@@ -1,0 +1,7 @@
+{{!-- Implicit logout — this renders the logout domain --}}
+<iframe
+  class="nyc-id-logout-iframe"
+  title="hidden-logout-iframe"
+  src="{{this.nycIDHost}}"
+>
+</iframe>

--- a/client/app/components/do-logout.js
+++ b/client/app/components/do-logout.js
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+import ENV from '../config/environment';
+
+export default class DoLogoutComponent extends Component {
+  get nycIDHost() {
+    const { origin } = new URL(ENV.NYCIDLocation || 'https://accounts-nonprd.nyc.gov');
+
+    return `${origin}/account/idpLogout.htm?x-frames-allow-from=${this.origin}`;
+  }
+
+  origin = window.location.origin;
+}

--- a/client/app/controllers/application.js
+++ b/client/app/controllers/application.js
@@ -1,12 +1,12 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default class ApplicationController extends Controller {
   @service session;
 
   @action
-  invalidateSession() {
-    this.session.invalidate();
+  doLogout() {
+    this.transitionToRoute('logout');
   }
 }

--- a/client/app/models/project.js
+++ b/client/app/models/project.js
@@ -5,7 +5,7 @@ export default class ProjectModel extends Model {
 
   @attr dcpApplicantCustomerValue;
 
-  @attr() dcpDcpProjectDcpPackageProject;
+  @attr({ defaultValue: () => [] }) dcpDcpProjectDcpPackageProject;
 
   get packages() {
     const [firstPackage] = this.dcpDcpProjectDcpPackageProject

--- a/client/app/router.js
+++ b/client/app/router.js
@@ -11,4 +11,5 @@ export default class Router extends EmberRouter {
 Router.map(function() { // eslint-disable-line
   this.route('projects');
   this.route('login');
+  this.route('logout');
 });

--- a/client/app/routes/logout.js
+++ b/client/app/routes/logout.js
@@ -1,0 +1,12 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+
+export default class LogoutRoute extends Route {
+  @service session;
+
+  @action
+  didTransition() {
+    this.session.invalidate();
+  }
+}

--- a/client/app/templates/application.hbs
+++ b/client/app/templates/application.hbs
@@ -15,9 +15,10 @@
       <li><a href="https://zap.planning.nyc.gov">Find Projects</a></li>
       <li>
         {{#if this.session.isAuthenticated}}
-          <button {{on "click" this.invalidateSession}}
+          <button {{on "click" this.doLogout}}
             href="#"
             type="button"
+            data-test-auth="logout"
           >
             Logout
           </button>

--- a/client/app/templates/logout.hbs
+++ b/client/app/templates/logout.hbs
@@ -1,0 +1,11 @@
+<DoLogout/>
+
+<div class="cell">
+  <div class="grid-container">
+    <div class="grid-x grid-padding-x grid-padding-y align-middle">
+      <div class="cell large-6 large-offset-3 text-center">
+        <h2>You have successfully signed out.</h2>
+      </div>
+    </div>
+  </div>
+</div>

--- a/client/config/environment.js
+++ b/client/config/environment.js
@@ -50,7 +50,6 @@ module.exports = function(environment) {
     ENV.APP.autoboot = false;
 
     ENV.host = '';
-    ENV.NYCIDLocation = '/login#access_token=test';
   }
 
   if (environment === 'production') {
@@ -77,5 +76,9 @@ function getOAuthHost(environment) {
     return 'https://accounts-nonprd.nyc.gov/account/api/oauth/authorize.htm?response_type=token&client_id=applicant-portal-staging';
   }
 
-  return '/';
+  if (environment === 'test') {
+    return '';
+  }
+
+  return '';
 }

--- a/client/tests/acceptance/user-can-login-test.js
+++ b/client/tests/acceptance/user-can-login-test.js
@@ -1,8 +1,9 @@
 import { module, test } from 'qunit';
-import { visit } from '@ember/test-helpers';
+import { visit, click, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import window, { setupWindowMock } from 'ember-window-mock';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { authenticateSession, currentSession } from 'ember-simple-auth/test-support';
 
 module('Acceptance | user can login', function(hooks) {
   setupApplicationTest(hooks);
@@ -19,5 +20,17 @@ module('Acceptance | user can login', function(hooks) {
 
     window.location.hash = '#access_token=a-valid-jwt';
     await visit('/login');
+  });
+
+  test('User can logout', async function (assert) {
+    this.server.createList('project', 10);
+
+    await authenticateSession();
+
+    await visit('/projects');
+    await click('[data-test-auth="logout"]');
+
+    assert.equal(currentURL(), '/logout');
+    assert.equal(currentSession().isAuthenticated, false);
   });
 });

--- a/client/tests/integration/components/do-logout-test.js
+++ b/client/tests/integration/components/do-logout-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | do-logout', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<DoLogout />`);
+
+    assert.equal(this.element.textContent.trim(), '');
+  });
+});

--- a/client/tests/unit/routes/logout-test.js
+++ b/client/tests/unit/routes/logout-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | logout', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    const route = this.owner.lookup('route:logout');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
This commit creates a logout route, which invalidates the local SimpleAuth session and renders a special NYC.ID logout iframe that implicitly invalidates the token they provide to the user.