### PR TITLE
87 Revise text for 'no applicant projects' and 'no active dcp projects whatsoever' scenarios

### DIFF
--- a/client/app/templates/projects.hbs
+++ b/client/app/templates/projects.hbs
@@ -13,37 +13,45 @@
 
 <div class="grid-x grid-padding-x">
   <div class="cell large-8">
-    {{#if (gt this.applicantProjects.length 0)}}
-      <ul class="no-bullet">
-        {{#each this.sortedApplicantProjects as |project|}}
-          <Projects::ApplicantProjectCard @project={{project}} />
-        {{/each}}
-      </ul>
+    {{#if (gt this.model.length 0)}}
+      {{#if (gt this.applicantProjects.length 0)}}
+        <ul class="no-bullet">
+          {{#each this.sortedApplicantProjects as |project|}}
+            <Projects::ApplicantProjectCard @project={{project}} />
+          {{/each}}
+        </ul>
+      {{else}}
+        <h4 class="text-dark-gray tiny-margin-bottom">Nothing to do.</h4>
+        <p 
+          class="text-dark-gray"
+          data-test-no-response-required
+        >
+          You do not currently have any projects that require your response.
+        </p>
+      {{/if}}
+
+      {{#if (gt this.planningProjects.length 0)}}
+        <hr class="large-margin-top large-margin-bottom" />
+        <ul class="no-bullet">
+          {{#each this.sortedPlanningProjects as |project|}}
+            <Projects::PlanningProjectCard @project={{project}} />
+          {{/each}}
+        </ul>
+      {{/if}}
     {{else}}
       <h4 class="text-dark-gray tiny-margin-bottom">Nothing to do.</h4>
-      <p 
-        class="text-dark-gray"
-        data-test-not-assigned
-      >
-        You are not currently assigned to a DCP project.
-      </p>
+        <p 
+          class="text-dark-gray"
+          data-test-not-assigned-any-active-project
+        >
+          You are not currently assigned to any active DCP projects.
+        </p>
+        <p>
+          Please reach out to&nbsp;
+          <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a>&nbsp;
+          if you believe this is an error.
+        </p>
     {{/if}}
-
-    {{#if (gt this.planningProjects.length 0)}}
-      <hr class="large-margin-top large-margin-bottom" />
-      <ul class="no-bullet">
-        {{#each this.sortedPlanningProjects as |project|}}
-          <Projects::PlanningProjectCard @project={{project}} />
-        {{/each}}
-      </ul>
-    {{/if}}
-  </div>
-
-  <div class="cell large-4">
-    <p>
-      If something has gone wrong, or you believe projects are missing from this list, please contact City Planning at
-      <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or <a href="tel:212-720-3300" class="nowrap">212-720-3300</a>.
-    </p>
   </div>
 </div>
 

--- a/client/tests/acceptance/user-sees-projects-of-all-types-test.js
+++ b/client/tests/acceptance/user-sees-projects-of-all-types-test.js
@@ -27,9 +27,18 @@ module('Acceptance | user sees projects of all types', function(hooks) {
     assert.equal(findAll('[data-test-view-pas]').length, 5);
   });
 
-  test('Page should display non-assigned message if no projects', async function(assert) {
+  test('Page should display "No response required" message if no applicant projects', async function(assert) {
+    this.server.createList('project', 1, 'planning');
+
     await visit('/projects');
-    assert.ok(find('[data-test-not-assigned]'));
+
+    assert.ok(find('[data-test-no-response-required]'));
+    assert.notOk(find('[data-test-not-assigned-any-active-project]'));
+  });
+
+  test('Page should display "Not assigned any active projects" message if no active projects whatsoever', async function(assert) {
+    await visit('/projects');
+    assert.ok(find('[data-test-not-assigned-any-active-project]'));
   });
 
   test('Projects are listed alphabetically', async function (assert) {


### PR DESCRIPTION
This commit updates the text shown when there are no applicant (To Do) projects, and also
the text for when there are no Active, Applicant-Only and General Public projects whatsoever
associated with a contact.

the applicant (To Do) projects are a subset of the Active, Applicant-Only and General Public
projects (which are any projects returned from the /projects API endpoint).

Addresses latest comments in  #87 

--- 
UI with these changes:

**No active DCP projects whatsoever:**
![image](https://user-images.githubusercontent.com/3311663/79790792-4ea44c00-831a-11ea-80a1-dd1ac87209ec.png)

**No Applicant projects**
![image](https://user-images.githubusercontent.com/3311663/79790945-84e1cb80-831a-11ea-9a6f-f7964ea5fb32.png)


**Applicant and Planning  projects**
![image](https://user-images.githubusercontent.com/3311663/79790862-68de2a00-831a-11ea-8346-77cb5f514c01.png)


