### PR TITLE
Use destroyRecord instead of store deleteRecord

### DIFF
--- a/client/app/components/packages/applicant-team-editor.js
+++ b/client/app/components/packages/applicant-team-editor.js
@@ -20,7 +20,8 @@ export default class ApplicantTeamEditorComponent extends Component {
   @action
   removeApplicant(applicant) {
     // remove the applicant from the ember store
-    this.store.deleteRecord(applicant);
+    // this.store.deleteRecord(applicant);
+    applicant.destroyRecord();
 
     // remove the DOM node by removing the object from the array passed to the editor component
     this.args.applicants.removeObject(applicant);

--- a/client/app/components/project-geography.js
+++ b/client/app/components/project-geography.js
@@ -41,7 +41,8 @@ export default class ProjectGeographyComponent extends Component {
   // Remove bbl object from list of bbls
   @action
   removeBbl(bblObjectToBeRemoved) {
-    this.store.deleteRecord(bblObjectToBeRemoved);
+    // this.store.deleteRecord(bblObjectToBeRemoved);
+    bblObjectToBeRemoved.destroyRecord();
     this.args.bbls.removeObject(bblObjectToBeRemoved);
   }
 

--- a/client/mirage/config.js
+++ b/client/mirage/config.js
@@ -31,12 +31,14 @@ export default function() {
   this.get('/applicants');
   this.get('/applicants/:id');
   this.patch('/applicants/:id');
+  this.del('/applicants/:id');
   this.post('/applicants');
 
   this.get('/bbls');
   this.get('/bbls/:id');
   this.post('/bbls');
   this.patch('/bbls/:id');
+  this.del('/bbls/:id');
 
   this.patch('/pas-forms');
   this.post('/pas-forms');


### PR DESCRIPTION
This uses the destroyRecord api instead of deleting through the store.

For reasons I don't know yet, it isn't picking up store.deleteRecord calls.