### PR TITLE
Move breadcrumbs to root; Add load spinner for packages;

### DIFF
--- a/client/app/templates/packages.hbs
+++ b/client/app/templates/packages.hbs
@@ -1,0 +1,5 @@
+<Breadcrumbs />
+
+<hr class="large-margin-bottom">
+
+{{outlet}}

--- a/client/app/templates/packages/edit.hbs
+++ b/client/app/templates/packages/edit.hbs
@@ -1,7 +1,3 @@
-<Breadcrumbs />
-
-<hr class="large-margin-bottom">
-
 <Packages::PasForm::Edit @package={{@model}} />
 
 {{outlet}}

--- a/client/app/templates/packages/loading.hbs
+++ b/client/app/templates/packages/loading.hbs
@@ -1,0 +1,3 @@
+<div class="text-center xlarge-padding-top xlarge-padding-bottom xlarge-margin-top xlarge-margin-bottom">
+  <FaIcon @icon="spinner" @spin={{true}} @pulse={{true}} @size="6x" class="text-silver" />
+</div>


### PR DESCRIPTION
This commit moves the breadcrumbs to the root of the packages route. This is needed because we want the breadcrumbs to be visible across all sub routes.

Additionally, this adds a load spinner for the packages route using the ember substate feature. This is done by adding a 'loading.hbs' template in the packages route. This route is triggered when the model is being resolved. I added this because this can be a large request, and without it, it would look like nothing is happening.

