### PR TITLE
83 Handle login errors, like for missing crm contact

### DIFF
--- a/client/app/controllers/login-error.js
+++ b/client/app/controllers/login-error.js
@@ -1,0 +1,11 @@
+import Controller from '@ember/controller';
+
+export default class LoginErrorController extends Controller {
+  /**
+    * @return      {bool} true if login route yields error response
+    *                     about Contact not existing in CRM.
+    */
+  get contactNotAssigned() {
+    return this.model.errors.some((error) => error.response.code === 'NO_CONTACT_FOUND');
+  }
+}

--- a/client/app/templates/login-error.hbs
+++ b/client/app/templates/login-error.hbs
@@ -1,0 +1,42 @@
+<div class="cell">
+  <div class="grid-container">
+    <div class="grid-x grid-padding-x grid-padding-y align-middle">
+      <div class="cell large-6 large-offset-3 text-center">
+        <h2>Oops!</h2>
+
+        {{#if this.contactNotAssigned}}
+          <p data-test-applicant-error-message="contact-not-assigned">
+            You are not currently assigned to a DCP project. Please email&nbsp;
+            <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a>&nbsp;
+            for further assistance.
+          </p>
+        {{else}}
+          <p>
+            Something went wrong.
+          </p>
+        {{/if}}
+
+        {{#each @model.errors as |error idx|}}
+          {{#if error.detail}}
+            <code class="callout display-block text-left red-muted" data-test-error-message={{idx}}>{{error.detail}}</code>
+          {{else}}
+            {{#each-in error.response as |key value|}}
+              <code class="callout display-block text-left red-muted" data-test-error-response={{concat key idx}}>
+                {{key}}: {{value}}
+              </code>
+            {{/each-in}}
+            <code class="callout display-block text-left red-muted">
+              status: {{error.status}}
+            </code>
+          {{/if}}
+        {{/each}}
+
+        <DoLogout />
+
+      </div>
+      <div class="cell large-10 large-offset-1 xlarge-8 xlarge-offset-2  text-center">
+        <p class="">Please contact City Planning at <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or 212-720-3300.</p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/client/tests/unit/controllers/login-error-test.js
+++ b/client/tests/unit/controllers/login-error-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | login-error', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    const controller = this.owner.lookup('controller:login-error');
+    assert.ok(controller);
+  });
+});

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -99,9 +99,13 @@ export class AuthService {
     };
 
     if (!contact) {
-      const errorMessage = 'CRM user not found. Please make sure your e-mail or ID is associated with an assignment.';
 
-      throw new HttpException(errorMessage, HttpStatus.UNAUTHORIZED);
+      const responseBody = {
+        "code": "NO_CONTACT_FOUND",
+        "message": 'CRM Contact not found for given email or ID.',
+      }
+
+      throw new HttpException(responseBody, HttpStatus.UNAUTHORIZED);
     }
 
     return this.signNewToken(contact.contactid, exp);


### PR DESCRIPTION
## TL;DR;

I'm proposing that in Nest, we write exceptions in this format:

```
     const responseBody = {
        'code': 'APPLICANT_PORTAL_SPECIFIC_CODE',
        'message': 'Brief details of internal error',
      }

      throw new HttpException(responseBody, HttpStatus.UNAUTHORIZED);
```

And the frontend can then use the `error.response.code` property (`APPLICANT_PORTAL_SPECIFIC_CODE`) to conditionally display more user friendly messages.

---
This PR modifies the frontend to display error messages for errors occuring during user login.
It also adjusts how the Applicant Portal API sends error responses to support more robust error reporting on the frontend.

In the frontend, this PR introduces an Ember error page for the login route. The error page
is automatically displayed by Ember if it detects an exception or
bad response in the route. The exception or bad response is supplied
to the template as the model.

The page also implicitly logs a user out through the DoLogout
component.

In the backend, the PR modifies the AuthService.generateNewToken() response body to provide an Applicant Portal API-specific error code when a Contact cannot be found for the provided email or ID. This short error code will help the frontend more robustly display a user-friendly message when no contact is found.

By default, responses from Nest appear as such:
```
{
  "statusCode": 403,
  "message": "Forbidden"
}
```

Somewhere along the way, likely in the Nest HTTP Exception filter, the response is wrapped up inside an error object within an array. The error object takes this form 

```
{
  response: ..., 
  status: ....,
  message: .... 
}
```

Where
  - the `response` property takes the form (string or object) of whatever is passed in to the first ("response") argument of the HTTPException constructor. 
 - the `status` property is derived from the status code passed in to the second ("status")  argument of the HTTPException constructor.
  - and the `message` is either
    a. A copy of the `response` argument, if that argument is a simple string.
    b. The value of the "message" property within `response`, if `response` is an object. 
    c. Derived from the "status" argument, if `response` is an object without the `message` property. 

We need to supply an object to the `response` property to add an "Applicant Portal Error Code" within it, so we also need to add the `message` property within `response` property to set the response message (otherwise, `message` will be display a generic "HTTP Exception" string). This PR thus proposes to discard use of the `error.message` property, and instead use its identical source,  `error.response.message`. 

Previously:
![image](https://user-images.githubusercontent.com/3311663/79604740-a5144f00-80bc-11ea-9acc-14b953a38d99.png)


Now: 
![image](https://user-images.githubusercontent.com/3311663/79598762-7c875780-80b2-11ea-98c1-91ed3d497a29.png)
