### PR TITLE
Revert netlify build command syntax for HOST env

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,20 +1,19 @@
 [build]
   base= "client/"
-  command = "yarn build --environment=production"
 
 # production
 [context.master]
-  environment = { HOST="https://applicant-portal.herokuapp.com/" }
+  command = "HOST=https://applicant-portal.herokuapp.com yarn build --environment=production"
 
 # staging
 [context.staging]
-  environment = { HOST="https://applicant-portal-staging.herokuapp.com" }
+  command = "HOST=https://applicant-portal-staging.herokuapp.com yarn build --environment=production"
 
 # qa team
 [context.qa]
-  environment = { HOST="https://applicant-portal-qa.herokuapp.com" }
+  command = "HOST=https://applicant-portal-qa.herokuapp.com yarn build --environment=production"
 
 # develop
 [context.develop]
-  environment = { HOST="https://applicant-portal-develop.herokuapp.com" }
+  command = "HOST=https://applicant-portal-develop.herokuapp.com yarn build --environment=production"
 


### PR DESCRIPTION
Following the Netlify file config for passing branch context environment settings, the redirection when a user logs-in broke.

Looking at network logs, it appears that the HOST environment may be not getting set correctly (it’s Heroku’s develop app for qa and staging branches).

This commit would go back to the syntax we had previously, putting HOST directly in the build command for each context.

![2020-04-09 10 03 59](https://user-images.githubusercontent.com/5316367/78903700-858c7f00-7a49-11ea-8883-e83718a5ad5c.gif)


Network requests show that this app is pointing to the `develop` Heroku app -- but it should be hitting the appropriate QA heroku app.
![image](https://user-images.githubusercontent.com/5316367/78903866-bbc9fe80-7a49-11ea-84e6-76dbc4a57670.png)
