### PR TITLE
Consistent Delete UI

### DIFF
--- a/client/app/components/land-use-action.hbs
+++ b/client/app/components/land-use-action.hbs
@@ -15,7 +15,7 @@
   </label>
 </div>
 {{#each this.landUseActionSelections as |landUseAction|}}
-  <fieldset class="fieldset">
+  <fieldset class="fieldset relative">
     <legend>
       <strong>{{landUseAction.name}}</strong>
     </legend>
@@ -66,15 +66,15 @@
         <span class="help-text">ex. 200307ZRK</span>
       </label>
     {{/if}}
-  <div class="text-right">
-    <button 
-      type="button" 
-      class="text-red"
-      onClick={{fn this.removeSelectedAction landUseAction}}
+
+    <button
+      type="button"
+      class="delete-fieldset"
+      {{on "click" (fn this.removeSelectedAction landUseAction)}}
       data-test-delete-button="{{landUseAction.name}}"
     >
-      {{fa-icon 'times'}} DELETE
+      Delete Action
+      <FaIcon @icon="times" @prefix="fas" fixedWidth={{true}} />
     </button>
-  </div>
   </fieldset>
 {{/each}}

--- a/client/app/components/land-use-action.hbs
+++ b/client/app/components/land-use-action.hbs
@@ -74,7 +74,7 @@
       data-test-delete-button="{{landUseAction.name}}"
     >
       Delete Action
-      <FaIcon @icon="times" @prefix="fas" fixedWidth={{true}} />
+      <FaIcon @icon="times" @prefix="fas" @fixedWidth={{true}} />
     </button>
   </fieldset>
 {{/each}}

--- a/client/app/components/packages/applicant-fieldset.hbs
+++ b/client/app/components/packages/applicant-fieldset.hbs
@@ -8,8 +8,8 @@
   {{!-- if sent to CRM "Applicant Information" table, need to know "type" --}}
   {{#if (eq @applicant.targetEntity "Applicant")}}
     <div class="cell medium-6" data-test-applicant-type-radio-group>
-      <Input 
-        @type="radio" 
+      <Input
+        @type="radio"
         name={{concat 'applicant-type' @elementId}}
         @value="Individual"
         checked={{if (eq @applicant.applicantType "Individual") true}}
@@ -17,9 +17,9 @@
         data-test-applicant-type-radio-individual
       />
       <label>Individual</label>
-      <Input 
-        @type="radio" 
-        name={{concat 'applicant-type' @elementId}} 
+      <Input
+        @type="radio"
+        name={{concat 'applicant-type' @elementId}}
         @value="Organization"
         checked={{if (eq @applicant.applicantType "Organization") true}}
         onClick={{fn this.updateAttr @applicant "applicantType" "Organization"}}
@@ -32,9 +32,9 @@
   {{!-- and if the applicant is on behalf of an organization, we need to know which organization --}}
   {{#if (eq @applicant.applicantType "Organization")}}
     <label>
-      Organization 
-      <Input 
-        type="text" 
+      Organization
+      <Input
+        type="text"
         @value={{@applicant.dcpOrganization}}
         data-test-applicant-organization
       />
@@ -45,15 +45,15 @@
   <div class="grid-x grid-margin-x">
     <div class="cell medium-6">
       <label>First Name</label>
-      <Input 
-        type="text" 
+      <Input
+        type="text"
         @value={{@applicant.dcpFirstname}}
       />
     </div>
     <div class="cell medium-6">
       <label>Last Name</label>
-        <Input 
-          type="text" 
+        <Input
+          type="text"
           @value={{@applicant.dcpLastname}}
         />
     </div>
@@ -63,8 +63,8 @@
   {{#if (eq @applicant.targetEntity "Applicant Team Member")}}
     <label>
       Organization
-      <Input 
-        type="text" 
+      <Input
+        type="text"
         @value={{@applicant.dcpOrganization}}
       />
     </label>
@@ -84,11 +84,17 @@
       <label>ZIP <Input type="text" @value={{@applicant.dcpZipcode}}/></label>
     </div>
   </div>
-  
+
   <label>Phone <Input type="text" @value={{@applicant.dcpPhone}}/></label>
 
-  <p class="text-right no-margin text-small">
-    {{yield}}
-  </p>
+  <button
+    type="button"
+    class="delete-fieldset"
+    {{on "click" (fn @removeApplicant @applicant)}}
+    data-test-remove-applicant-button
+  >
+    Remove {{@applicant.targetEntity}}
+    <FaIcon @icon="times"  @prefix="fas" @fixedWidth={{true}} />
+  </button>
 
 </fieldset>

--- a/client/app/components/packages/applicant-fieldset.hbs
+++ b/client/app/components/packages/applicant-fieldset.hbs
@@ -94,7 +94,7 @@
     data-test-remove-applicant-button
   >
     Remove {{@applicant.targetEntity}}
-    <FaIcon @icon="times"  @prefix="fas" @fixedWidth={{true}} />
+    <FaIcon @icon="times" @prefix="fas" @fixedWidth={{true}} />
   </button>
 
 </fieldset>

--- a/client/app/components/packages/applicant-team-editor.hbs
+++ b/client/app/components/packages/applicant-team-editor.hbs
@@ -1,4 +1,4 @@
-<section {{did-insert this.addApplicantIfEmpty}}>
+<div {{did-insert this.addApplicantIfEmpty}}>
   {{#each @applicants as |applicant index|}}
     <Packages::ApplicantFieldset
       @elementId={{concat 'applicant-fieldset-' index}}
@@ -6,20 +6,7 @@
       @removeApplicant={{fn this.removeApplicant}}
       data-test-applicant-fieldset={{index}}
       data-test-applicant-type={{applicant.targetEntity}}
-    >
-      <button
-        class="trash-button text-red-dark"
-        type="button"
-        onClick={{fn this.removeApplicant applicant}}
-        data-test-remove-applicant-button
-      >
-        <FaIcon 
-          @icon="times"
-          @prefix="fas"
-        />
-        Remove Applicant
-      </button>
-    </Packages::ApplicantFieldset>
+    />
   {{/each}}
 
   {{!-- buttons for user to add new applicants --}}
@@ -28,7 +15,7 @@
       Add an Applicant Team Member:
     </p>
     <p class="button-group">
-      <button 
+      <button
         class="button secondary"
         type="button"
         {{on "click" (fn this.addApplicant "Applicant") }}
@@ -36,7 +23,7 @@
       >
         Add Applicant
       </button>
-      <button 
+      <button
         class="button secondary"
         type="button"
         {{on "click" (fn this.addApplicant "Applicant Team Member") }}
@@ -46,4 +33,4 @@
       </button>
     </p>
   </div>
-</section>
+</div>

--- a/client/app/components/packages/attachments.hbs
+++ b/client/app/components/packages/attachments.hbs
@@ -7,7 +7,7 @@
         </b>
       </legend>
 
-      <ul class="no-bullet">  
+      <ul class="no-bullet">
         {{#each @fileManager.existingFiles as |file idx|}}
           <li
           class="text-justify"
@@ -77,25 +77,30 @@
             class="text-justify"
           >
           <div class="grid-x">
-            <div class="cell small-8">
+            <div class="cell auto">
               <b
                 data-test-document-to-be-uploaded-name={{idx}}
               >
                 {{file.name}}
               </b>
             </div>
-            <div class="cell small-3 text-right">
+            <div class="cell shrink">
               <small>
                 TO BE ADDED
               </small>
             </div>
-            <div class="cell small-1 text-right">
+            <div class="cell shrink">
               <button
-                 {{on "click" (fn this.deselectFileForUpload file)}}
-                data-test-deselect-file-button={{idx}}
                 type="button"
+                class="text-red-dark"
+                {{on "click" (fn this.deselectFileForUpload file)}}
+                data-test-deselect-file-button={{idx}}
               >
-                <FaIcon @icon="times" @prefix="fas" class="text-red" />
+                <FaIcon
+                  @icon="times"
+                  @prefix="fas"
+                  @fixedWidth={{true}}
+                />
               </button>
             </div>
           </div>

--- a/client/app/components/project-geography.hbs
+++ b/client/app/components/project-geography.hbs
@@ -78,7 +78,7 @@
       data-test-button-remove-bbl="{{bbl.dcpBblnumber}}"
     >
       Delete BBL
-      <FaIcon @icon="times" @prefix="fas" fixedWidth={{true}} />
+      <FaIcon @icon="times" @prefix="fas" @fixedWidth={{true}} />
     </button>
   </fieldset>
 {{/each}}

--- a/client/app/components/project-geography.hbs
+++ b/client/app/components/project-geography.hbs
@@ -8,77 +8,77 @@
 </LabsSearch>
 
 {{#each @bbls as |bbl idx|}}
-  <fieldset class="fieldset">
+  <fieldset class="fieldset relative">
     <legend data-test-bbl-title="{{bbl.dcpBblnumber}}">
-    <strong>{{bbl.dcpBblnumber}}</strong>
-  </legend>
-  <fieldset>
-    <legend data-test-development-site-question="{{bbl.dcpBblnumber}}-{{bbl.dcpDevelopmentsite}}">
-      Is this BBL part of the development site?
+      <strong>{{bbl.dcpBblnumber}}</strong>
     </legend>
-    <Input
-      @type="radio"
-      name={{concat idx '-bbl-dev-site'}}
-      id={{concat idx '-bbl-dev-site-yes'}}
-      @value={{eq bbl.dcpDevelopmentsite true}}
-      checked={{eq bbl.dcpDevelopmentsite true}}
-      onClick={{fn this.updateAttr bbl "dcpDevelopmentsite" true}}
-      data-test-bbl-development-site-yes="{{bbl.dcpBblnumber}}"
-    />
-    <label for="{{concat idx '-bbl-dev-site-yes'}}">
-      Yes
-    </label>
-    <Input
-      @type="radio"
-      name={{concat idx '-bbl-dev-site'}}
-      id={{concat idx '-bbl-dev-site-no'}}
-      @value={{eq bbl.dcpDevelopmentsite false}}
-      checked={{eq bbl.dcpDevelopmentsite false}}
-      onClick={{fn this.updateAttr bbl "dcpDevelopmentsite" false}}
-      data-test-bbl-development-site-no="{{bbl.dcpBblnumber}}"
-    />
-    <label for="{{concat idx '-bbl-dev-site-no'}}">
-      No
-    </label>
-  </fieldset>
-  <fieldset>
-    <legend data-test-partial-lot-question="{{bbl.dcpBblnumber}}-{{bbl.dcpPartiallot}}">
-      Is this a partial lot?
-    </legend>
-    <Input
-      type="radio"
-      name="bbl-partial-lot-yes"
-      id="bbl-partial-lot-yes"
-      @value={{eq bbl.dcpPartiallot true}}
-      checked={{eq bbl.dcpPartiallot true}}
-      onClick={{fn this.updateAttr bbl "dcpPartiallot" true}}
-      data-test-bbl-partial-lot-yes="{{bbl.dcpBblnumber}}"
-    />
-    <label for="bbl-partial-lot-yes">
-      Yes
-    </label>
-    <Input
-      @type="radio"
-      name="bbl-partial-lot-no"
-      id="bbl-partial-lot-no"
-      @value={{eq bbl.dcpPartiallot false}}
-      checked={{eq bbl.dcpPartiallot false}}
-      onClick={{fn this.updateAttr bbl "dcpPartiallot" false}}
-      data-test-bbl-partial-lot-no="{{bbl.dcpBblnumber}}"
-    />
-    <label for="bbl-partial-lot-no">
-      No
-    </label>
-  </fieldset>
-    <div class="text-right">
-      <button
-        type="button"
-        class="text-red"
-        data-test-button-remove-bbl="{{bbl.dcpBblnumber}}"
-        onClick={{fn this.removeBbl bbl}}
-      >
-        {{fa-icon 'times'}} DELETE
-      </button>
-    </div>
+    <fieldset>
+      <legend data-test-development-site-question="{{bbl.dcpBblnumber}}-{{bbl.dcpDevelopmentsite}}">
+        Is this BBL part of the development site?
+      </legend>
+      <Input
+        @type="radio"
+        name={{concat idx '-bbl-dev-site'}}
+        id={{concat idx '-bbl-dev-site-yes'}}
+        @value={{eq bbl.dcpDevelopmentsite true}}
+        checked={{eq bbl.dcpDevelopmentsite true}}
+        {{on "click" (fn this.updateAttr bbl "dcpDevelopmentsite" true)}}
+        data-test-bbl-development-site-yes="{{bbl.dcpBblnumber}}"
+      />
+      <label for="{{concat idx '-bbl-dev-site-yes'}}">
+        Yes
+      </label>
+      <Input
+        @type="radio"
+        name={{concat idx '-bbl-dev-site'}}
+        id={{concat idx '-bbl-dev-site-no'}}
+        @value={{eq bbl.dcpDevelopmentsite false}}
+        checked={{eq bbl.dcpDevelopmentsite false}}
+        {{on "click" (fn this.updateAttr bbl "dcpDevelopmentsite" false)}}
+        data-test-bbl-development-site-no="{{bbl.dcpBblnumber}}"
+      />
+      <label for="{{concat idx '-bbl-dev-site-no'}}">
+        No
+      </label>
+    </fieldset>
+    <fieldset>
+      <legend data-test-partial-lot-question="{{bbl.dcpBblnumber}}-{{bbl.dcpPartiallot}}">
+        Is this a partial lot?
+      </legend>
+      <Input
+        type="radio"
+        name="bbl-partial-lot-yes"
+        id="bbl-partial-lot-yes"
+        @value={{eq bbl.dcpPartiallot true}}
+        checked={{eq bbl.dcpPartiallot true}}
+        {{on "click" (fn this.updateAttr bbl "dcpPartiallot" true)}}
+        data-test-bbl-partial-lot-yes="{{bbl.dcpBblnumber}}"
+      />
+      <label for="bbl-partial-lot-yes">
+        Yes
+      </label>
+      <Input
+        @type="radio"
+        name="bbl-partial-lot-no"
+        id="bbl-partial-lot-no"
+        @value={{eq bbl.dcpPartiallot false}}
+        checked={{eq bbl.dcpPartiallot false}}
+        {{on "click" (fn this.updateAttr bbl "dcpPartiallot" false)}}
+        data-test-bbl-partial-lot-no="{{bbl.dcpBblnumber}}"
+      />
+      <label for="bbl-partial-lot-no">
+        No
+      </label>
+    </fieldset>
+
+    <button
+      type="button"
+      class="delete-fieldset"
+      {{on "click" (fn this.removeBbl bbl)}}
+      data-test-button-remove-bbl="{{bbl.dcpBblnumber}}"
+    >
+      Delete BBL
+      <FaIcon @icon="times" @prefix="fas" fixedWidth={{true}} />
+    </button>
   </fieldset>
 {{/each}}

--- a/client/app/styles/app.scss
+++ b/client/app/styles/app.scss
@@ -60,3 +60,14 @@ $sticky-sidebar-offset: 6rem + rem-calc(20);
     overflow: auto;
   }
 }
+
+.delete-fieldset {
+  position: absolute;
+  top: 0;
+  right: $global-margin;
+  background-color: $off-white;
+  color: $red-dark;
+  font-size: rem-calc(14);
+  padding: 0.4em;
+  padding-right: 0;
+}


### PR DESCRIPTION
This PR
- [x] Makes all the buttons that delete fieldsets look the same, positioning them consistently to the top-right of the fieldset
- [x] Simplifies the `<ApplicantFieldset />` component 
- [x] Uses `{{on "click"...` consistently, replacing a few stray `onClick={{...`
- [x] Fixes indentation in `project-geography.hbs` 

![image](https://user-images.githubusercontent.com/409279/81217782-2c156280-8fab-11ea-888a-4b899d9edb1a.png)

Addresses #177.