### PR TITLE
Pin RXJS version

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -35,7 +35,7 @@
     "nock": "^12.0.3",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
-    "rxjs": "^6.5.4",
+    "rxjs": "6.5.4",
     "superagent": "^5.2.2",
     "underscore": "^1.10.2"
   },

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -5779,7 +5779,7 @@ rxjs@6.5.4:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^6.5.3, rxjs@^6.5.4:
+rxjs@^6.5.3:
   version "6.5.5"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
   integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==


### PR DESCRIPTION
Having issues with later patches of RXJS. Pinning to 6.5.4.