### PR TITLE
23 file upload component core frontend functionality

### DIFF
--- a/client/app/components/packages/attachments.hbs
+++ b/client/app/components/packages/attachments.hbs
@@ -127,6 +127,8 @@
             </div>
             <div class="cell small-1 text-right">
               <button
+                 {{on "click" (fn this.deselectFileForUpload file)}}
+                data-test-deselect-file-button={{idx}}
                 type="button"
               >
                 <FaIcon @icon="times" @prefix="fas" class="text-red" />

--- a/client/app/components/packages/attachments.hbs
+++ b/client/app/components/packages/attachments.hbs
@@ -77,7 +77,7 @@
       </ul>
       <hr>
       <ul class="no-bullet">
-        {{#each this.fileManager.deleteFiles as |file idx|}}
+        {{#each this.fileManager.filesToDelete as |file idx|}}
           <li
             class="text-justify"
           >
@@ -108,7 +108,7 @@
         {{/each}}
       </ul>
       <ul class="no-bullet">
-        {{#each this.fileManager.uploadFiles.files as |file idx|}}
+        {{#each this.fileManager.filesToUpload.files as |file idx|}}
           <li
             class="text-justify"
           >

--- a/client/app/components/packages/attachments.hbs
+++ b/client/app/components/packages/attachments.hbs
@@ -1,6 +1,12 @@
 <h3>
   Attached Documents
-  <a class="section-anchor" id="uploads" data-magellan-target="uploads"></a>
+  <a
+    href="#"
+    class="section-anchor"
+    id="uploads"
+    data-magellan-target="uploads"
+  >
+  </a>
 </h3>
 
 <p>
@@ -9,15 +15,26 @@
 
 <div class="site-main grid-x grid-margin-x">
   <div class="cell small-6">
-    REQUIRED FOR ALL PROJECTS:
+    <b>REQUIRED FOR ALL PROJECTS:</b>
     <ul>
-      <li>Official Zoning Sectional Map</li>
-      <li>Project Area Photographs</li>
-      <li>Tax Map(s)</li>
+      <li><a href="#">Tax Map(s)</a> — if project area has more than one tax block submit a separate map for each tax block</li>
+      <li><a href="#">Official Zoning Map</a> — circle the project area</li>
+      <li><a href="#">Land Use Map</a></li>
+      <li>Site Plan — include building heights, unit counts and square footage calculations (GSF &nbsp; ZSF) for proposed project (certain exceptions apply, consult the Lead Planner)</li>
+      <li>Photographs</li>
+      <li>Signature Form</li>
     </ul>
   </div>
   <div class="cell small-6">
-    FOR PROJECTS IN THE NYC COASTAL ZONE:
+    <b>FOR PROJECTS IN THE NYC COASTAL ZONE:</b>
+    <ul>
+      <li>Map of <a href="#">project location within the NYC coastal zone</a> including Special Area Designations</li>
+    </ul>
+    <b>FOR <a href="#">CITY MAP CHANGES</a>:</b>
+    <ul>
+      <li>Most recent Borough President’s final Section Map or most recent approved and filed Alteration Map for the project area</li>
+      <li>Site survey — recommended but not required</li>
+    </ul>
   </div>
   <div class="cell">
     <fieldset class="fieldset">
@@ -34,6 +51,7 @@
           <div class="grid-x">
             <div class="cell small-8">
               <a
+                href="#"
                 data-test-document-name={{idx}}
               >
                 {{file.name}}
@@ -46,6 +64,7 @@
             </div>
             <div class="cell small-1 text-right">
               <button
+                type="button"
                 {{on "click" (fn this.markFileForDeletion file)}}
                 data-test-delete-file-button={{idx}}
               >
@@ -77,6 +96,7 @@
             </div>
             <div class="cell small-1 text-right">
               <button
+                type="button"
                 {{on "click" (fn this.unmarkFileForDeletion file)}}
                 data-test-undo-delete-file-button={{idx}}
               >
@@ -106,7 +126,9 @@
               </small>
             </div>
             <div class="cell small-1 text-right">
-              <button>
+              <button
+                type="button"
+              >
                 <FaIcon @icon="times" @prefix="fas" class="text-red" />
               </button>
             </div>
@@ -116,8 +138,8 @@
       </ul>
       <div class="cell large-auto">
         <FileUpload
-          id={{concat "FileUploader" this.args.package.id}}
-          @name={{this.args.package.id}}
+          id={{concat "FileUploader" @package.id}}
+          @name={{@package.id}}
           @accept='*/*'
           @multiple={{true}}
           class="button secondary expanded"

--- a/client/app/components/packages/attachments.hbs
+++ b/client/app/components/packages/attachments.hbs
@@ -46,6 +46,8 @@
             </div>
             <div class="cell small-1 text-right">
               <button
+                {{on "click" (fn this.markFileForDeletion file)}}
+                data-test-delete-file-button={{idx}}
               >
                 <FaIcon @icon="times" @prefix="fas" class="text-red" />
               </button>
@@ -56,27 +58,34 @@
       </ul>
       <hr>
       <ul class="no-bullet">
-        <li
-          class="text-justify"
-        >
-         <div class="grid-x">
-           <div class="cell small-8">
-             <b>
-              file-to-be-deleted.pptx
-             </b>
-           </div>
-           <div class="cell small-3 text-right">
-            <small>
-              TO BE DELETED
-            </small>
-           </div>
-           <div class="cell small-1 text-right">
-            <button>
-              <FaIcon @icon="undo" @prefix="fas" />
-            </button>
-           </div>
-         </div>
-        </li>
+        {{#each this.fileManager.deleteFiles as |file idx|}}
+          <li
+            class="text-justify"
+          >
+          <div class="grid-x">
+            <div class="cell small-8">
+              <b
+                data-test-document-to-be-deleted-name={{idx}}
+              >
+                {{file.name}}
+              </b>
+            </div>
+            <div class="cell small-3 text-right">
+              <small>
+                TO BE DELETED
+              </small>
+            </div>
+            <div class="cell small-1 text-right">
+              <button
+                {{on "click" (fn this.unmarkFileForDeletion file)}}
+                data-test-undo-delete-file-button={{idx}}
+              >
+                <FaIcon @icon="undo" @prefix="fas" />
+              </button>
+            </div>
+          </div>
+          </li>
+        {{/each}}
       </ul>
       <ul class="no-bullet">
         {{#each this.fileManager.uploadFiles.files as |file idx|}}

--- a/client/app/components/packages/attachments.hbs
+++ b/client/app/components/packages/attachments.hbs
@@ -27,27 +27,32 @@
         </b>
       </legend>
       <ul class="no-bullet">  
-        <li
+        {{#each @package.documents as |document idx|}}
+          <li
           class="text-justify"
-        >
-         <div class="grid-x">
-           <div class="cell small-8">
-             <a>
-              file-already-in-CRM.pptx
-             </a>
-           </div>
-           <div class="cell small-3 text-right">
-            <small>
-              added 3/14/2020
-            </small>
-           </div>
-           <div class="cell small-1 text-right">
-            <button>
-              <FaIcon @icon="times" @prefix="fas" class="text-red" />
-            </button>
-           </div>
-         </div>
-        </li>
+          >
+          <div class="grid-x">
+            <div class="cell small-8">
+              <a
+                data-test-document-name={{idx}}
+              >
+                {{document.name}}
+              </a>
+            </div>
+            <div class="cell small-3 text-right">
+              <small>
+                {{document.timeCreated}}
+              </small>
+            </div>
+            <div class="cell small-1 text-right">
+              <button
+              >
+                <FaIcon @icon="times" @prefix="fas" class="text-red" />
+              </button>
+            </div>
+          </div>
+          </li>
+        {{/each}}
       </ul>
       <hr>
       <ul class="no-bullet">

--- a/client/app/components/packages/attachments.hbs
+++ b/client/app/components/packages/attachments.hbs
@@ -27,7 +27,7 @@
         </b>
       </legend>
       <ul class="no-bullet">  
-        {{#each this.fileManager.existingDocuments as |document idx|}}
+        {{#each this.fileManager.existingFiles as |file idx|}}
           <li
           class="text-justify"
           >
@@ -36,12 +36,12 @@
               <a
                 data-test-document-name={{idx}}
               >
-                {{document.name}}
+                {{file.name}}
               </a>
             </div>
             <div class="cell small-3 text-right">
               <small>
-                {{document.timeCreated}}
+                {{file.timeCreated}}
               </small>
             </div>
             <div class="cell small-1 text-right">

--- a/client/app/components/packages/attachments.hbs
+++ b/client/app/components/packages/attachments.hbs
@@ -79,31 +79,41 @@
         </li>
       </ul>
       <ul class="no-bullet">
-        <li
-          class="text-justify"
-        >
-         <div class="grid-x">
-           <div class="cell small-8">
-             <b>
-              file-to-be-uploaded.pptx
-             </b>
-           </div>
-           <div class="cell small-3 text-right">
-            <small>
-              TO BE ADDED
-            </small>
-           </div>
-           <div class="cell small-1 text-right">
-            <button>
-              <FaIcon @icon="times" @prefix="fas" class="text-red" />
-            </button>
-           </div>
-         </div>
-        </li>
+        {{#each this.fileManager.uploadFiles.files as |file idx|}}
+          <li
+            class="text-justify"
+          >
+          <div class="grid-x">
+            <div class="cell small-8">
+              <b>
+                {{file.name}}
+              </b>
+            </div>
+            <div class="cell small-3 text-right">
+              <small>
+                TO BE ADDED
+              </small>
+            </div>
+            <div class="cell small-1 text-right">
+              <button>
+                <FaIcon @icon="times" @prefix="fas" class="text-red" />
+              </button>
+            </div>
+          </div>
+          </li>
+        {{/each}}
       </ul>
       <div class="cell large-auto">
-        <label for="fileUpload" class="button secondary expanded">Choose Files</label>
-        <input type="file" id="fileUpload" class="show-for-sr" multiple>
+        <FileUpload
+          @name={{this.args.package.id}}
+          @accept='*/*'
+          @multiple={{true}}
+          class="button secondary expanded"
+        >
+          <FaIcon @icon="upload" @prefix="fas" />
+          Choose Files
+        </FileUpload>
+
       </div>
     </fieldset>
   </div>

--- a/client/app/components/packages/attachments.hbs
+++ b/client/app/components/packages/attachments.hbs
@@ -1,41 +1,4 @@
-<h3>
-  Attached Documents
-  <a
-    href="#"
-    class="section-anchor"
-    id="uploads"
-    data-magellan-target="uploads"
-  >
-  </a>
-</h3>
-
-<p>
-  Please attach the following required documents. (Additional materials that help to explain the proposed project may also be submitted.)  
-</p>
-
 <div class="site-main grid-x grid-margin-x">
-  <div class="cell small-6">
-    <b>REQUIRED FOR ALL PROJECTS:</b>
-    <ul>
-      <li><a href="#">Tax Map(s)</a> — if project area has more than one tax block submit a separate map for each tax block</li>
-      <li><a href="#">Official Zoning Map</a> — circle the project area</li>
-      <li><a href="#">Land Use Map</a></li>
-      <li>Site Plan — include building heights, unit counts and square footage calculations (GSF &nbsp; ZSF) for proposed project (certain exceptions apply, consult the Lead Planner)</li>
-      <li>Photographs</li>
-      <li>Signature Form</li>
-    </ul>
-  </div>
-  <div class="cell small-6">
-    <b>FOR PROJECTS IN THE NYC COASTAL ZONE:</b>
-    <ul>
-      <li>Map of <a href="#">project location within the NYC coastal zone</a> including Special Area Designations</li>
-    </ul>
-    <b>FOR <a href="#">CITY MAP CHANGES</a>:</b>
-    <ul>
-      <li>Most recent Borough President’s final Section Map or most recent approved and filed Alteration Map for the project area</li>
-      <li>Site survey — recommended but not required</li>
-    </ul>
-  </div>
   <div class="cell">
     <fieldset class="fieldset">
       <legend>
@@ -149,7 +112,6 @@
           <FaIcon @icon="upload" @prefix="fas" />
           Choose Files
         </FileUpload>
-
       </div>
     </fieldset>
   </div>

--- a/client/app/components/packages/attachments.hbs
+++ b/client/app/components/packages/attachments.hbs
@@ -1,0 +1,105 @@
+<h3>
+  Attached Documents
+  <a class="section-anchor" id="uploads" data-magellan-target="uploads"></a>
+</h3>
+
+<p>
+  Please attach the following required documents. (Additional materials that help to explain the proposed project may also be submitted.)  
+</p>
+
+<div class="site-main grid-x grid-margin-x">
+  <div class="cell small-6">
+    REQUIRED FOR ALL PROJECTS:
+    <ul>
+      <li>Official Zoning Sectional Map</li>
+      <li>Project Area Photographs</li>
+      <li>Tax Map(s)</li>
+    </ul>
+  </div>
+  <div class="cell small-6">
+    FOR PROJECTS IN THE NYC COASTAL ZONE:
+  </div>
+  <div class="cell">
+    <fieldset class="fieldset">
+      <legend>
+        <b>
+          Attachments
+        </b>
+      </legend>
+      <ul class="no-bullet">  
+        <li
+          class="text-justify"
+        >
+         <div class="grid-x">
+           <div class="cell small-8">
+             <a>
+              file-already-in-CRM.pptx
+             </a>
+           </div>
+           <div class="cell small-3 text-right">
+            <small>
+              added 3/14/2020
+            </small>
+           </div>
+           <div class="cell small-1 text-right">
+            <button>
+              <FaIcon @icon="times" @prefix="fas" class="text-red" />
+            </button>
+           </div>
+         </div>
+        </li>
+      </ul>
+      <hr>
+      <ul class="no-bullet">
+        <li
+          class="text-justify"
+        >
+         <div class="grid-x">
+           <div class="cell small-8">
+             <b>
+              file-to-be-deleted.pptx
+             </b>
+           </div>
+           <div class="cell small-3 text-right">
+            <small>
+              TO BE DELETED
+            </small>
+           </div>
+           <div class="cell small-1 text-right">
+            <button>
+              <FaIcon @icon="undo" @prefix="fas" />
+            </button>
+           </div>
+         </div>
+        </li>
+      </ul>
+      <ul class="no-bullet">
+        <li
+          class="text-justify"
+        >
+         <div class="grid-x">
+           <div class="cell small-8">
+             <b>
+              file-to-be-uploaded.pptx
+             </b>
+           </div>
+           <div class="cell small-3 text-right">
+            <small>
+              TO BE ADDED
+            </small>
+           </div>
+           <div class="cell small-1 text-right">
+            <button>
+              <FaIcon @icon="times" @prefix="fas" class="text-red" />
+            </button>
+           </div>
+         </div>
+        </li>
+      </ul>
+      <div class="cell large-auto">
+        <label for="fileUpload" class="button secondary expanded">Choose Files</label>
+        <input type="file" id="fileUpload" class="show-for-sr" multiple>
+      </div>
+    </fieldset>
+  </div>
+</div>

--- a/client/app/components/packages/attachments.hbs
+++ b/client/app/components/packages/attachments.hbs
@@ -94,7 +94,9 @@
           >
           <div class="grid-x">
             <div class="cell small-8">
-              <b>
+              <b
+                data-test-document-to-be-uploaded-name={{idx}}
+              >
                 {{file.name}}
               </b>
             </div>
@@ -114,6 +116,7 @@
       </ul>
       <div class="cell large-auto">
         <FileUpload
+          id={{concat "FileUploader" this.args.package.id}}
           @name={{this.args.package.id}}
           @accept='*/*'
           @multiple={{true}}

--- a/client/app/components/packages/attachments.hbs
+++ b/client/app/components/packages/attachments.hbs
@@ -27,7 +27,7 @@
         </b>
       </legend>
       <ul class="no-bullet">  
-        {{#each @package.documents as |document idx|}}
+        {{#each this.fileManager.existingDocuments as |document idx|}}
           <li
           class="text-justify"
           >

--- a/client/app/components/packages/attachments.js
+++ b/client/app/components/packages/attachments.js
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+
+/**
+  * This component creates a new File Manager specifically for
+  * the passed in package The File Mananger is among one of many
+  * on the the applicantion File Manager service.
+  * 
+  * This cm
+  * @param      {Package Model}  package
+  */
+export default class PackagesAttachmentsComponent extends Component {
+}

--- a/client/app/components/packages/attachments.js
+++ b/client/app/components/packages/attachments.js
@@ -22,11 +22,16 @@ export default class PackagesAttachmentsComponent extends Component {
 
   @action
   markFileForDeletion(file) {
-    this.fileManager.deleteFile(file);
+    this.fileManager.markFileForDeletion(file);
   }
 
   @action
   unmarkFileForDeletion(file) {
-    this.fileManager.undoDeleteFile(file);
+    this.fileManager.unMarkFileForDeletion(file);
+  }
+
+  @action
+  deselectFileForUpload(file) {
+    this.fileManager.deselectFileForUpload(file);
   }
 }

--- a/client/app/components/packages/attachments.js
+++ b/client/app/components/packages/attachments.js
@@ -1,12 +1,19 @@
 import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
 
 /**
   * This component creates a new File Manager specifically for
-  * the passed in package The File Mananger is among one of many
-  * on the the applicantion File Manager service.
-  * 
-  * This cm
+  * the passed in package. The File Manager is among one of many
+  * on the the application File Manager service.
+  *
   * @param      {Package Model}  package
   */
 export default class PackagesAttachmentsComponent extends Component {
+  @service
+  fileManagement;
+
+  get fileManager() {
+    return this.fileManagement.fileManagers[this.args.packageId] ||
+      this.fileManagement.createFileManager(this.args.package);
+  }
 }

--- a/client/app/components/packages/attachments.js
+++ b/client/app/components/packages/attachments.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
 
 /**
   * This component creates a new File Manager specifically for
@@ -17,5 +18,15 @@ export default class PackagesAttachmentsComponent extends Component {
       this.args.package.id,
       this.args.package.documents,
     );
+  }
+
+  @action
+  markFileForDeletion(file) {
+    this.fileManager.deleteFile(file);
+  }
+
+  @action
+  unmarkFileForDeletion(file) {
+    this.fileManager.undoDeleteFile(file);
   }
 }

--- a/client/app/components/packages/attachments.js
+++ b/client/app/components/packages/attachments.js
@@ -9,16 +9,17 @@ import { action } from '@ember/object';
   * @param      {Package Model}  package
   */
 export default class PackagesAttachmentsComponent extends Component {
-  @service
-  fileManagement;
+  constructor() {
+    super(...arguments);
 
-  get fileManager() {
-    return this.fileManagement.fileManagers[this.args.package.id]
-    || this.fileManagement.createFileManager(
+    this.fileManager = this.fileManagement.findOrCreate(
       this.args.package.id,
       this.args.package.documents,
     );
   }
+
+  @service
+  fileManagement;
 
   @action
   markFileForDeletion(file) {

--- a/client/app/components/packages/attachments.js
+++ b/client/app/components/packages/attachments.js
@@ -13,7 +13,10 @@ export default class PackagesAttachmentsComponent extends Component {
   fileManagement;
 
   get fileManager() {
-    return this.fileManagement.fileManagers[this.args.packageId] ||
-      this.fileManagement.createFileManager(this.args.package);
+    return this.fileManagement.fileManagers[this.args.packageId]
+    || this.fileManagement.createFileManager(
+      this.args.package.id,
+      this.args.package.documents,
+    );
   }
 }

--- a/client/app/components/packages/attachments.js
+++ b/client/app/components/packages/attachments.js
@@ -5,7 +5,6 @@ import { inject as service } from '@ember/service';
   * This component creates a new File Manager specifically for
   * the passed in package. The File Manager is among one of many
   * on the the application File Manager service.
-  *
   * @param      {Package Model}  package
   */
 export default class PackagesAttachmentsComponent extends Component {
@@ -13,7 +12,7 @@ export default class PackagesAttachmentsComponent extends Component {
   fileManagement;
 
   get fileManager() {
-    return this.fileManagement.fileManagers[this.args.packageId]
+    return this.fileManagement.fileManagers[this.args.package.id]
     || this.fileManagement.createFileManager(
       this.args.package.id,
       this.args.package.documents,

--- a/client/app/models/package.js
+++ b/client/app/models/package.js
@@ -15,4 +15,7 @@ export default class PackageModel extends Model {
 
   @attr('number')
   dcpVisibility;
+
+  @attr()
+  documents;
 }

--- a/client/app/services/file-management.js
+++ b/client/app/services/file-management.js
@@ -13,15 +13,16 @@ export default class FileManagementService extends Service {
   fileManagers = {}
 
   createFileManager(
-    id = '',
+    packageId = '',
     existingFiles = [],
   ) {
-    this.fileManagers[id] = new FileManager(
+    this.fileManagers[packageId] = new FileManager(
+      packageId,
       existingFiles,
       [],
-      this.fileQueue.create(id),
+      this.fileQueue.create(packageId),
     );
 
-    return this.fileManagers[id];
+    return this.fileManagers[packageId];
   }
 }

--- a/client/app/services/file-management.js
+++ b/client/app/services/file-management.js
@@ -1,6 +1,9 @@
-import Service from '@ember/service';
+import Service, { inject as service } from '@ember/service';
 
 export default class FileManagementService extends Service {
+  @service
+  fileQueue;
+
   // A hash of all File Managers in the app.
   // There is one File Manager per editable Package.
   // The key to access a File Manager is the respective
@@ -9,14 +12,12 @@ export default class FileManagementService extends Service {
 
   createFileManager(
     id = '',
-    existingDocuments = [],
-    deleteDocuments = [],
-    uploadDocuments = [],
+    existingFiles = [],
   ) {
     this.fileManagers[id] = {
-      existingDocuments,
-      deleteDocuments,
-      uploadDocuments,
+      existingFiles,
+      deleteFiles: [],
+      uploadFiles: this.fileQueue.create(id),
     };
 
     return this.fileManagers[id];

--- a/client/app/services/file-management.js
+++ b/client/app/services/file-management.js
@@ -1,4 +1,5 @@
 import Service, { inject as service } from '@ember/service';
+import FileManager from './file-manager';
 
 export default class FileManagementService extends Service {
   @service
@@ -14,11 +15,11 @@ export default class FileManagementService extends Service {
     id = '',
     existingFiles = [],
   ) {
-    this.fileManagers[id] = {
+    this.fileManagers[id] = new FileManager(
       existingFiles,
-      deleteFiles: [],
-      uploadFiles: this.fileQueue.create(id),
-    };
+      [],
+      this.fileQueue.create(id),
+    );
 
     return this.fileManagers[id];
   }

--- a/client/app/services/file-management.js
+++ b/client/app/services/file-management.js
@@ -1,14 +1,5 @@
 import Service from '@ember/service';
 
-function createFileManager(pkg) {
-  const { documents } = pkg;
-  return {
-    existingDocuments: documents,
-    deleteDocuments: [],
-    uploadDocuments: [],
-  };
-}
-
 export default class FileManagementService extends Service {
   // A hash of all File Managers in the app.
   // There is one File Manager per editable Package.
@@ -16,8 +7,18 @@ export default class FileManagementService extends Service {
   // package ID.
   fileManagers = {}
 
-  createFileManager(pkg) {
-    this.fileManagers[pkg.id] = createFileManager(pkg);
-    return this.fileManagers[pkg.id];
+  createFileManager(
+    id = '',
+    existingDocuments = [],
+    deleteDocuments = [],
+    uploadDocuments = [],
+  ) {
+    this.fileManagers[id] = {
+      existingDocuments,
+      deleteDocuments,
+      uploadDocuments,
+    };
+
+    return this.fileManagers[id];
   }
 }

--- a/client/app/services/file-management.js
+++ b/client/app/services/file-management.js
@@ -1,0 +1,23 @@
+import Service from '@ember/service';
+
+function createFileManager(pkg) {
+  const { documents } = pkg;
+  return {
+    existingDocuments: documents,
+    deleteDocuments: [],
+    uploadDocuments: [],
+  };
+}
+
+export default class FileManagementService extends Service {
+  // A hash of all File Managers in the app.
+  // There is one File Manager per editable Package.
+  // The key to access a File Manager is the respective
+  // package ID.
+  fileManagers = {}
+
+  createFileManager(pkg) {
+    this.fileManagers[pkg.id] = createFileManager(pkg);
+    return this.fileManagers[pkg.id];
+  }
+}

--- a/client/app/services/file-management.js
+++ b/client/app/services/file-management.js
@@ -9,6 +9,7 @@ export default class FileManagementService extends Service {
   // There is one File Manager per editable Package.
   // The key to access a File Manager is the respective
   // package ID.
+  // REDO: Look into managing this through Package models
   fileManagers = {}
 
   createFileManager(

--- a/client/app/services/file-management.js
+++ b/client/app/services/file-management.js
@@ -10,17 +10,24 @@ export default class FileManagementService extends Service {
   // The key to access a File Manager is the respective
   // package ID.
   // REDO: Look into managing this through Package models
-  fileManagers = {}
+  fileManagers = {} // REDO: WeakMap? Map?
 
-  createFileManager(
-    packageId = '',
-    existingFiles = [],
-  ) {
+  findOrCreate(packageId = '', existingFiles = []) {
+    if (this.fileManagers[packageId]) {
+      return this.fileManagers[packageId];
+    }
+
+    return this.registerFileManager(packageId, existingFiles);
+  }
+
+  registerFileManager(packageId, existingFiles) {
+    const fileQueue = this.fileQueue.create(packageId);
+
     this.fileManagers[packageId] = new FileManager(
       packageId,
       existingFiles,
       [],
-      this.fileQueue.create(packageId),
+      fileQueue,
     );
 
     return this.fileManagers[packageId];

--- a/client/app/services/file-manager.js
+++ b/client/app/services/file-manager.js
@@ -8,14 +8,18 @@ export default class FileManager {
     this.uploadFiles = uploadFiles;
   }
 
-  deleteFile(existingFile) {
+  markFileForDeletion(existingFile) {
     this.deleteFiles.addObject(existingFile);
     this.existingFiles.removeObject(existingFile);
   }
 
-  undoDeleteFile(deleteFile) {
+  unMarkFileForDeletion(deleteFile) {
     this.existingFiles.addObject(deleteFile);
     this.deleteFiles.removeObject(deleteFile);
+  }
+
+  deselectFileForUpload(fileToUpload) {
+    this.uploadFiles.remove(fileToUpload);
   }
 
   uploadAllFiles(packageId) {

--- a/client/app/services/file-manager.js
+++ b/client/app/services/file-manager.js
@@ -2,28 +2,28 @@ import ENV from 'client/config/environment';
 
 // This class supports the FileManagement service
 export default class FileManager {
-  constructor(existingFiles, deleteFiles, uploadFiles) {
+  constructor(existingFiles, filesToDelete, filesToUpload) {
     this.existingFiles = existingFiles || [];
-    this.deleteFiles = deleteFiles || [];
-    this.uploadFiles = uploadFiles;
+    this.filesToDelete = filesToDelete || [];
+    this.filesToUpload = filesToUpload;
   }
 
   markFileForDeletion(existingFile) {
-    this.deleteFiles.addObject(existingFile);
+    this.filesToDelete.addObject(existingFile);
     this.existingFiles.removeObject(existingFile);
   }
 
   unMarkFileForDeletion(deleteFile) {
     this.existingFiles.addObject(deleteFile);
-    this.deleteFiles.removeObject(deleteFile);
+    this.filesToDelete.removeObject(deleteFile);
   }
 
   deselectFileForUpload(fileToUpload) {
-    this.uploadFiles.remove(fileToUpload);
+    this.filesToUpload.remove(fileToUpload);
   }
 
-  uploadAllFiles(packageId) {
-    return this.uploadFiles.files.map((file) => file.upload(`${ENV.host}/document`, {
+  uploadFiles(packageId) {
+    return this.filesToUpload.files.map((file) => file.upload(`${ENV.host}/document`, {
       fileKey: 'file',
       withCredentials: true,
       data: {
@@ -34,9 +34,9 @@ export default class FileManager {
   }
 
   save() {
-    // todo: add promises from deleteFiles()
+    // todo: add promises from filesToDelete()
     return Promise.all(
-      this.uploadAllFiles(),
+      this.uploadFiles(),
     );
   }
 }

--- a/client/app/services/file-manager.js
+++ b/client/app/services/file-manager.js
@@ -1,4 +1,5 @@
 import ENV from 'client/config/environment';
+import fetch from 'fetch';
 
 // This class supports the FileManagement service
 // TODO: We need to handle rehydrating the existingFiles.
@@ -48,10 +49,28 @@ export default class FileManager {
     }));
   }
 
-  save() {
-    // todo: add promises from filesToDelete()
-    return Promise.all(
-      this.uploadFiles(),
-    );
+  deleteFiles() {
+    // Assumes that the backend delivers files each with
+    // a unique CRM or sharepoint based ID.
+    // TODO: If this is not possible, rework this to be a
+    // POST request to a differently named endpoint, like
+    // deleteDocument
+    return this.filesToDelete.map((file) => fetch(
+      `${ENV.host}/document/${file.id}`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    ));
+  }
+
+  async save() {
+    // See TODO at top of this file.
+    await this.uploadFiles();
+
+    await this.deleteFiles();
+
+    this.filesToDelete.clear();
   }
 }

--- a/client/app/services/file-manager.js
+++ b/client/app/services/file-manager.js
@@ -1,5 +1,6 @@
 import ENV from 'client/config/environment';
 
+// This class supports the FileManagement service
 export default class FileManager {
   constructor(existingFiles, deleteFiles, uploadFiles) {
     this.existingFiles = existingFiles || [];

--- a/client/app/services/file-manager.js
+++ b/client/app/services/file-manager.js
@@ -35,7 +35,7 @@ export default class FileManager {
   }
 
   uploadFiles() {
-    return this.filesToUpload.files.map((file) => file.upload(`${ENV.host}/document`, {
+    return Promise.all(this.filesToUpload.files.map((file) => file.upload(`${ENV.host}/document`, {
       fileKey: 'file',
       withCredentials: true,
       data: {
@@ -46,7 +46,7 @@ export default class FileManager {
         // remove `entityName` after deprecating it from the backend
         entityName: 'dcp_package',
       },
-    }));
+    })));
   }
 
   deleteFiles() {
@@ -55,14 +55,14 @@ export default class FileManager {
     // TODO: If this is not possible, rework this to be a
     // POST request to a differently named endpoint, like
     // deleteDocument
-    return this.filesToDelete.map((file) => fetch(
+    return Promise.all(this.filesToDelete.map((file) => fetch(
       `${ENV.host}/document/${file.id}`, {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json',
         },
       },
-    ));
+    )));
   }
 
   async save() {

--- a/client/app/services/file-manager.js
+++ b/client/app/services/file-manager.js
@@ -1,8 +1,19 @@
 import ENV from 'client/config/environment';
 
 // This class supports the FileManagement service
+// TODO: We need to handle rehydrating the existingFiles.
+// After the app calls fileManager.save(), the Package
+// model should have new associated documents.
+// We need to re-request the package with associated documents
+// and rehydrate existhingFiles.
 export default class FileManager {
-  constructor(existingFiles, filesToDelete, filesToUpload) {
+  constructor(
+    packageId,
+    existingFiles,
+    filesToDelete,
+    filesToUpload,
+  ) {
+    this.packageId = packageId;
     this.existingFiles = existingFiles || [];
     this.filesToDelete = filesToDelete || [];
     this.filesToUpload = filesToUpload;
@@ -22,12 +33,16 @@ export default class FileManager {
     this.filesToUpload.remove(fileToUpload);
   }
 
-  uploadFiles(packageId) {
+  uploadFiles() {
     return this.filesToUpload.files.map((file) => file.upload(`${ENV.host}/document`, {
       fileKey: 'file',
       withCredentials: true,
       data: {
-        instanceId: packageId,
+        instanceId: this.packageId,
+        // Todo: `entityName` shouldn't be necessary.
+        // In this application, documents should only be
+        // uploaded to packages (at least so far).
+        // remove `entityName` after deprecating it from the backend
         entityName: 'dcp_package',
       },
     }));

--- a/client/app/services/file-manager.js
+++ b/client/app/services/file-manager.js
@@ -12,12 +12,12 @@ export default class FileManager {
     packageId,
     existingFiles,
     filesToDelete,
-    filesToUpload,
+    filesToUpload, // EmberFileUpload Queue Object
   ) {
     this.packageId = packageId;
     this.existingFiles = existingFiles || [];
     this.filesToDelete = filesToDelete || [];
-    this.filesToUpload = filesToUpload;
+    this.filesToUpload = filesToUpload; // EmberFileUpload QUEUE Object
   }
 
   markFileForDeletion(existingFile) {

--- a/client/app/services/file-manager.js
+++ b/client/app/services/file-manager.js
@@ -1,7 +1,9 @@
+import ENV from 'client/config/environment';
+
 export default class FileManager {
   constructor(existingFiles, deleteFiles, uploadFiles) {
-    this.existingFiles = existingFiles;
-    this.deleteFiles = deleteFiles;
+    this.existingFiles = existingFiles || [];
+    this.deleteFiles = deleteFiles || [];
     this.uploadFiles = uploadFiles;
   }
 
@@ -13,5 +15,23 @@ export default class FileManager {
   undoDeleteFile(deleteFile) {
     this.existingFiles.addObject(deleteFile);
     this.deleteFiles.removeObject(deleteFile);
+  }
+
+  uploadAllFiles(packageId) {
+    return this.uploadFiles.files.map((file) => file.upload(`${ENV.host}/document`, {
+      fileKey: 'file',
+      withCredentials: true,
+      data: {
+        instanceId: packageId,
+        entityName: 'dcp_package',
+      },
+    }));
+  }
+
+  save() {
+    // todo: add promises from deleteFiles()
+    return Promise.all(
+      this.uploadAllFiles(),
+    );
   }
 }

--- a/client/app/services/file-manager.js
+++ b/client/app/services/file-manager.js
@@ -1,0 +1,17 @@
+export default class FileManager {
+  constructor(existingFiles, deleteFiles, uploadFiles) {
+    this.existingFiles = existingFiles;
+    this.deleteFiles = deleteFiles;
+    this.uploadFiles = uploadFiles;
+  }
+
+  deleteFile(existingFile) {
+    this.deleteFiles.addObject(existingFile);
+    this.existingFiles.removeObject(existingFile);
+  }
+
+  undoDeleteFile(deleteFile) {
+    this.existingFiles.addObject(deleteFile);
+    this.deleteFiles.removeObject(deleteFile);
+  }
+}

--- a/client/mirage/config.js
+++ b/client/mirage/config.js
@@ -1,3 +1,4 @@
+import { Response } from 'ember-cli-mirage';
 import ENV from '../config/environment';
 
 export default function() {
@@ -31,6 +32,12 @@ export default function() {
   this.get('/bbls/:id');
   this.patch('/bbls/:id');
 
+  this.post('/document', function(schema, request) {
+    // requestBody should be a FormData object
+    const { requestBody } = request;
+    const success = requestBody.get('instanceId') && requestBody.get('entityName') && requestBody.get('file');
+    return success ? new Response(200) : new Response(400, {}, { errors: ['Bad Parameters'] });
+  });
   /*
     Shorthand cheatsheet:
 

--- a/client/mirage/config.js
+++ b/client/mirage/config.js
@@ -38,6 +38,16 @@ export default function() {
     const success = requestBody.get('instanceId') && requestBody.get('entityName') && requestBody.get('file');
     return success ? new Response(200) : new Response(400, {}, { errors: ['Bad Parameters'] });
   });
+
+  // Assumes that the backend delivers files each with
+  // a unique CRM or sharepoint based ID.
+  // TODO: If this is not possible, rework this to be a
+  // POST request for a differently named endpoint, like
+  // deleteDocument
+  this.del('/document/:id', function(schema, request) {
+    const { params: { id } } = request;
+    return id ? new Response(200) : new Response(400, {}, { errors: ['Bad Parameters'] });
+  });
   /*
     Shorthand cheatsheet:
 

--- a/client/mirage/factories/package.js
+++ b/client/mirage/factories/package.js
@@ -118,4 +118,21 @@ export default Factory.extend({
       return visibility[i % visibility.length];
     },
   }),
+
+  withExistingDocuments: trait({
+    documents: [
+      {
+        name: 'PAS Form.pdf',
+        // TODO: Format that this is the final serialized
+        // format of the "timeCreated" property
+        timeCreated: '2020-04-23T22:35:30Z',
+        id: '59fbf112-71a5-4af5-b20a-a746g08c4c6p',
+      },
+      {
+        name: 'Action Changes.excel',
+        timeCreated: '2020-02-21T22:25:10Z',
+        id: 'f0f2f3a3-3936-499b-8f37-a9827a1c14f2',
+      },
+    ],
+  }),
 });

--- a/client/package.json
+++ b/client/package.json
@@ -45,6 +45,7 @@
     "ember-data": "~3.17.0",
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^7.0.1",
+    "ember-file-upload": "^3.0.3",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",

--- a/client/tests/integration/components/packages/attachments-test.js
+++ b/client/tests/integration/components/packages/attachments-test.js
@@ -5,6 +5,7 @@ import {
   find,
   findAll,
   click,
+  clearRender,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { selectFiles } from 'ember-file-upload/test-support';
@@ -107,12 +108,6 @@ module('Integration | Component | packages/attachments', function(hooks) {
       ],
     };
 
-    await render(hbs`<
-      Packages::Attachments
-      @package={{this.package}}
-     />`);
-
-
     const file = new File(['foo'], 'PAS Form.pdf', { type: 'text/plain' });
     const file2 = new File(['foo'], 'Action Changes.excel', { type: 'text/plain' });
 
@@ -136,5 +131,32 @@ module('Integration | Component | packages/attachments', function(hooks) {
     await click('[data-test-deselect-file-button="0"]');
 
     await assert.equal(findAll('[data-test-document-to-be-uploaded-name]').length, 0);
+  });
+
+  test('user can return to attachments component and see correct files', async function (assert) {
+    this.package = {
+      id: '123',
+      documents: [
+      ],
+    };
+
+    const file = new File(['foo'], 'PAS Form.pdf', { type: 'text/plain' });
+    const file2 = new File(['foo'], 'Action Changes.excel', { type: 'text/plain' });
+
+    await render(hbs`<
+      Packages::Attachments
+      @package={{this.package}}
+    />`);
+
+    await selectFiles('#FileUploader123 > input', file, file2);
+
+    await clearRender();
+
+    await render(hbs`<
+      Packages::Attachments
+      @package={{this.package}}
+    />`);
+
+    await assert.equal(findAll('[data-test-document-to-be-uploaded-name]').length, 2);
   });
 });

--- a/client/tests/integration/components/packages/attachments-test.js
+++ b/client/tests/integration/components/packages/attachments-test.js
@@ -9,6 +9,9 @@ import {
 import { hbs } from 'ember-cli-htmlbars';
 import { selectFiles } from 'ember-file-upload/test-support';
 
+// TODO:
+//   - Make use of qunit-dom
+//   - Use server.create and store.findAll to set up test data
 module('Integration | Component | packages/attachments', function(hooks) {
   setupRenderingTest(hooks);
 

--- a/client/tests/integration/components/packages/attachments-test.js
+++ b/client/tests/integration/components/packages/attachments-test.js
@@ -7,6 +7,7 @@ import {
   click,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { selectFiles } from 'ember-file-upload/test-support';
 
 module('Integration | Component | packages/attachments', function(hooks) {
   setupRenderingTest(hooks);
@@ -94,5 +95,35 @@ module('Integration | Component | packages/attachments', function(hooks) {
     await assert.equal(findAll('[data-test-document-to-be-deleted-name]').length, 0);
     await assert.equal(find('[data-test-document-name="0"]').textContent.trim(), 'Action Changes.excel');
     await assert.equal(find('[data-test-document-name="1"]').textContent.trim(), 'PAS Form.pdf');
+  });
+
+  test('user can select local files for upload', async function(assert) {
+    this.package = {
+      id: '123',
+      documents: [
+      ],
+    };
+
+    await render(hbs`<
+      Packages::Attachments
+      @package={{this.package}}
+     />`);
+
+
+    const file = new File(['foo'], 'PAS Form.pdf', { type: 'text/plain' });
+    const file2 = new File(['foo'], 'Action Changes.excel', { type: 'text/plain' });
+
+    await render(hbs`<
+      Packages::Attachments
+      @package={{this.package}}
+    />`);
+
+    await assert.equal(findAll('[data-test-document-to-be-uploaded-name]').length, 0);
+
+    await selectFiles('#FileUploader123 > input', file, file2);
+
+    await assert.equal(findAll('[data-test-document-to-be-uploaded-name]').length, 2);
+    await assert.equal(find('[data-test-document-to-be-uploaded-name="0"]').textContent.trim(), 'PAS Form.pdf');
+    await assert.equal(find('[data-test-document-to-be-uploaded-name="1"]').textContent.trim(), 'Action Changes.excel');
   });
 });

--- a/client/tests/integration/components/packages/attachments-test.js
+++ b/client/tests/integration/components/packages/attachments-test.js
@@ -1,14 +1,36 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, find } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | packages/attachments', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it displays a list attachments already uploaded to the package', async function(assert) {
-    await render(hbs`<Packages::Attachments />`);
+    this.package = {
+      documents: [
+        {
+          name: 'PAS Form.pdf',
+          // TODO: Format that this is the final serialized
+          // format of the "timeCreated" property 
+          timeCreated: '2020-04-23T22:35:30Z',
+          id: '59fbf112-71a5-4af5-b20a-a746g08c4c6p',
+        },
+        {
+          name: 'Action Changes.excel',
+          timeCreated: '2020-02-21T22:25:10Z',
+          id: 'f0f2f3a3-3936-499b-8f37-a9827a1c14f2',
+        },
+      ]
+    };
 
-    await this.pauseTest();
+    await render(hbs`<
+      Packages::Attachments
+      @package={{this.package}}
+     />`);
+
+
+     assert.equal(find('[data-test-document-name="0"]').textContent.trim(), 'PAS Form.pdf');
+     assert.equal(find('[data-test-document-name="1"]').textContent.trim(), 'Action Changes.excel');
   });
 });

--- a/client/tests/integration/components/packages/attachments-test.js
+++ b/client/tests/integration/components/packages/attachments-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | packages/attachments', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it displays a list attachments already uploaded to the package', async function(assert) {
+    await render(hbs`<Packages::Attachments />`);
+
+    await this.pauseTest();
+  });
+});

--- a/client/tests/integration/components/packages/attachments-test.js
+++ b/client/tests/integration/components/packages/attachments-test.js
@@ -2,8 +2,6 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import {
   render,
-  find,
-  findAll,
   click,
   clearRender,
 } from '@ember/test-helpers';
@@ -42,8 +40,8 @@ module('Integration | Component | packages/attachments', function(hooks) {
       @package={{this.package}}
      />`);
 
-    assert.equal(find('[data-test-document-name="0"]').textContent.trim(), 'PAS Form.pdf');
-    assert.equal(find('[data-test-document-name="1"]').textContent.trim(), 'Action Changes.excel');
+    assert.dom('[data-test-document-name="0"]').hasText('PAS Form.pdf');
+    assert.dom('[data-test-document-name="1"]').hasText('Action Changes.excel');
   });
 
   test('user can mark and unmark an existing document for deletion', async function(assert) {
@@ -70,37 +68,37 @@ module('Integration | Component | packages/attachments', function(hooks) {
       @package={{this.package}}
      />`);
 
-    await assert.equal(findAll('[data-test-document-to-be-deleted-name]').length, 0);
+    await assert.dom('[data-test-document-to-be-deleted-name]').doesNotExist();
 
     // mark a file for deletion
     await click('[data-test-delete-file-button="0"]');
 
-    await assert.equal(findAll('[data-test-document-name]').length, 1);
-    await assert.equal(findAll('[data-test-document-to-be-deleted-name]').length, 1);
-    await assert.equal(find('[data-test-document-to-be-deleted-name]').textContent.trim(), 'PAS Form.pdf');
+    await assert.dom('[data-test-document-name]').exists({ count: 1 });
+    await assert.dom('[data-test-document-to-be-deleted-name]').exists({ count: 1 });
+    await assert.dom('[data-test-document-to-be-deleted-name]').hasText('PAS Form.pdf');
 
     // mark second file for deletion
     await click('[data-test-delete-file-button="0"]');
 
-    await assert.equal(findAll('[data-test-document-name]').length, 0);
-    await assert.equal(findAll('[data-test-document-to-be-deleted-name]').length, 2);
-    await assert.equal(find('[data-test-document-to-be-deleted-name="0"]').textContent.trim(), 'PAS Form.pdf');
-    await assert.equal(find('[data-test-document-to-be-deleted-name="1"]').textContent.trim(), 'Action Changes.excel');
+    await assert.dom('[data-test-document-name]').doesNotExist();
+    await assert.dom('[data-test-document-to-be-deleted-name]').exists({ count: 2 });
+    await assert.dom('[data-test-document-to-be-deleted-name="0"]').hasText('PAS Form.pdf');
+    await assert.dom('[data-test-document-to-be-deleted-name="1"]').hasText('Action Changes.excel');
 
     // unmark a file for deletion
     await click('[data-test-undo-delete-file-button="1"]');
 
-    await assert.equal(findAll('[data-test-document-name]').length, 1);
-    await assert.equal(findAll('[data-test-document-to-be-deleted-name]').length, 1);
-    await assert.equal(find('[data-test-document-name]').textContent.trim(), 'Action Changes.excel');
+    await assert.dom('[data-test-document-name]').exists({ count: 1 });
+    await assert.dom('[data-test-document-to-be-deleted-name]').exists({ count: 1 });
+    await assert.dom('[data-test-document-name]').hasText('Action Changes.excel');
 
     // unmark another file for deletion
     await click('[data-test-undo-delete-file-button="0"]');
 
-    await assert.equal(findAll('[data-test-document-name]').length, 2);
-    await assert.equal(findAll('[data-test-document-to-be-deleted-name]').length, 0);
-    await assert.equal(find('[data-test-document-name="0"]').textContent.trim(), 'Action Changes.excel');
-    await assert.equal(find('[data-test-document-name="1"]').textContent.trim(), 'PAS Form.pdf');
+    await assert.dom('[data-test-document-name]').exists({ count: 2 });
+    await assert.dom('[data-test-document-to-be-deleted-name]').doesNotExist();
+    await assert.dom('[data-test-document-name="0"]').hasText('Action Changes.excel');
+    await assert.dom('[data-test-document-name="1"]').hasText('PAS Form.pdf');
   });
 
   test('user can select and deselect local files for upload', async function(assert) {
@@ -118,21 +116,21 @@ module('Integration | Component | packages/attachments', function(hooks) {
       @package={{this.package}}
     />`);
 
-    await assert.equal(findAll('[data-test-document-to-be-uploaded-name]').length, 0);
+    await assert.dom('[data-test-document-to-be-uploaded-name]').doesNotExist();
 
     await selectFiles('#FileUploader123 > input', file, file2);
 
-    await assert.equal(findAll('[data-test-document-to-be-uploaded-name]').length, 2);
-    await assert.equal(find('[data-test-document-to-be-uploaded-name="0"]').textContent.trim(), 'PAS Form.pdf');
-    await assert.equal(find('[data-test-document-to-be-uploaded-name="1"]').textContent.trim(), 'Action Changes.excel');
+    await assert.dom('[data-test-document-to-be-uploaded-name]').exists({ count: 2 });
+    await assert.dom('[data-test-document-to-be-uploaded-name="0"]').hasText('PAS Form.pdf');
+    await assert.dom('[data-test-document-to-be-uploaded-name="1"]').hasText('Action Changes.excel');
 
     await click('[data-test-deselect-file-button="0"]');
 
-    await assert.equal(findAll('[data-test-document-to-be-uploaded-name]').length, 1);
+    await assert.dom('[data-test-document-to-be-uploaded-name]').exists({ count: 1 });
 
     await click('[data-test-deselect-file-button="0"]');
 
-    await assert.equal(findAll('[data-test-document-to-be-uploaded-name]').length, 0);
+    await assert.dom('[data-test-document-to-be-uploaded-name]').doesNotExist();
   });
 
   test('user can return to attachments component and see correct files', async function (assert) {
@@ -159,7 +157,7 @@ module('Integration | Component | packages/attachments', function(hooks) {
       @package={{this.package}}
     />`);
 
-    await assert.equal(findAll('[data-test-document-to-be-uploaded-name]').length, 2);
+    await assert.dom('[data-test-document-to-be-uploaded-name]').exists({ count: 2 });
   });
 
   test('fileManager.save() will upload and delete files, then reset to-be-uploaded/deleted lists', async function (assert) {
@@ -196,17 +194,17 @@ module('Integration | Component | packages/attachments', function(hooks) {
 
     const fileManager = this.owner.lookup('service:fileManagement').fileManagers['123'];
 
-    await assert.equal(findAll('[data-test-document-name]').length, 0);
-    await assert.equal(findAll('[data-test-document-to-be-deleted-name]').length, 2);
-    await assert.equal(find('[data-test-document-to-be-deleted-name="0"]').textContent.trim(), 'PAS Form.pdf');
-    await assert.equal(find('[data-test-document-to-be-deleted-name="1"]').textContent.trim(), 'Action Changes.excel');
-    await assert.equal(findAll('[data-test-document-to-be-uploaded-name]').length, 2);
-    await assert.equal(find('[data-test-document-to-be-uploaded-name="0"]').textContent.trim(), 'Zoning Application.pdf');
-    await assert.equal(find('[data-test-document-to-be-uploaded-name="1"]').textContent.trim(), 'RWCDS.excel');
+    await assert.dom('[data-test-document-name]').doesNotExist();
+    await assert.dom('[data-test-document-to-be-deleted-name]').exists({ count: 2 });
+    await assert.dom('[data-test-document-to-be-deleted-name="0"]').hasText('PAS Form.pdf');
+    await assert.dom('[data-test-document-to-be-deleted-name="1"]').hasText('Action Changes.excel');
+    await assert.dom('[data-test-document-to-be-uploaded-name]').exists({ count: 2 });
+    await assert.dom('[data-test-document-to-be-uploaded-name="0"]').hasText('Zoning Application.pdf');
+    await assert.dom('[data-test-document-to-be-uploaded-name="1"]').hasText('RWCDS.excel');
 
     await fileManager.save();
 
-    await assert.equal(findAll('[data-test-document-to-be-deleted-name]').length, 0);
-    await assert.equal(findAll('[data-test-document-to-be-uploaded-name]').length, 0);
+    await assert.dom('[data-test-document-to-be-deleted-name]').doesNotExist();
+    await assert.dom('[data-test-document-to-be-uploaded-name]').doesNotExist();
   });
 });

--- a/client/tests/integration/components/packages/attachments-test.js
+++ b/client/tests/integration/components/packages/attachments-test.js
@@ -100,7 +100,7 @@ module('Integration | Component | packages/attachments', function(hooks) {
     await assert.equal(find('[data-test-document-name="1"]').textContent.trim(), 'PAS Form.pdf');
   });
 
-  test('user can select local files for upload', async function(assert) {
+  test('user can select and deselect local files for upload', async function(assert) {
     this.package = {
       id: '123',
       documents: [
@@ -128,5 +128,13 @@ module('Integration | Component | packages/attachments', function(hooks) {
     await assert.equal(findAll('[data-test-document-to-be-uploaded-name]').length, 2);
     await assert.equal(find('[data-test-document-to-be-uploaded-name="0"]').textContent.trim(), 'PAS Form.pdf');
     await assert.equal(find('[data-test-document-to-be-uploaded-name="1"]').textContent.trim(), 'Action Changes.excel');
+
+    await click('[data-test-deselect-file-button="0"]');
+
+    await assert.equal(findAll('[data-test-document-to-be-uploaded-name]').length, 1);
+
+    await click('[data-test-deselect-file-button="0"]');
+
+    await assert.equal(findAll('[data-test-document-to-be-uploaded-name]').length, 0);
   });
 });

--- a/client/tests/integration/components/packages/attachments-test.js
+++ b/client/tests/integration/components/packages/attachments-test.js
@@ -12,7 +12,7 @@ module('Integration | Component | packages/attachments', function(hooks) {
         {
           name: 'PAS Form.pdf',
           // TODO: Format that this is the final serialized
-          // format of the "timeCreated" property 
+          // format of the "timeCreated" property
           timeCreated: '2020-04-23T22:35:30Z',
           id: '59fbf112-71a5-4af5-b20a-a746g08c4c6p',
         },
@@ -21,7 +21,7 @@ module('Integration | Component | packages/attachments', function(hooks) {
           timeCreated: '2020-02-21T22:25:10Z',
           id: 'f0f2f3a3-3936-499b-8f37-a9827a1c14f2',
         },
-      ]
+      ],
     };
 
     await render(hbs`<
@@ -29,8 +29,7 @@ module('Integration | Component | packages/attachments', function(hooks) {
       @package={{this.package}}
      />`);
 
-
-     assert.equal(find('[data-test-document-name="0"]').textContent.trim(), 'PAS Form.pdf');
-     assert.equal(find('[data-test-document-name="1"]').textContent.trim(), 'Action Changes.excel');
+    assert.equal(find('[data-test-document-name="0"]').textContent.trim(), 'PAS Form.pdf');
+    assert.equal(find('[data-test-document-name="1"]').textContent.trim(), 'Action Changes.excel');
   });
 });

--- a/client/tests/integration/components/packages/attachments-test.js
+++ b/client/tests/integration/components/packages/attachments-test.js
@@ -8,6 +8,7 @@ module('Integration | Component | packages/attachments', function(hooks) {
 
   test('it displays a list attachments already uploaded to the package', async function(assert) {
     this.package = {
+      id: '123',
       documents: [
         {
           name: 'PAS Form.pdf',

--- a/client/tests/integration/components/packages/attachments-test.js
+++ b/client/tests/integration/components/packages/attachments-test.js
@@ -17,23 +17,10 @@ module('Integration | Component | packages/attachments', function(hooks) {
   setupMirage(hooks);
 
   test('it displays a list attachments already uploaded to the package', async function(assert) {
-    this.package = {
-      id: '123',
-      documents: [
-        {
-          name: 'PAS Form.pdf',
-          // TODO: Format that this is the final serialized
-          // format of the "timeCreated" property
-          timeCreated: '2020-04-23T22:35:30Z',
-          id: '59fbf112-71a5-4af5-b20a-a746g08c4c6p',
-        },
-        {
-          name: 'Action Changes.excel',
-          timeCreated: '2020-02-21T22:25:10Z',
-          id: 'f0f2f3a3-3936-499b-8f37-a9827a1c14f2',
-        },
-      ],
-    };
+    this.server.create('package', 'withExistingDocuments', { id: '123' });
+
+    const store = this.owner.lookup('service:store');
+    this.package = await store.findRecord('package', '123');
 
     await render(hbs`<
       Packages::Attachments
@@ -45,23 +32,10 @@ module('Integration | Component | packages/attachments', function(hooks) {
   });
 
   test('user can mark and unmark an existing document for deletion', async function(assert) {
-    this.package = {
-      id: '123',
-      documents: [
-        {
-          name: 'PAS Form.pdf',
-          // TODO: Format that this is the final serialized
-          // format of the "timeCreated" property
-          timeCreated: '2020-04-23T22:35:30Z',
-          id: '59fbf112-71a5-4af5-b20a-a746g08c4c6p',
-        },
-        {
-          name: 'Action Changes.excel',
-          timeCreated: '2020-02-21T22:25:10Z',
-          id: 'f0f2f3a3-3936-499b-8f37-a9827a1c14f2',
-        },
-      ],
-    };
+    this.server.create('package', 'withExistingDocuments', { id: '123' });
+
+    const store = this.owner.lookup('service:store');
+    this.package = await store.findRecord('package', '123');
 
     await render(hbs`<
       Packages::Attachments
@@ -102,11 +76,10 @@ module('Integration | Component | packages/attachments', function(hooks) {
   });
 
   test('user can select and deselect local files for upload', async function(assert) {
-    this.package = {
-      id: '123',
-      documents: [
-      ],
-    };
+    this.server.create('package', { id: '123' });
+
+    const store = this.owner.lookup('service:store');
+    this.package = await store.findRecord('package', '123');
 
     const file = new File(['foo'], 'PAS Form.pdf', { type: 'text/plain' });
     const file2 = new File(['foo'], 'Action Changes.excel', { type: 'text/plain' });
@@ -134,11 +107,10 @@ module('Integration | Component | packages/attachments', function(hooks) {
   });
 
   test('user can return to attachments component and see correct files', async function (assert) {
-    this.package = {
-      id: '123',
-      documents: [
-      ],
-    };
+    this.server.create('package', { id: '123' });
+
+    const store = this.owner.lookup('service:store');
+    this.package = await store.findRecord('package', '123');
 
     const file = new File(['foo'], 'PAS Form.pdf', { type: 'text/plain' });
     const file2 = new File(['foo'], 'Action Changes.excel', { type: 'text/plain' });
@@ -161,23 +133,10 @@ module('Integration | Component | packages/attachments', function(hooks) {
   });
 
   test('fileManager.save() will upload and delete files, then reset to-be-uploaded/deleted lists', async function (assert) {
-    this.package = {
-      id: '123',
-      documents: [
-        {
-          name: 'PAS Form.pdf',
-          // TODO: Format that this is the final serialized
-          // format of the "timeCreated" property
-          timeCreated: '2020-04-23T22:35:30Z',
-          id: '59fbf112-71a5-4af5-b20a-a746g08c4c6p',
-        },
-        {
-          name: 'Action Changes.excel',
-          timeCreated: '2020-02-21T22:25:10Z',
-          id: 'f0f2f3a3-3936-499b-8f37-a9827a1c14f2',
-        },
-      ],
-    };
+    this.server.create('package', 'withExistingDocuments', { id: '123' });
+
+    const store = this.owner.lookup('service:store');
+    this.package = await store.findRecord('package', '123');
 
     await render(hbs`<
       Packages::Attachments

--- a/client/tests/unit/services/file-management-test.js
+++ b/client/tests/unit/services/file-management-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | fileManagement', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let service = this.owner.lookup('service:file-management');
+    assert.ok(service);
+  });
+});

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -18,7 +18,7 @@
     invariant "^2.2.4"
     semver "^5.5.0"
 
-"@babel/core@^7.0.0", "@babel/core@^7.1.6", "@babel/core@^7.2.2", "@babel/core@^7.3.4", "@babel/core@^7.8.3", "@babel/core@^7.8.4", "@babel/core@^7.9.0":
+"@babel/core@^7.1.6", "@babel/core@^7.2.2", "@babel/core@^7.3.4", "@babel/core@^7.4.4", "@babel/core@^7.8.3", "@babel/core@^7.8.4", "@babel/core@^7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.9.0.tgz#ac977b538b77e132ff706f3b8a4dbad09c03c56e"
   integrity sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==
@@ -5392,6 +5392,15 @@ ember-fetch@^7.0.1:
     ember-cli-typescript "^3.1.3"
     node-fetch "^2.6.0"
     whatwg-fetch "^3.0.0"
+
+ember-file-upload@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/ember-file-upload/-/ember-file-upload-3.0.3.tgz#9d1708afa35923530453a40e2992a9bccb621f7c"
+  integrity sha512-5SJU/mrCWOJjBGDn/M8f/9acw5VCC4/tTw7quYP/fsXUM4MfCGpng1sBXE3DsDry8ioXJRynDlzI8Ub6VoQPyg==
+  dependencies:
+    "@babel/core" "^7.4.4"
+    ember-cli-babel "^7.7.3"
+    ember-cli-htmlbars "^3.0.1"
 
 ember-get-config@^0.2.2, ember-get-config@^0.2.4:
   version "0.2.4"


### PR DESCRIPTION
Thinking of opening this up for official PR review and Merge at this state, and tackling the below Todos in future PRs. This should help avoid a massive PR down the road. 

At this stage, the component has a stable frontend UI and tests. It can
  - [x] Select files
  - [x] Deselect a file for upload
  - [x] Mark files for deletion
  - [x] Unmark files for deletion
  - [x] Execute POST upload requests for all selected files
  - [x] Execute DELETE requests for all to-be-deleted files
  - [x] save() method to initiate processing all to-be-uploaded and to-be-deleted files.
--- 

Todo/Redo for future issues:
- [x] convert tests to use this.server.create and store.query
- [x] use qunit-dom
- [ ] Rework File Manager to sit on Package models, instead of being managed inside File Managers service
  - [x] Make sure File Manager creation happens on model init, instead of in a getter.

Core feature remaining todos:

- [ ] Set up upload and delete backend endpoints
- [ ] isDirty computed on File Manager service