### PR TITLE
27: package statuscode is changed to Submitted when user clicks Submit button

### DIFF
--- a/client/app/components/packages/pas-form/edit.js
+++ b/client/app/components/packages/pas-form/edit.js
@@ -27,7 +27,8 @@ export default class PasFormComponent extends Component {
 
   @action
   async submit(projectPackage) {
-    await projectPackage.saveDescendants();
+    projectPackage.statuscode = 'Submitted';
+    await projectPackage.save();
 
     this.router.transitionTo('packages.show', projectPackage.id);
   }

--- a/client/tests/integration/components/pas-form-test.js
+++ b/client/tests/integration/components/pas-form-test.js
@@ -152,6 +152,8 @@ module('Integration | Component | pas-form', function(hooks) {
       <div id="reveal-modal-container"></div>
       `);
 
+    assert.equal(this.server.db.packages[0].statuscode, undefined);
+
     // modal doesn't exist to start
     assert.dom('[data-test-reveal-modal]').doesNotExist();
     assert.dom('[data-test-confirm-submit-button]').doesNotExist();
@@ -164,5 +166,7 @@ module('Integration | Component | pas-form', function(hooks) {
     assert.dom('[data-test-confirm-submit-button]').exists();
 
     await click('[data-test-confirm-submit-button]');
+
+    assert.equal(this.server.db.packages[0].statuscode, 'Submitted');
   });
 });


### PR DESCRIPTION
package `statuscode` is set to "Submitted" when a user clicks the Submit button on the PAS Form.

Partly addresses #27

In future PRs:
- conditions for disabling Submit button