### PR TITLE
Fix landing page sign-in button, redirect to nycid

### DIFF
--- a/client/app/controllers/index.js
+++ b/client/app/controllers/index.js
@@ -1,0 +1,16 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import window from 'ember-window-mock';
+import ENV from '../config/environment';
+
+// TODO:  Don't repeat this logic from components/sign-in-button.js, make it reusable!
+export default class IndexController extends Controller {
+  get loginLocation() {
+    return ENV.NYCIDLocation;
+  }
+
+  @action
+  handleLogin() {
+    window.location.href = this.loginLocation;
+  }
+}

--- a/client/app/models/project.js
+++ b/client/app/models/project.js
@@ -10,14 +10,12 @@ export default class ProjectModel extends Model {
   get packages() {
     const [firstPackage] =
       this.dcpDcpProjectDcpPackageProject
-        .filter(projectPackage => projectPackage['dcp-packagetype'] === 'PAS Package')
+        .filter((projectPackage) => projectPackage['dcp-packagetype'] === 'PAS Package')
         .sortBy('versionnumber')
         .reverse();
 
     if (firstPackage) {
       return [firstPackage];
-    } else {
-      return [];
-    }
+    } return [];
   }
 }

--- a/client/app/templates/index.hbs
+++ b/client/app/templates/index.hbs
@@ -34,7 +34,7 @@
   </div>
   <div class="cell large-5">
 
-    <a href="/nycid.html" class="button large expanded">
+    <a {{ on "click" this.handleLogin }} href="#" class="button large expanded">
       <b>Sign In</b>
       &nbsp;<FaIcon @icon="external-link-alt" @prefix="fas" @fixedWidth={{true}} />
     </a>

--- a/client/tests/unit/controllers/index-test.js
+++ b/client/tests/unit/controllers/index-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | index', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let controller = this.owner.lookup('controller:index');
+    assert.ok(controller);
+  });
+});


### PR DESCRIPTION
This PR is a hot fix to have the big orange sign in button on the landing page to redirect users to nyc id.

It copies the logic used in the sign-in button in an index.js controller (left a todo to make this DRY, but wanted to get this hot fix in for demo).

![2020-04-07 14 54 24](https://user-images.githubusercontent.com/5316367/78708192-bd77b300-78df-11ea-9ff2-343ead0f876c.gif)
