### PR TITLE
20: Use Applicant Team Editor component in PAS Form

### DIFF
--- a/client/app/components/pas-form.hbs
+++ b/client/app/components/pas-form.hbs
@@ -25,8 +25,9 @@
     <section class="form-section" id="#applicant-team">
       <h3>Applicant Team</h3>
 
-      {{!-- TODO: Add applicant-team-editor component --}}
-      <div class="bg-red-dim xlarge-padding medium-margin-bottom">applicant-team-editor component</div>
+      <Packages::ApplicantTeamEditor
+        @applicants={{@package.pasForm.applicants}}
+      />
     </section>
 
     <section class="form-section" id="#applicant-team">


### PR DESCRIPTION
This PR replaces the placeholder div for the applicant team editor with the actual component, rendering:
```hbs
<Packages::ApplicantTeamEditor @applicants={{@package.pasForm.applicants}}/>
```

Small part of getting #20 ready to go.