### PR TITLE
PAS Form Packages/PASForm entity fields, etc

### DIFF
--- a/client/app/models/pas-form.js
+++ b/client/app/models/pas-form.js
@@ -1,6 +1,210 @@
-import Model, { belongsTo } from '@ember-data/model';
+import Model, { belongsTo, attr } from '@ember-data/model';
 
 export default class PasFormModel extends Model {
   @belongsTo
   package;
+
+
+  // Project Information
+  @attr('string')
+  dcpRevisedprojectname;
+
+
+  // Project Geography
+  @attr('string')
+  dcpDescriptionofprojectareageography;
+
+
+  // Proposed Land Use Actions
+  @attr('string')
+  dcpPfchangeincitymap;
+
+  @attr('string')
+  dcpPfudaap;
+
+  @attr('string')
+  dcpPfsiteselectionpublicfacility;
+
+  @attr('string')
+  dcpPfura;
+
+  @attr('string')
+  dcpPfacquisitionofrealproperty;
+
+  @attr('string')
+  dcpPfhousingplanandproject;
+
+  @attr('string')
+  dcpPfdispositionofrealproperty;
+
+  @attr('string')
+  dcpPffranchise;
+
+  @attr('string')
+  dcpPfrevocableconsent;
+
+  @attr('string')
+  dcpPfconcession;
+
+  @attr('string')
+  dcpPflandfill;
+
+  @attr('string')
+  dcpPfzoningspecialpermit;
+
+  @attr('string')
+  dcpZoningspecialpermitpursuantto;
+
+  @attr('string')
+  dcpZoningspecialpermittomodify;
+
+  @attr('string')
+  dcpPfzoningauthorization;
+
+  @attr('string')
+  dcpZoningauthorizationpursuantto;
+
+  @attr('string')
+  dcpZoningauthorizationtomodify;
+
+  @attr('string')
+  dcpPfzoningcertification;
+
+  @attr('string')
+  dcpZoningpursuantto;
+
+  @attr('string')
+  dcpZoningtomodify;
+
+  @attr('string')
+  dcpPfzoningmapamendment;
+
+  @attr('string')
+  dcpExistingmapamend;
+
+  @attr('string')
+  dcpProposedmapamend;
+
+  @attr('string')
+  dcpPfzoningtextamendment;
+
+  @attr('string')
+  dcpAffectedzrnumber;
+
+  @attr('string')
+  dcpZoningresolutiontitle;
+
+  @attr('string')
+  dcpPreviousulurpnumbers1;
+
+  @attr('string')
+  dcpPreviousulurpnumbers2;
+
+
+  // Project Area
+  @attr('string')
+  dcpProposedprojectorportionconstruction;
+
+  @attr('string')
+  dcpUrbanrenewalarea;
+
+  @attr('string')
+  dcpUrbanareaname;
+
+  @attr('string')
+  dcpLegalstreetfrontage;
+
+  @attr('string')
+  dcpLanduseactiontype2;
+
+  @attr('string')
+  dcpPleaseexplaintypeiienvreview;
+
+  @attr('string')
+  dcpProjectareaindustrialbusinesszone;
+
+  @attr('string')
+  dcpProjectareaindutrialzonename;
+
+  @attr('string')
+  dcpIsprojectarealandmark;
+
+  @attr('string')
+  dcpProjectarealandmarkname;
+
+  @attr('string')
+  dcpProjectareacoastalzonelocatedin;
+
+  @attr('string')
+  dcpProjectareaischancefloodplain;
+
+  @attr('string')
+  dcpRestrictivedeclaration;
+
+  @attr('string')
+  dcpCityregisterfilenumber;
+
+  @attr('string')
+  dcpRestrictivedeclarationrequired;
+
+
+  // Proposed Development Site
+  @attr('string')
+  dcpEstimatedcompletiondate;
+
+  @attr('string')
+  dcpProposeddevelopmentsitenewconstruction;
+
+  @attr('string')
+  dcpProposeddevelopmentsitedemolition;
+
+  @attr('string')
+  dcpProposeddevelopmentsiteinfoalteration;
+
+  @attr('string')
+  dcpProposeddevelopmentsiteinfoaddition;
+
+  @attr('string')
+  dcpProposeddevelopmentsitechnageofuse;
+
+  @attr('string')
+  dcpProposeddevelopmentsiteenlargement;
+
+  @attr('string')
+  dcpProposeddevelopmentsiteinfoother;
+
+  @attr('string')
+  dcpProposeddevelopmentsiteotherexplanation;
+
+  @attr('string')
+  dcpIsinclusionaryhousingdesignatedarea;
+
+  @attr('string')
+  dcpInclusionaryhousingdesignatedareaname;
+
+  @attr('string')
+  dcpDiscressionaryfundingforffordablehousing;
+
+  @attr('string')
+  dcpHousingunittype;
+
+
+  // Project Description
+  @attr('string')
+  dcpProjectdescriptionproposeddevelopment;
+
+  @attr('string')
+  dcpProjectdescriptionbackground;
+
+  @attr('string')
+  dcpProjectdescriptionproposedactions;
+
+  @attr('string')
+  dcpProjectdescriptionproposedarea;
+
+  @attr('string')
+  dcpProjectdescriptionsurroundingarea;
+
+  @attr('string')
+  dcpProjectattachmentsotherinformation;
 }

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -9,6 +9,7 @@ import { ConfigModule } from './config/config.module';
 import { ContactModule } from './contact/contact.module';
 import { CrmModule } from './crm/crm.module';
 import { ProjectsModule } from './projects/projects.module';
