### PR TITLE
Lookup and include package documents

### DIFF
--- a/client/app/services/file-manager.js
+++ b/client/app/services/file-manager.js
@@ -56,8 +56,9 @@ export default class FileManager {
     // POST request to a differently named endpoint, like
     // deleteDocument
     return Promise.all(this.filesToDelete.map((file) => fetch(
-      `${ENV.host}/documents/${file.id}`, {
+      `${ENV.host}/documents?serverRelativeUrl=${file.serverRelativeUrl}`, {
         method: 'DELETE',
+        credentials: 'include',
         headers: {
           'Content-Type': 'application/json',
         },

--- a/client/mirage/config.js
+++ b/client/mirage/config.js
@@ -57,9 +57,8 @@ export default function() {
   // TODO: If this is not possible, rework this to be a
   // POST request for a differently named endpoint, like
   // deleteDocument
-  this.del('/documents/:id', function(schema, request) {
-    const { params: { id } } = request;
-    return id ? new Response(200) : new Response(400, {}, { errors: ['Bad Parameters'] });
+  this.del('/documents', function() {
+    return new Response(204);
   });
   /*
     Shorthand cheatsheet:

--- a/server/src/crm/crm.service.ts
+++ b/server/src/crm/crm.service.ts
@@ -389,4 +389,70 @@ export class CrmService {
     };
     return this.create(query, data, headers);
   }
+
+  async generateSharePointAccessToken(): Promise<any> {
+    const TENANT_ID = this.config.get('TENANT_ID');
+    const SHAREPOINT_CLIENT_ID = this.config.get('SHAREPOINT_CLIENT_ID');
+    const SHAREPOINT_CLIENT_SECRET = this.config.get('SHAREPOINT_CLIENT_SECRET');
+    const ADO_PRINCIPAL = this.config.get('ADO_PRINCIPAL');
+    const SHAREPOINT_TARGET_HOST = this.config.get('SHAREPOINT_TARGET_HOST');
+
+    const clientId = `${SHAREPOINT_CLIENT_ID}@${TENANT_ID}`;
+    const data = `
+      grant_type=client_credentials
+      &client_id=${clientId}
+      &client_secret=${SHAREPOINT_CLIENT_SECRET}
+      &resource=${ADO_PRINCIPAL}/${SHAREPOINT_TARGET_HOST}@${TENANT_ID}
+    `;
+
+    const options = {
+      url: `https://accounts.accesscontrol.windows.net/${TENANT_ID}/tokens/OAuth/2`,
+      headers: {
+        'Accept-Encoding': 'gzip, deflate',
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'OData-MaxVersion': '4.0',
+        'OData-Version': '4.0',
+        Accept: 'application/json',
+        Prefer: 'return=representation',
+      },
+      body: data,
+      encoding: null,
+    };
+
+    return new Promise(resolve => {
+      Request.post(options, (error, response, body) => {
+        const stringifiedBody = body.toString('utf-8');
+        if (response.statusCode >= 400) {
+          console.log('error', stringifiedBody);
+        }
+
+        resolve(JSON.parse(stringifiedBody));
+      });
+    })
+  }
+
+  async getSharepointFolderFiles(folderIdentifier): Promise<any> {
+    const { access_token } = await this.generateSharePointAccessToken();
+    const SHAREPOINT_CRM_SITE = this.config.get('SHAREPOINT_CRM_SITE');
+    const url = `https://nyco365.sharepoint.com/sites/${SHAREPOINT_CRM_SITE}/_api/web/GetFolderByServerRelativeUrl('/sites/${SHAREPOINT_CRM_SITE}/${folderIdentifier}')/Files`;
+  
+    const options = {
+      url,
+      headers: {
+        'Authorization': `Bearer ${access_token}`,
+        Accept: 'application/json',
+      },
+    };
+
+    return new Promise(resolve => {
+      Request.post(options, (error, response, body) => {
+        const stringifiedBody = body.toString('utf-8');
+        if (response.statusCode >= 400) {
+          console.log('error', stringifiedBody);
+        }
+
+        resolve(JSON.parse(stringifiedBody));
+      });
+    })
+  }
 }

--- a/server/src/crm/crm.service.ts
+++ b/server/src/crm/crm.service.ts
@@ -420,7 +420,7 @@ export class CrmService {
     };
 
     return new Promise(resolve => {
-      Request.post(options, (error, response, body) => {
+      Request.get(options, (error, response, body) => {
         const stringifiedBody = body.toString('utf-8');
         if (response.statusCode >= 400) {
           console.log('error', stringifiedBody);
@@ -452,6 +452,32 @@ export class CrmService {
         }
 
         resolve(JSON.parse(stringifiedBody));
+      });
+    })
+  }
+
+  async deleteSharepointFile(serverRelativeUrl): Promise<any> {
+    const { access_token } = await this.generateSharePointAccessToken();
+    const SHAREPOINT_CRM_SITE = this.config.get('SHAREPOINT_CRM_SITE');
+    const url = `https://nyco365.sharepoint.com/sites/${SHAREPOINT_CRM_SITE}/_api/web/GetFileByServerRelativeUrl('${serverRelativeUrl}')`;
+
+    const options = {
+      url,
+      headers: {
+        'Authorization': `Bearer ${access_token}`,
+        Accept: 'application/json',
+        'X-HTTP-Method': 'DELETE',
+      },
+    };
+
+    return new Promise(resolve => {
+      Request.del(options, (error, response, body) => {
+        const stringifiedBody = body.toString('utf-8');
+        if (response.statusCode >= 400) {
+          console.log('error', stringifiedBody);
+        }
+
+        resolve();
       });
     })
   }

--- a/server/src/document/document.controller.ts
+++ b/server/src/document/document.controller.ts
@@ -6,6 +6,9 @@ import {
   Session,
   Body,
   UseGuards,
+  Delete,
+  Query,
+  HttpCode,
 } from '@nestjs/common';
 import { ConfigService } from '../config/config.service';
 import { CrmService } from '../crm/crm.service';
@@ -14,6 +17,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { AuthenticateGuard } from '../authenticate.guard';
 
 @Controller('documents')
+@UseGuards(AuthenticateGuard)
 export class DocumentController {
   constructor(
     private readonly config: ConfigService,
@@ -32,7 +36,6 @@ export class DocumentController {
    */
   @Post('/')
   @UseInterceptors(FileInterceptor('file'))
-  @UseGuards(AuthenticateGuard)
   async create(@UploadedFile() file, @Body('instanceId') instanceId, @Session() session) {
     const headers = {
       // Document will be uploaded as this user
@@ -58,5 +61,11 @@ export class DocumentController {
       true,
       headers
     );
+  }
+
+  @Delete('/')
+  @HttpCode(204)
+  async destroy(@Query('serverRelativeUrl') serverRelativeUrl) {
+    return this.crmService.deleteSharepointFile(serverRelativeUrl);
   }
 }

--- a/server/src/packages/packages.controller.ts
+++ b/server/src/packages/packages.controller.ts
@@ -14,6 +14,7 @@ export const PACKAGE_ATTRS = [
   'dcp_packagetype',
   'dcp_visibility',
   'versionnumber',
+  'documents',
 ];
 
 @UseInterceptors(new JsonApiSerializeInterceptor('packages', {

--- a/server/src/packages/packages.service.ts
+++ b/server/src/packages/packages.service.ts
@@ -56,6 +56,7 @@ export class PackagesService {
       documents: documents.map(document => ({
         name: document['Name'],
         timeCreated: document['TimeCreated'],
+        serverRelativeUrl: document['ServerRelativeUrl'],
       })),
     };
   }

--- a/server/src/packages/packages.service.ts
+++ b/server/src/packages/packages.service.ts
@@ -24,8 +24,13 @@ export class PackagesService {
     // but it's slower.
 
     // Double network request approach
-    const { records: [{ _dcp_pasform_value, dcp_project }] } = await this.crmService.get('dcp_packages', `
-      $select=_dcp_pasform_value
+    const { records: [{
+      _dcp_pasform_value,
+      dcp_project,
+      dcp_packageid,
+      dcp_name,
+    }] } = await this.crmService.get('dcp_packages', `
+      $select=_dcp_pasform_value,dcp_packageid,dcp_name
       &$filter=dcp_packageid eq ${packageId}
       &$expand=dcp_project
     `);
@@ -39,10 +44,19 @@ export class PackagesService {
         dcp_dcp_projectbbl_dcp_pasform
     `);
 
+    const { value: documents } = await this.findPackageSharepointDocuments(
+      dcp_name,
+      dcp_packageid,
+    );
+
     return {
       ...projectPackageForm.dcp_package,
       dcp_pasform: projectPackageForm,
       project: dcp_project,
+      documents: documents.map(document => ({
+        name: document['Name'],
+        timeCreated: document['TimeCreated'],
+      })),
     };
   }
 
@@ -50,5 +64,12 @@ export class PackagesService {
     const allowedAttrs = pick(body, PACKAGE_ATTRS);
 
     return this.crmService.update('dcp_packages', id, allowedAttrs);
+  }
+
+  async findPackageSharepointDocuments(packageName, id:string) {
+    const cleanedId = id.toUpperCase().replace(/-/g, '');
+    const folderIdentifier = `${packageName}_${cleanedId}`;
+
+    return this.crmService.getSharepointFolderFiles(`dcp_package/${folderIdentifier}`);
   }
 }


### PR DESCRIPTION
This adds a separate authentication stratgy for looking up a package’s documents in SharePoint.

That auth is used to lookup a packages uploaded documents.

Include endpoint for deleting documents.