### PR TITLE
21: update removeBbl action and standardize radio buttons

### DIFF
--- a/client/app/components/project-geography.hbs
+++ b/client/app/components/project-geography.hbs
@@ -6,75 +6,79 @@
 >
   <small class="dark-gray">{{search.result.label}} <br> {{bbl-breakup search.result.bbl}}</small>
 </LabsSearch>
- 
+
 {{#each @bbls as |bbl idx|}}
   <fieldset class="fieldset">
     <legend data-test-bbl-title="{{bbl.dcpBblnumber}}">
-	  <strong>{{bbl.dcpBblnumber}}</strong>
-	</legend>
-	<fieldset>
-	  <legend data-test-development-site-question="{{bbl.dcpBblnumber}}-{{bbl.dcpDevelopmentsite}}">
-	    Is this BBL part of the development site?
-	  </legend>
-	  <input
-		type="radio"
-		name={{concat idx '-bbl-dev-site'}}
-		id={{concat idx '-bbl-dev-site-yes'}}
-		data-test-bbl-development-site-yes="{{bbl.dcpBblnumber}}"
-		checked={{if bbl.dcpDevelopmentsite "checked"}}
-		onClick={{fn this.updateAttr bbl "dcpDevelopmentsite" true}}
-	  />
-	  <label for="{{concat idx '-bbl-dev-site-yes'}}">
-	    Yes
-	  </label>
-	  <input
-	    type="radio"
-		name={{concat idx '-bbl-dev-site'}}
-		id={{concat idx '-bbl-dev-site-no'}}
-		data-test-bbl-development-site-no="{{bbl.dcpBblnumber}}"
-		checked={{if (eq bbl.dcpDevelopmentsite false) "checked"}}
-		onClick={{fn this.updateAttr bbl "dcpDevelopmentsite" false}}
-	  />
-	  <label for="{{concat idx '-bbl-dev-site-no'}}">
-		No
-	  </label>
-	</fieldset>
-	<fieldset>
-	  <legend data-test-partial-lot-question="{{bbl.dcpBblnumber}}-{{bbl.dcpPartiallot}}">
-		Is this a partial lot?
-	  </legend>
-	  <Input
-	    type="radio"
-		name="bbl-partial-lot-yes"
-		id="bbl-partial-lot-yes"
-		data-test-bbl-partial-lot-yes="{{bbl.dcpBblnumber}}"
-		checked={{if (eq bbl.dcpPartiallot true) "checked"}}
-		onClick={{fn this.updateAttr bbl "dcpPartiallot" true}}
-	  />
-	  <label for="bbl-partial-lot-yes">
-		Yes
-	  </label>
-	  <input
-	    type="radio"
-		name="bbl-partial-lot-no"
-		id="bbl-partial-lot-no"
-		data-test-bbl-partial-lot-no="{{bbl.dcpBblnumber}}"
-		checked={{if (eq bbl.dcpPartiallot false) "checked"}}
-		onClick={{fn this.updateAttr bbl "dcpPartiallot" false}}
-	  />
-	  <label for="bbl-partial-lot-no">
-		No
-	  </label>
-	</fieldset>
-	  <div class="text-right">
-	    <button 
-		  type="button" 
-		  class="text-red"
-		  data-test-button-remove-bbl="{{bbl.dcpBblnumber}}" 
-		  onClick={{fn this.removeBbl bbl}}
-		>
-		  {{fa-icon 'times'}} DELETE
-		</button>
-	  </div>
+    <strong>{{bbl.dcpBblnumber}}</strong>
+  </legend>
+  <fieldset>
+    <legend data-test-development-site-question="{{bbl.dcpBblnumber}}-{{bbl.dcpDevelopmentsite}}">
+      Is this BBL part of the development site?
+    </legend>
+    <Input
+      @type="radio"
+      name={{concat idx '-bbl-dev-site'}}
+      id={{concat idx '-bbl-dev-site-yes'}}
+      @value={{eq bbl.dcpDevelopmentsite true}}
+      @checked={{eq bbl.dcpDevelopmentsite true}}
+      onClick={{fn this.updateAttr bbl "dcpDevelopmentsite" true}}
+      data-test-bbl-development-site-yes="{{bbl.dcpBblnumber}}"
+    />
+    <label for="{{concat idx '-bbl-dev-site-yes'}}">
+      Yes
+    </label>
+    <Input
+      @type="radio"
+      name={{concat idx '-bbl-dev-site'}}
+      id={{concat idx '-bbl-dev-site-no'}}
+      @value={{eq bbl.dcpDevelopmentsite false}}
+      @checked={{eq bbl.dcpDevelopmentsite false}}
+      onClick={{fn this.updateAttr bbl "dcpDevelopmentsite" false}}
+      data-test-bbl-development-site-no="{{bbl.dcpBblnumber}}"
+    />
+    <label for="{{concat idx '-bbl-dev-site-no'}}">
+      No
+    </label>
+  </fieldset>
+  <fieldset>
+    <legend data-test-partial-lot-question="{{bbl.dcpBblnumber}}-{{bbl.dcpPartiallot}}">
+      Is this a partial lot?
+    </legend>
+    <Input
+      type="radio"
+      name="bbl-partial-lot-yes"
+      id="bbl-partial-lot-yes"
+      @value={{eq bbl.dcpPartiallot true}}
+      @checked={{eq bbl.dcpPartiallot true}}
+      onClick={{fn this.updateAttr bbl "dcpPartiallot" true}}
+      data-test-bbl-partial-lot-yes="{{bbl.dcpBblnumber}}"
+    />
+    <label for="bbl-partial-lot-yes">
+      Yes
+    </label>
+    <Input
+      @type="radio"
+      name="bbl-partial-lot-no"
+      id="bbl-partial-lot-no"
+      @value={{eq bbl.dcpPartiallot false}}
+      @checked={{eq bbl.dcpPartiallot false}}
+      onClick={{fn this.updateAttr bbl "dcpPartiallot" false}}
+      data-test-bbl-partial-lot-no="{{bbl.dcpBblnumber}}"
+    />
+    <label for="bbl-partial-lot-no">
+      No
+    </label>
+  </fieldset>
+    <div class="text-right">
+      <button 
+        type="button" 
+        class="text-red"
+        data-test-button-remove-bbl="{{bbl.dcpBblnumber}}" 
+        onClick={{fn this.removeBbl bbl}}
+      >
+        {{fa-icon 'times'}} DELETE
+      </button>
+    </div>
   </fieldset>
 {{/each}}

--- a/client/app/components/project-geography.js
+++ b/client/app/components/project-geography.js
@@ -41,6 +41,7 @@ export default class ProjectGeographyComponent extends Component {
   // Remove bbl object from list of bbls
   @action
   removeBbl(bblObjectToBeRemoved) {
+    this.store.deleteRecord(bblObjectToBeRemoved);
     this.args.bbls.removeObject(bblObjectToBeRemoved);
   }
 


### PR DESCRIPTION
In `ProjectGeography` component: 
- Add `store.deleteRecord` to `removeBbl` action
- Standardize radio buttons

Addressing issue #21 
Following larger PR #101 