+import { PackagesModule } from './packages/packages.module';
 
 @Module({
   imports: [
@@ -16,7 +17,8 @@ import { ProjectsModule } from './projects/projects.module';
     ConfigModule,
     ContactModule,
     CrmModule,
-    ProjectsModule
+    ProjectsModule,
+    PackagesModule,
   ],
   controllers: [AppController],
 })

--- a/server/src/json-api-serialize.interceptor.ts
+++ b/server/src/json-api-serialize.interceptor.ts
@@ -12,6 +12,9 @@ export class JsonApiSerializeInterceptor implements NestInterceptor {
   constructor(resourceName, serializationOptions) {
     this.serializer = new Serializer(resourceName, {
       ...serializationOptions,
+
+      // REDO: we should just make the client support dash prefixes
+      // because it'll be tough when we have to deserialize
       keyForAttribute(key) {
         let dasherized = dasherize(key);
 

--- a/server/src/packages/packages.controller.spec.ts
+++ b/server/src/packages/packages.controller.spec.ts
@@ -1,0 +1,22 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PackagesController } from './packages.controller';
+import { PackagesService } from './packages.service';
+import { CrmModule } from '../crm/crm.module';
+
+describe('Packages Controller', () => {
+  let controller: PackagesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [CrmModule],
+      providers: [PackagesService],
+      controllers: [PackagesController],
+    }).compile();
+
+    controller = module.get<PackagesController>(PackagesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/server/src/packages/packages.controller.ts
+++ b/server/src/packages/packages.controller.ts
@@ -1,0 +1,140 @@
+import { Controller, Get, Param, UseInterceptors } from '@nestjs/common';
+import { PackagesService } from './packages.service';
+import { JsonApiSerializeInterceptor } from '../json-api-serialize.interceptor';
+
+@UseInterceptors(new JsonApiSerializeInterceptor('packages', {
+  id: 'dcp_packageid',
+  attributes: [
+    'statuscode',
+    'dcp_packagetype',
+    'dcp_visibility',
+    'pas-form',
+  ],
+  'pas-form': {
+    ref: 'dcp_pasformid',
+    attributes: [
+      // Project Information
+      'dcp_revisedprojectname',
+
+      // Project Geography
+      'dcp_descriptionofprojectareageography',
+
+      // Proposed Land Use Actions
+      'dcp_pfchangeincitymap',
+      'dcp_pfudaap',
+      'dcp_pfsiteselectionpublicfacility',
+      'dcp_pfura',
+      'dcp_pfacquisitionofrealproperty',
+      'dcp_pfhousingplanandproject',
+      'dcp_pfdispositionofrealproperty',
+      'dcp_pffranchise',
+      'dcp_pfrevocableconsent',
+      'dcp_pfconcession',
+      'dcp_pflandfill',
+      'dcp_pfzoningspecialpermit',
+      'dcp_zoningspecialpermitpursuantto',
+      'dcp_zoningspecialpermittomodify',
+      'dcp_pfzoningauthorization',
+      'dcp_zoningauthorizationpursuantto',
+      'dcp_zoningauthorizationtomodify',
+      'dcp_pfzoningcertification',
+      'dcp_zoningpursuantto',
+      'dcp_zoningtomodify',
+      'dcp_pfzoningmapamendment',
+      'dcp_existingmapamend',
+      'dcp_proposedmapamend',
+      'dcp_pfzoningtextamendment',
+      'dcp_affectedzrnumber',
+      'dcp_zoningresolutiontitle',
+      'dcp_previousulurpnumbers1',
+      'dcp_previousulurpnumbers2',
+
+      // Project Area
+      'dcp_proposedprojectorportionconstruction',
+      'dcp_urbanrenewalarea',
+      'dcp_urbanareaname',
+      'dcp_legalstreetfrontage',
+      'dcp_landuseactiontype2',
+      'dcp_pleaseexplaintypeiienvreview',
+      'dcp_projectareaindustrialbusinesszone',
+      'dcp_projectareaindutrialzonename',
+      'dcp_isprojectarealandmark',
+      'dcp_projectarealandmarkname',
+      'dcp_projectareacoastalzonelocatedin',
+      'dcp_projectareaischancefloodplain',
+      'dcp_restrictivedeclaration',
+      'dcp_cityregisterfilenumber',
+      'dcp_restrictivedeclarationrequired',
+
+      // Proposed Development Site
+      'dcp_estimatedcompletiondate',
+      'dcp_proposeddevelopmentsitenewconstruction',
+      'dcp_proposeddevelopmentsitedemolition',
+      'dcp_proposeddevelopmentsiteinfoalteration',
+      'dcp_proposeddevelopmentsiteinfoaddition',
+      'dcp_proposeddevelopmentsitechnageofuse',
+      'dcp_proposeddevelopmentsiteenlargement',
+      'dcp_proposeddevelopmentsiteinfoother',
+      'dcp_proposeddevelopmentsiteotherexplanation',
+      'dcp_isinclusionaryhousingdesignatedarea',
+      'dcp_inclusionaryhousingdesignatedareaname',
+      'dcp_discressionaryfundingforffordablehousing',
+      'dcp_housingunittype',
+
+      // Project Description
+      'dcp_projectdescriptionproposeddevelopment',
+      'dcp_projectdescriptionbackground',
+      'dcp_projectdescriptionproposedactions',
+      'dcp_projectdescriptionproposedarea',
+      'dcp_projectdescriptionsurroundingarea',
+      'dcp_projectattachmentsotherinformation',
+
+      // associations/relationships/navigation links/extensions
+      'applicants',
+      'bbls',
+    ],
+    applicants: {
+      ref: 'dcp_applicantinformationid',
+      attributes: [
+        'dcp_firstname',
+        'dcp_lastname',
+        'dcp_organization',
+        'dcp_email',
+        'dcp_address',
+        'dcp_city',
+        'dcp_state',
+        'dcp_zipcode',
+        'dcp_phone',
+      ],
+    },
+    bbls: {
+      ref: 'dcp_projectbblid',
+      attributes: [
+        'dcp_partiallot',
+        'dcp_developmentsite',
+      ],
+    },
+  },
+
+  // remap verbose navigation link names to
+  // more concise names
+  transform(projectPackage) {
+    return {
+      ...projectPackage,
+      'pas-form': {
+        ...projectPackage?.dcp_pasform,
+        applicants: projectPackage?.dcp_pasform?.dcp_dcp_applicantinformation_dcp_pasform,
+        bbls: projectPackage?.dcp_pasform?.dcp_dcp_projectbbl_dcp_pasform,
+      },
+    };
+  },
+}))
+@Controller('packages')
+export class PackagesController {
+  constructor(private readonly packagesService: PackagesService) {}
+
+  @Get('/:id')
+  packages(@Param('id') id) {
+    return this.packagesService.getPackage(id);
+  }
+}

--- a/server/src/packages/packages.module.ts
+++ b/server/src/packages/packages.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PackagesController } from './packages.controller';
+import { PackagesService } from './packages.service';
+import { CrmModule } from 'src/crm/crm.module';
+
+@Module({
+  imports: [CrmModule],
+  exports: [PackagesService],
+  providers: [PackagesService],
+  controllers: [PackagesController],
+})
+export class PackagesModule {}

--- a/server/src/packages/packages.service.spec.ts
+++ b/server/src/packages/packages.service.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CrmModule } from '../crm/crm.module';
+import { PackagesService } from './packages.service';
+
+describe('PackagesService', () => {
+  let service: PackagesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [CrmModule],
+      providers: [PackagesService],
+    }).compile();
+
+    service = module.get<PackagesService>(PackagesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/server/src/packages/packages.service.ts
+++ b/server/src/packages/packages.service.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common';
+import { CrmService } from '../crm/crm.service';
+
+@Injectable()
+export class PackagesService {
+  constructor(private readonly crmService: CrmService) {}
+
+  async getPackage(packageId) {
+    // Note: The reason for making two network calls
+    // has to do with a limitation with the Web API: we can't request
+    // associated entities from within another associated entity in
+    // the same request.
+    //
+    // alternative approach is to get everything in 1 req then
+    // invert the package/form
+    // return this.crmService.get('dcp_pasforms', `
+    //   $filter=_RELATED_PACKAGE/PACKAGE_ID eq ${packageId}
+    //   &$expand=dcp_package,other_things,here
+    // `);
+    //
+    // Two network requests might seem clearer to future maintainers,
+    // but it's slower.
+
+    // Double network request approach
+    const { records: [{ _dcp_pasform_value }] } = await this.crmService.get('dcp_packages', `
+      $select=_dcp_pasform_value
+      &$filter=dcp_packageid eq ${packageId}
+    `);
+
+    const { records: [projectPackageForm] } = await this.crmService.get('dcp_pasforms', `
+      $filter=
+        dcp_pasformid eq ${_dcp_pasform_value}
+      &$expand=
+        dcp_dcp_applicantinformation_dcp_pasform,
+        dcp_package,
+        dcp_dcp_projectbbl_dcp_pasform
+    `);
+
+    return {
+      ...projectPackageForm.dcp_package,
+      dcp_pasform: projectPackageForm,
+    };
+  }
+}

--- a/server/src/projects/projects.controller.ts
+++ b/server/src/projects/projects.controller.ts
@@ -32,6 +32,9 @@ import { JsonApiSerializeInterceptor } from '../json-api-serialize.interceptor';
       'dcp_visibility',
     ],
   },
+
+  // remap verbose navigation link names to
+  // more concise names
   transform(project) {
     return {
       ...project,

--- a/server/src/projects/projects.service.ts
+++ b/server/src/projects/projects.service.ts
@@ -20,11 +20,12 @@ export class ProjectsService {
   public async findManyByContactId(contactId: string) {
     try {
       const { records } = await this.crmService.get('dcp_projects', `
-        $filter=dcp_dcp_project_dcp_projectapplicant_Project/
-          any(o:
-            o/_dcp_applicant_customer_value eq '${contactId}'
-            and o/statuscode eq ${APPLICANT_ACTIVE_STATUS_CODE}
-          ) 
+        $filter=
+          dcp_dcp_project_dcp_projectapplicant_Project/
+            any(o:
+              o/_dcp_applicant_customer_value eq '${contactId}'
+              and o/statuscode eq ${APPLICANT_ACTIVE_STATUS_CODE}
+            ) 
           and (
             dcp_visibility eq ${PROJECT_VISIBILITY_APPLICANT_ONLY}
             or dcp_visibility eq ${PROJECT_VISIBILITY_GENERAL_PUBLIC}


### PR DESCRIPTION
This PR creates a packages service in the backend which queries for the package, its pas form, and some of the PAS form's related entities (bbls and applicantinformations).

Includes Client side changes as well.