### PR TITLE
add confirmation modal to PAS form

### DIFF
--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -783,6 +783,7 @@
           type="button"
           class="button expanded large secondary"
           {{on "click" this.toggleModal}}
+          data-test-submit-button
         >
           {{!-- TODO: Disable this button if model dirty/invaild --}}
           Submit
@@ -808,8 +809,9 @@
               <div class="cell large-6 text-right">
                 <button
                   type="button"
-                  class="button large no-margin
-                ">
+                  class="button large no-margin"
+                  data-test-confirm-submit-button
+                >
                   Submit
                 </button>
               </div>

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -780,12 +780,41 @@
         <button
           type="button"
           class="button expanded large secondary"
-          disabled
+          {{on "click" this.toggleModal}}
         >
-        {{!-- TODO: Make this button work with the action passed in @submit--}}
+          {{!-- TODO: Disable this button if model dirty/invaild --}}
           Submit
         </button>
       </p>
+      {{#if this.modalIsOpen}}
+        {{#ember-wormhole to="reveal-modal-container"}}
+          <RevealModal @toggle={{this.toggleModal}}>
+            <h6>Confirm Pre-Applicant Statement submission</h6>
+            <p class="header-large medium-margin-top small-margin-bottom">Are you sure?</p>
+            <p>Before submitting, ensure that your answers are accurate and complete, and that necessary attachments (including the signature form) have been uploaded. If City Planning does not receive enough accurate information to provide guidance, the lead planner will notify you and request that this form be resubmitted with needed materials, corrections, or clarifications.</p>
+            <hr>
+            <div class="grid-x grid-margin-x">
+              <div class="cell large-6">
+                <button
+                  type="button"
+                  class="button large secondary no-margin"
+                  {{on "click" this.toggleModal}}
+                >
+                  Continue Editing
+                </button>
+              </div>
+              <div class="cell large-6 text-right">
+                <button
+                  type="button"
+                  class="button large no-margin
+                ">
+                  Submit
+                </button>
+              </div>
+            </div>
+          </RevealModal>
+        {{/ember-wormhole}}
+      {{/if}}
       <nav>
         <ul class="no-bullet text-weight-bold">
           <li class="medium-margin-bottom">

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -787,7 +787,7 @@
         </button>
       </p>
       {{#if this.modalIsOpen}}
-        {{#ember-wormhole to="reveal-modal-container"}}
+        <EmberWormhole @to="reveal-modal-container">
           <RevealModal @toggle={{this.toggleModal}}>
             <h6>Confirm Pre-Applicant Statement submission</h6>
             <p class="header-large medium-margin-top small-margin-bottom">Are you sure?</p>
@@ -813,7 +813,7 @@
               </div>
             </div>
           </RevealModal>
-        {{/ember-wormhole}}
+        </EmberWormhole>
       {{/if}}
       <nav>
         <ul class="no-bullet text-weight-bold">

--- a/client/app/components/packages/pas-form/edit.js
+++ b/client/app/components/packages/pas-form/edit.js
@@ -3,10 +3,17 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class PasFormComponent extends Component {
+  @tracked modalIsOpen = false;
+
   @tracked package;
 
   @action
   updateAttr(obj, attr, newVal) {
     obj[attr] = newVal;
+  }
+
+  @action
+  toggleModal() {
+    this.modalIsOpen = !this.modalIsOpen;
   }
 }

--- a/client/app/components/reveal-modal.hbs
+++ b/client/app/components/reveal-modal.hbs
@@ -1,0 +1,15 @@
+<div class="reveal-overlay">
+  <div class="reveal-overlay-target" {{on "click" @toggle}}></div>
+  <div
+    class="reveal"
+    role="dialog"
+    aria-hidden="false"
+    tabindex="-1"
+    data-test-confirmation-modal
+  >
+    {{yield}}
+    <button {{on "click" @toggle}} class="close-button" aria-label="Close modal" type="button">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+</div>

--- a/client/app/components/reveal-modal.hbs
+++ b/client/app/components/reveal-modal.hbs
@@ -1,14 +1,25 @@
 <div class="reveal-overlay">
-  <div class="reveal-overlay-target" {{on "click" @toggle}}></div>
+  <div
+    class="reveal-overlay-target"
+    role="button"
+    {{on "click" @toggle}}
+    data-test-reveal-overlay
+  ></div>
   <div
     class="reveal"
     role="dialog"
     aria-hidden="false"
     tabindex="-1"
-    data-test-confirmation-modal
+    data-test-reveal-modal
   >
     {{yield}}
-    <button {{on "click" @toggle}} class="close-button" aria-label="Close modal" type="button">
+    <button
+      type="button"
+      class="close-button"
+      aria-label="Close modal"
+      {{on "click" @toggle}}
+      data-test-reveal-close-button
+    >
       <span aria-hidden="true">&times;</span>
     </button>
   </div>

--- a/client/app/styles/app.scss
+++ b/client/app/styles/app.scss
@@ -18,6 +18,7 @@
 
 // Custom app components
 @import 'modules/_login';
+@import 'modules/_reveal-modal';
 @import 'modules/_m-search';
 @import 'modules/_pasform';
 

--- a/client/app/styles/modules/_reveal-modal.scss
+++ b/client/app/styles/modules/_reveal-modal.scss
@@ -1,0 +1,35 @@
+// --------------------------------------------------
+// Module: Reveal Modal
+// --------------------------------------------------
+
+#reveal-modal-container {
+  z-index: 3;
+}
+
+.reveal-overlay {
+  display: block;
+  padding: 1rem;
+
+  @include breakpoint(medium) {
+    padding: 4rem 1rem;
+  }
+}
+
+.reveal-overlay-target {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+
+.reveal {
+  display: block;
+  border: 0;
+  box-shadow: 0 0 0 rem-calc(4) rgba(0,0,0,0.1);
+  top: 0;
+
+  &:focus {
+    outline: none;
+  }
+}

--- a/client/app/templates/application.hbs
+++ b/client/app/templates/application.hbs
@@ -34,3 +34,5 @@
     {{outlet}}
   </div>
 </div>
+
+<div id="reveal-modal-container"></div>

--- a/client/package.json
+++ b/client/package.json
@@ -58,6 +58,7 @@
     "ember-truth-helpers": "^2.1.0",
     "ember-welcome-page": "^4.0.0",
     "ember-window-mock": "^0.6.0",
+    "ember-wormhole": "^0.5.5",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.1.0",
     "eslint-plugin-ember": "^7.10.1",

--- a/client/tests/integration/components/pas-form-test.js
+++ b/client/tests/integration/components/pas-form-test.js
@@ -111,4 +111,27 @@ module('Integration | Component | pas-form', function(hooks) {
 
     assert.equal(this.server.db.pasForms[0].dcpRevisedprojectname, 'Some Cool New Project Name');
   });
+
+  test('user sees a confirmation modal upon submit', async function(assert) {
+    const projectPackage = this.server.create('package');
+
+    this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form' });
+
+    // render form
+    await render(hbs`
+      <Packages::PasForm::Edit @package={{this.package}} />
+      <div id="reveal-modal-container"></div>
+      `);
+
+    // modal doesn't exist to start
+    assert.dom('[data-test-reveal-modal]').doesNotExist();
+    assert.dom('[data-test-confirm-submit-button]').doesNotExist();
+
+    // click submit
+    await click('[data-test-submit-button]');
+
+    // modal should exist
+    assert.dom('[data-test-reveal-modal]').exists();
+    assert.dom('[data-test-confirm-submit-button]').exists();
+  });
 });

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4894,7 +4894,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0:
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.0.tgz#de3baedd093163b6c2461f95964888c1676325ac"
   integrity sha512-Zr4my8Xn+CzO0gIuFNXji0eTRml5AxZUTDQz/wsNJ5AJAtyFWCY4QtKdoELNNbiCVGt1lq5yLiwTm4scGKu6xA==
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
+ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.10.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -5011,6 +5011,16 @@ ember-cli-htmlbars-inline-precompile@^2.1.0:
     hash-for-dep "^1.2.3"
     heimdalljs-logger "^0.1.9"
     silent-error "^1.1.0"
+
+ember-cli-htmlbars@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.5.tgz#b5a105429a6bce4f7c9c97b667e3b8926e31397f"
+  integrity sha512-3f3PAxdnQ/fhQa8XP/3z4RLRgLHxV8j4Ln75aHbRdemOCjBa048KxL9l+acRLhCulbGQCMnLiIUIC89PAzLrcA==
+  dependencies:
+    broccoli-persistent-filter "^1.4.3"
+    hash-for-dep "^1.2.3"
+    json-stable-stringify "^1.0.0"
+    strip-bom "^3.0.0"
 
 ember-cli-htmlbars@^3.0.0, ember-cli-htmlbars@^3.0.1:
   version "3.1.0"
@@ -5402,12 +5412,6 @@ ember-cookies@^0.5.0:
     ember-cli-babel "^7.1.0"
     ember-getowner-polyfill "^1.1.0 || ^2.0.0"
 
-ember-data-save-relationships@laborvoices/ember-data-save-relationships#master:
-  version "0.0.10"
-  resolved "https://codeload.github.com/laborvoices/ember-data-save-relationships/tar.gz/16d1dbcad36f3504525de3bdf689b0414e618e4a"
-  dependencies:
-    ember-cli-babel "^6.12.0"
-
 ember-data@~3.17.0:
   version "3.17.0"
   resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-3.17.0.tgz#724eaacd1ee43b1766a77b52e4b5a43a309a2d26"
@@ -5753,6 +5757,14 @@ ember-window-mock@^0.6.0:
     broccoli-funnel "^2.0.1"
     ember-cli-babel "^7.13.0"
     ember-cli-htmlbars "^4.2.0"
+
+ember-wormhole@^0.5.5:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/ember-wormhole/-/ember-wormhole-0.5.5.tgz#db417ff748cb21e574cd5f233889897bc27096cb"
+  integrity sha512-z8l3gpoKmRA2BnTwvnYRk4jKVcETKHpddsD6kpS+EJ4EfyugadFS3zUqBmRDuJhFbNP8BVBLXlbbATj+Rk1Kgg==
+  dependencies:
+    ember-cli-babel "^6.10.0"
+    ember-cli-htmlbars "^2.0.1"
 
 emoji-regex@^7.0.1:
   version "7.0.3"


### PR DESCRIPTION
This PR add a `<RevealModal />` component and adjusts the UX so that the user sees a warning and must confirm submission of the PAS form. 

Addresses #86. 