### PR TITLE
119: pre-populate project name on pas-form with dcpProjectname

### DIFF
--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -19,7 +19,8 @@
         <strong>Project Name</strong>
         <Input
           @type="text"
-          @value={{@package.pasForm.dcpRevisedprojectname}}
+          @value={{if @package.pasForm.dcpRevisedprojectname @package.pasForm.dcpRevisedprojectname @package.project.dcpProjectname}}
+          @key-down={{fn (mut @package.pasForm.dcpRevisedprojectname)}}
           data-test-dcprevisedprojectname
         />
       </label>

--- a/client/app/routes/packages/edit.js
+++ b/client/app/routes/packages/edit.js
@@ -4,7 +4,7 @@ export default class PackagesEditRoute extends Route {
   model(params) {
     return this.store.findRecord('package', params.id, {
       reload: true,
-      include: 'pasForm',
+      include: 'pasForm,project',
     });
   }
 }

--- a/client/tests/integration/components/pas-form-test.js
+++ b/client/tests/integration/components/pas-form-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import {
-  render, click, fillIn, settled,
+  render, click, fillIn, settled, triggerEvent,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -96,9 +96,13 @@ module('Integration | Component | pas-form', function(hooks) {
   });
 
   test('user can save pas form', async function(assert) {
-    const projectPackage = this.server.create('package');
+    // although we cannot actually test that the value in the project name input box is equal to:
+    // pasForm.dcpRevisedprojectname when the revised name exists, and project.dcpProjectname when it does not exist
+    // the dcpProjectname is included in this test as documentation
+    const ourProject = this.server.create('project', { id: 1, dcpProjectname: 'Frozen Banana Castle' });
+    const projectPackage = this.server.create('package', { project: ourProject });
 
-    this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form' });
+    this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form,project' });
 
     // render form
     await render(hbs`<Packages::PasForm::Edit @package={{this.package}} />`);
@@ -109,6 +113,7 @@ module('Integration | Component | pas-form', function(hooks) {
 
     // edit a field to make it pasForm dirty
     await fillIn('[data-test-dcprevisedprojectname]', 'Some Cool New Project Name');
+    await triggerEvent('[data-test-dcprevisedprojectname]', 'keydown');
 
     // save button should become active when dirty
     assert.dom('[data-test-save-button').hasProperty('disabled', false);


### PR DESCRIPTION
Pre-populate the project name input box on the pas-form with either `project.dcpProjectname` or `pasForm.dcpRevisedprojectname`.

When pasForm.dcpRevisedprojectname exists, the input value on the project name input box is pasForm.dcpRevisedprojectname. Otherwise, value is project.dcpProjectname. When a user starts typing in the input box, pasForm.dcpRevisedprojectname is mutated on key-down event.

Addresses #119 