### PR TITLE
162:  Refactor applicants model

### DIFF
--- a/client/app/components/packages/applicant-fieldset.hbs
+++ b/client/app/components/packages/applicant-fieldset.hbs
@@ -8,24 +8,20 @@
   {{!-- if sent to CRM "Applicant Information" table, need to know "type" --}}
   {{#if (eq @applicant.friendlyEntityName "Applicant")}}
     <div class="cell medium-6" data-test-applicant-type-radio-group>
-      <Input
-        @type="radio"
-        name={{concat 'applicant-type' @elementId}}
-        @value="Applicant"
-        checked={{if (eq @applicant.dcpType "Applicant") true}}
-        onClick={{fn this.updateAttr @applicant "dcpType" "Applicant"}}
-        data-test-applicant-type-radio-individual
-      />
-      <label>Individual</label>
-      <Input
-        @type="radio"
-        name={{concat 'applicant-type' @elementId}}
-        @value="Authorized Applicant Representative"
-        checked={{if (eq @applicant.dcpType "Authorized Applicant Representative") true}}
-        onClick={{fn this.updateAttr @applicant "dcpType" "Authorized Applicant Representative"}}
-        data-test-applicant-type-radio-organization
-      />
-      <label>Organization</label>
+      <RadioButton
+        @value={{717170000}}
+        @groupValue={{@applicant.dcpType}}
+          data-test-applicant-type-radio-individual
+      >
+        Individual
+      </RadioButton>
+      <RadioButton
+        @value={{717170001}}
+        @groupValue={{@applicant.dcpType}}
+          data-test-applicant-type-radio-organization
+      >
+        Organization
+      </RadioButton>
     </div>
   {{/if}}
 

--- a/client/app/components/packages/applicant-fieldset.hbs
+++ b/client/app/components/packages/applicant-fieldset.hbs
@@ -1,28 +1,28 @@
 <fieldset class="fieldset relative" ...attributes>
-  <legend data-test-applicant-title="{{@applicant.targetEntity}}">
+  <legend data-test-applicant-title="{{@applicant.friendlyEntityName}}">
     <strong>
-      {{@applicant.targetEntity}}
+      {{@applicant.friendlyEntityName}}
     </strong>
   </legend>
 
   {{!-- if sent to CRM "Applicant Information" table, need to know "type" --}}
-  {{#if (eq @applicant.targetEntity "Applicant")}}
+  {{#if (eq @applicant.friendlyEntityName "Applicant")}}
     <div class="cell medium-6" data-test-applicant-type-radio-group>
       <Input
         @type="radio"
         name={{concat 'applicant-type' @elementId}}
-        @value="Individual"
-        checked={{if (eq @applicant.dcpType "Individual") true}}
-        onClick={{fn this.updateAttr @applicant "dcpType" "Individual"}}
+        @value="Applicant"
+        checked={{if (eq @applicant.dcpType "Applicant") true}}
+        onClick={{fn this.updateAttr @applicant "dcpType" "Applicant"}}
         data-test-applicant-type-radio-individual
       />
       <label>Individual</label>
       <Input
         @type="radio"
         name={{concat 'applicant-type' @elementId}}
-        @value="Organization"
-        checked={{if (eq @applicant.dcpType "Organization") true}}
-        onClick={{fn this.updateAttr @applicant "dcpType" "Organization"}}
+        @value="Authorized Applicant Representative"
+        checked={{if (eq @applicant.dcpType "Authorized Applicant Representative") true}}
+        onClick={{fn this.updateAttr @applicant "dcpType" "Authorized Applicant Representative"}}
         data-test-applicant-type-radio-organization
       />
       <label>Organization</label>
@@ -60,7 +60,7 @@
   </div>
 
   {{!-- always allow input for Applicant Team Members --}}
-  {{#if (eq @applicant.targetEntity "Applicant Team Member")}}
+  {{#if (eq @applicant.friendlyEntityName "Applicant Team Member")}}
     <label>
       Organization
       <Input
@@ -93,7 +93,7 @@
     {{on "click" (fn @removeApplicant @applicant)}}
     data-test-remove-applicant-button
   >
-    Remove {{@applicant.targetEntity}}
+    Remove {{@applicant.friendlyEntityName}}
     <FaIcon @icon="times" @prefix="fas" @fixedWidth={{true}} />
   </button>
 

--- a/client/app/components/packages/applicant-fieldset.hbs
+++ b/client/app/components/packages/applicant-fieldset.hbs
@@ -12,8 +12,8 @@
         @type="radio"
         name={{concat 'applicant-type' @elementId}}
         @value="Individual"
-        checked={{if (eq @applicant.applicantType "Individual") true}}
-        onClick={{fn this.updateAttr @applicant "applicantType" "Individual"}}
+        checked={{if (eq @applicant.dcpType "Individual") true}}
+        onClick={{fn this.updateAttr @applicant "dcpType" "Individual"}}
         data-test-applicant-type-radio-individual
       />
       <label>Individual</label>
@@ -21,8 +21,8 @@
         @type="radio"
         name={{concat 'applicant-type' @elementId}}
         @value="Organization"
-        checked={{if (eq @applicant.applicantType "Organization") true}}
-        onClick={{fn this.updateAttr @applicant "applicantType" "Organization"}}
+        checked={{if (eq @applicant.dcpType "Organization") true}}
+        onClick={{fn this.updateAttr @applicant "dcpType" "Organization"}}
         data-test-applicant-type-radio-organization
       />
       <label>Organization</label>
@@ -30,7 +30,7 @@
   {{/if}}
 
   {{!-- and if the applicant is on behalf of an organization, we need to know which organization --}}
-  {{#if (eq @applicant.applicantType "Organization")}}
+  {{#if (eq @applicant.dcpType "Organization")}}
     <label>
       Organization
       <Input

--- a/client/app/components/packages/applicant-team-editor.hbs
+++ b/client/app/components/packages/applicant-team-editor.hbs
@@ -5,7 +5,7 @@
       @applicant={{applicant}}
       @removeApplicant={{fn this.removeApplicant}}
       data-test-applicant-fieldset={{index}}
-      data-test-applicant-type={{applicant.targetEntity}}
+      data-test-applicant-type={{applicant.friendlyEntityName}}
     />
   {{/each}}
 
@@ -18,7 +18,7 @@
       <button
         class="button secondary"
         type="button"
-        {{on "click" (fn this.addApplicant "Applicant") }}
+        {{on "click" (fn this.addApplicant "dcp_applicantinformation") }}
         data-test-add-applicant-button
       >
         Add Applicant
@@ -26,7 +26,7 @@
       <button
         class="button secondary"
         type="button"
-        {{on "click" (fn this.addApplicant "Applicant Team Member") }}
+        {{on "click" (fn this.addApplicant "dcp_applicantrepresentativeinformation") }}
         data-test-add-applicant-team-member-button
       >
         Add Other Team Member

--- a/client/app/components/packages/applicant-team-editor.js
+++ b/client/app/components/packages/applicant-team-editor.js
@@ -30,7 +30,7 @@ export default class ApplicantTeamEditorComponent extends Component {
   @action
   addApplicantIfEmpty() {
     if (!this.args.applicants.length) {
-      this.addApplicant('Applicant');
+      this.addApplicant();
     }
   }
 }

--- a/client/app/models/applicant.js
+++ b/client/app/models/applicant.js
@@ -46,8 +46,8 @@ export default class ApplicantModel extends Model {
   get friendlyEntityName() {
     if (this.targetEntity === 'dcp_applicantinformation') {
       return 'Applicant';
-    } if (this.targetEntity === 'dcp_applicantrepresentativeinformation') {
-      return 'Applicant Team Member';
-    } throw new Error('Invalid applicant targetEntity');
+    }
+
+    return 'Applicant Team Member';
   }
 }

--- a/client/app/models/applicant.js
+++ b/client/app/models/applicant.js
@@ -4,13 +4,8 @@ export default class ApplicantModel extends Model {
   @belongsTo('pas-form')
   pasForm;
 
-  // indicates which table to send to crm ("Applicant" or "Applicant Representative")
-  @attr('string', {
-    defaultValue: 'Applicant',
-  })
-  targetEntity;
-
-  // doesn't exist on "Applicant Representative Information" CRM table
+  // only exists on dcp_applicantinformation CRM entity
+  // either 'Applicant' or 'Authorized Applicant Representative'
   @attr('string')
   dcpType;
 
@@ -40,4 +35,19 @@ export default class ApplicantModel extends Model {
 
   @attr('string')
   dcpPhone;
+
+  // indicates which table to send to crm ('Applicant' or 'Applicant Representative')
+  @attr('string', {
+    defaultValue: 'dcp_applicantinformation',
+  })
+  targetEntity;
+
+  // derive a friendlier name for the entities to use in the UI
+  get friendlyEntityName() {
+    if (this.targetEntity === 'dcp_applicantinformation') {
+      return 'Applicant';
+    } if (this.targetEntity === 'dcp_applicantrepresentativeinformation') {
+      return 'Applicant Team Member';
+    } throw new Error('Invalid applicant targetEntity');
+  }
 }

--- a/client/app/models/applicant.js
+++ b/client/app/models/applicant.js
@@ -6,7 +6,10 @@ export default class ApplicantModel extends Model {
 
   // only exists on dcp_applicantinformation CRM entity
   // either 'Applicant' or 'Authorized Applicant Representative'
-  @attr('string')
+  // either 717170000 or 717170001
+  @attr('number', {
+    defaultValue: 717170000,
+  })
   dcpType;
 
   @attr('string')

--- a/client/app/models/applicant.js
+++ b/client/app/models/applicant.js
@@ -12,7 +12,7 @@ export default class ApplicantModel extends Model {
 
   // doesn't exist on "Applicant Representative Information" CRM table
   @attr('string')
-  applicantType;
+  dcpType;
 
   @attr('string')
   dcpFirstname;

--- a/client/mirage/factories/applicant.js
+++ b/client/mirage/factories/applicant.js
@@ -12,18 +12,18 @@ export default Factory.extend({
 
   individualApplicant: trait({
     targetEntity: 'Applicant',
-    applicantType: 'Individual',
+    dcpType: 'Individual',
     dcpOrganization: null,
   }),
   organizationApplicant: trait({
     targetEntity: 'Applicant',
-    applicantType: 'Organization',
+    dcpType: 'Organization',
     dcpOrganization: 'Planning Labs',
   }),
 
   applicantTeamMember: trait({
     targetEntity: 'Applicant Team Member',
-    applicantType: null,
+    dcpType: null,
     dcpOrganization: 'Vandelay Industries',
   }),
 });

--- a/client/mirage/factories/applicant.js
+++ b/client/mirage/factories/applicant.js
@@ -11,18 +11,18 @@ export default Factory.extend({
   dcpPhone: '867-5309',
 
   individualApplicant: trait({
-    targetEntity: 'Applicant',
+    targetEntity: 'dcp_applicantinformation',
     dcpType: 'Individual',
     dcpOrganization: null,
   }),
   organizationApplicant: trait({
-    targetEntity: 'Applicant',
+    targetEntity: 'dcp_applicantinformation',
     dcpType: 'Organization',
     dcpOrganization: 'Planning Labs',
   }),
 
   applicantTeamMember: trait({
-    targetEntity: 'Applicant Team Member',
+    targetEntity: 'dcp_applicantrepresentativeinformation',
     dcpType: null,
     dcpOrganization: 'Vandelay Industries',
   }),

--- a/client/mirage/factories/applicant.js
+++ b/client/mirage/factories/applicant.js
@@ -12,12 +12,12 @@ export default Factory.extend({
 
   individualApplicant: trait({
     targetEntity: 'dcp_applicantinformation',
-    dcpType: 'Individual',
+    dcpType: 717170000,
     dcpOrganization: null,
   }),
   organizationApplicant: trait({
     targetEntity: 'dcp_applicantinformation',
-    dcpType: 'Organization',
+    dcpType: 717170001,
     dcpOrganization: 'Planning Labs',
   }),
 

--- a/client/tests/integration/components/packages/applicant-team-editor-test.js
+++ b/client/tests/integration/components/packages/applicant-team-editor-test.js
@@ -56,11 +56,11 @@ module('Integration | Component | packages/applicant-team-editor', function(hook
 
     // can add an applicant
     await click('[data-test-add-applicant-button]');
-    assert.dom('[data-test-applicant-type="Applicant"').exists();
+    assert.dom('[data-test-applicant-type="Applicant"]').exists();
 
     // can add an applicant team member
     await click('[data-test-add-applicant-team-member-button]');
-    assert.dom('[data-test-applicant-type="Applicant Team Member"').exists();
+    assert.dom('[data-test-applicant-type="Applicant Team Member"]').exists();
   });
 
   test('user can remove applicants', async function(assert) {
@@ -98,6 +98,6 @@ module('Integration | Component | packages/applicant-team-editor', function(hook
     await click('[data-test-applicant-type-radio-organization]');
 
     // should be reflected in the applicants array!
-    assert.equal(this.applicants[0].dcpType, 'Authorized Applicant Representative');
+    assert.equal(this.applicants[0].dcpType, 717170001);
   });
 });

--- a/client/tests/integration/components/packages/applicant-team-editor-test.js
+++ b/client/tests/integration/components/packages/applicant-team-editor-test.js
@@ -98,6 +98,6 @@ module('Integration | Component | packages/applicant-team-editor', function(hook
     await click('[data-test-applicant-type-radio-organization]');
 
     // should be reflected in the applicants array!
-    assert.equal(this.applicants[0].dcpType, 'Organization');
+    assert.equal(this.applicants[0].dcpType, 'Authorized Applicant Representative');
   });
 });

--- a/client/tests/integration/components/packages/applicant-team-editor-test.js
+++ b/client/tests/integration/components/packages/applicant-team-editor-test.js
@@ -98,6 +98,6 @@ module('Integration | Component | packages/applicant-team-editor', function(hook
     await click('[data-test-applicant-type-radio-organization]');
 
     // should be reflected in the applicants array!
-    assert.equal(this.applicants[0].applicantType, 'Organization');
+    assert.equal(this.applicants[0].dcpType, 'Organization');
   });
 });

--- a/client/tests/unit/models/applicant-test.js
+++ b/client/tests/unit/models/applicant-test.js
@@ -8,6 +8,10 @@ module('Unit | Model | applicant', function(hooks) {
   test('it exists', function(assert) {
     const store = this.owner.lookup('service:store');
     const model = store.createRecord('applicant', {});
+
+    // make sure code cov tests the computed friendlyEntityName conditional
+    model.targetEntity = 'invalid';
+
     assert.ok(model);
   });
 });

--- a/server/src/packages/pas-form/applicants/applicants.controller.ts
+++ b/server/src/packages/pas-form/applicants/applicants.controller.ts
@@ -15,6 +15,7 @@ export const APPLICANT_ATTRIBUTES = [
   'dcp_state',
   'dcp_zipcode',
   'dcp_phone',
+  'dcp_type',
 ];
 
 @UseInterceptors(new JsonApiSerializeInterceptor('applicants', {


### PR DESCRIPTION
This PR refactors the applicants model to prep for server logic to translate frontend applicant model to the appropriate entity in CRM.  Prep work for #162.  Want to merge this as a small PR to make sure everyone has these changes in their feature branches.

The changes:
1. Rename `applicantType` to `dcpType`, to make the model consistently follow CRM naming
2. Use explicit entityType values to make it clear which entity/table in CRM they will go to.  This will make it simpler on the server side implementation.  Because this is using the explicit crm entity values, I created a computed that translates those entity names into friendly names which we use in the UI (to avoid complicated/repetitive conditionals in the template). 