### PR TITLE
Map in the NYCID client IDs

### DIFF
--- a/client/config/environment.js
+++ b/client/config/environment.js
@@ -73,8 +73,10 @@ function getHost(environment) {
 }
 
 function getOAuthHost(environment) {
-  if (environment === 'development' || environment === 'staging' || environment === 'production') {
-    return 'https://accounts-nonprd.nyc.gov/account/api/oauth/authorize.htm?response_type=token&client_id=applicant-portal-staging';
+  const { NYCID_CLIENT_ID } = process.env;
+
+  if (environment === 'development' || environment === 'production') {
+    return `https://accounts-nonprd.nyc.gov/account/api/oauth/authorize.htm?response_type=token&client_id=${NYCID_CLIENT_ID}`;
   }
 
   return '/';

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,17 +4,16 @@
 
 # production
 [context.master]
-  environment = { HOST="https://applicant-portal.herokuapp.com/" }
+  environment = { HOST="https://applicant-portal.herokuapp.com/", NYCID_CLIENT_ID='' }
 
 # staging
 [context.staging]
-  environment = { HOST="https://applicant-portal-staging.herokuapp.com" }
+  environment = { HOST="https://applicant-portal-staging.herokuapp.com", NYCID_CLIENT_ID='applicant-portal-staging' }
 
 # qa team
 [context.qa]
-  environment = { HOST="https://applicant-portal-qa.herokuapp.com" }
+  environment = { HOST="https://applicant-portal-qa.herokuapp.com", NYCID_CLIENT_ID='applicant-portal-qa' }
 
 # develop
 [context.develop]
-  environment = { HOST="https://applicant-portal-develop.herokuapp.com" }
-
+  environment = { HOST="https://applicant-portal-develop.herokuapp.com", NYCID_CLIENT_ID='applicant-portal-develop' }


### PR DESCRIPTION
This PR tells the client which NYC.ID URI client ID to use when making the login the button.

Each environment needs a separate account because you have to configure each account with the correct redirect URL.

@bfreeds one thing I'm still not clear on is the difference between the `develop` branch and `staging` branch?