### PR TITLE
110: addresses next to bbl in ProjectGeography component bbl list

### DIFF
--- a/client/app/components/project-geography.hbs
+++ b/client/app/components/project-geography.hbs
@@ -10,7 +10,16 @@
 {{#each @bbls as |bbl idx|}}
   <fieldset class="fieldset relative">
     <legend data-test-bbl-title="{{bbl.dcpBblnumber}}">
-      <strong>{{bbl.dcpBblnumber}}</strong>
+      <a
+        href="https://zola.planning.nyc.gov/bbl/{{bbl.dcpBblnumber}}"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <strong>{{bbl.dcpBblnumber}}</strong>
+      </a>
+      {{#if bbl.temporaryAddressLabel}}
+        ({{bbl.temporaryAddressLabel}})
+      {{/if}}
     </legend>
     <fieldset>
       <legend data-test-development-site-question="{{bbl.dcpBblnumber}}-{{bbl.dcpDevelopmentsite}}">

--- a/client/app/components/project-geography.js
+++ b/client/app/components/project-geography.js
@@ -10,27 +10,23 @@ export default class ProjectGeographyComponent extends Component {
   // represents array of bbl models
   @tracked bbls;
 
-  // TODO: ISSUE #110
-  // Used to find corresponding addresses for list of bbls.
-  // Populated later with labs-search addon response.
-  // bblToAddressLookup = {};
-
   @action
   selectSearchResult(labsSearchResult) {
     // `labsSearchResult` is object with `label` (address) and `bbl` attributes.
     // labsSearchResult.bbl comes back as a number,
     // whereas dcpBblnumber in CRM is stored as a string.
+    const currentBbl = labsSearchResult.bbl.toString();
+
     const bblObjectToPush = this.store.createRecord('bbl', {
-      dcpBblnumber: labsSearchResult.bbl.toString(),
+      dcpBblnumber: currentBbl,
       dcpDevelopmentsite: null,
       dcpPartiallot: null,
     });
 
-    // TODO: ISSUE #110
-    // set local variables for displaying address next to bbl in list
-    // const currentAddress = labsSearchResult.label;
-    // const formattedAddress = currentAddress.replace(', New York, NY, USA', '');
-    // this.bblToAddressLookup[currentBbl] = formattedAddress;
+    // set local variables for displaying address next to bbl in bbls list
+    const currentAddress = labsSearchResult.label;
+    const formattedAddress = currentAddress.replace(', New York, NY, USA', '');
+    bblObjectToPush.temporaryAddressLabel = formattedAddress;
 
     // use unshiftObect to push to TOP of array
     // this sorting is so that when a user adds a new bbl, the bbl does not appear at the

--- a/client/app/models/pas-form.js
+++ b/client/app/models/pas-form.js
@@ -789,6 +789,7 @@ export default class PasFormModel extends Model {
 
   @attr('string') dcpRepresentativeaddress3;
 
+  temporaryAddressLabel = '';
 
   async saveDirtyBbls() {
     return Promise.all(

--- a/client/tests/integration/components/project-geography-test.js
+++ b/client/tests/integration/components/project-geography-test.js
@@ -41,10 +41,15 @@ module('Integration | Component | project-geography', function(hooks) {
     await fillIn('.map-search-input', '1000120001');
     await triggerKeyEvent('.labs-geosearch', 'keypress', 13);
 
+    assert.dom(this.element).includesText('1 Bowling Green, Manhattan');
+
     assert.dom('[data-test-bbl-title="1000120001"]').exists();
 
+    // test that user can add more than one bbl
     await fillIn('.map-search-input', '1000030001');
     await triggerKeyEvent('.labs-geosearch', 'keypress', 13);
+
+    assert.dom(this.element).includesText('10 Battery Park, Manhattan');
 
     assert.dom('[data-test-bbl-title="1000030001"]').exists();
   });


### PR DESCRIPTION
**BBls list in ProjectGeography component now includes link to zola and address.** 

**Address**: When a user searches a bbl or address in the labs-search component, an object with a bbl and corresponding address is returned. A lookup is populated with these bbl-address pairs so that addresses can be displayed next to the bbl in the bbls list. NOTE: these will disappear on hard refresh. 

**Zola Link**: This PR also provides link to zola on each bbl.

Addresses #110 

<img width="768" alt="Screen Shot 2020-05-06 at 5 01 29 PM" src="https://user-images.githubusercontent.com/26672885/81232868-48b99680-8fbb-11ea-9500-749214e5df43.png">
