### PR TITLE
90 Filter out projects where contact is not in applicant team

### DIFF
--- a/server/src/projects/projects.service.ts
+++ b/server/src/projects/projects.service.ts
@@ -20,8 +20,9 @@ export class ProjectsService {
     const projectVisibilityApplicantOnly = '717170002';
     const projectVisibilityGeneralPublic = '717170003';
 
+    // Todo: Migrate this query to use oData service and write tests for this 
     try  {
-      results = await this.crmService.get(`dcp_projects?$filter=dcp_dcp_project_dcp_projectapplicant_Project/any(o:o/_dcp_applicant_customer_value%20eq%20%27${contactId}%27)%20and%20(dcp_visibility%20eq%20${projectVisibilityApplicantOnly}%20or%20dcp_visibility%20eq%20${projectVisibilityGeneralPublic})%20and%20statecode%20eq%20${projectActiveStateCode}&$expand=dcp_dcp_project_dcp_package_project,dcp_dcp_project_dcp_projectapplicant_Project($filter=%20statuscode%20eq%20${applicantActiveStatusCode})`);
+      results = await this.crmService.get(`dcp_projects?$filter=dcp_dcp_project_dcp_projectapplicant_Project/any(o:o/_dcp_applicant_customer_value%20eq%20%27${contactId}%27%20and%20o/statuscode%20eq%20${applicantActiveStatusCode})%20and%20(dcp_visibility%20eq%20${projectVisibilityApplicantOnly}%20or%20dcp_visibility%20eq%20${projectVisibilityGeneralPublic})%20and%20statecode%20eq%20${projectActiveStateCode}&$expand=dcp_dcp_project_dcp_package_project,dcp_dcp_project_dcp_projectapplicant_Project($filter=%20statuscode%20eq%20${applicantActiveStatusCode})`);
     } catch(e) {
       const errorMessage = `Error finding projects by contact ID. ${e.message}`;
       console.log(errorMessage);


### PR DESCRIPTION
Previously the projects endpoint only filtered associated
applicant team objects by their statuscode. This commit
ensures that projects are also in themselves filtered by whether
the authenticated contact is an "active" contact within
the project's associated applicant team members.

This filtering step was part of PR #84 /Issue #73  but
overlooked.

The critical addition to the query is the segment in bold below:

..._Project/any(o:o/_dcp_applicant_customer_value%20eq%20%27${contactId}%27
**%20and%20o/statuscode%20eq%20${applicantActiveStatusCode}** )