### PR TITLE
163 debug missing radio btn answers

### DIFF
--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -1,897 +1,979 @@
 <div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-
-    <p>
-      The <strong>Pre-Application Statement</strong> requests pertinent information about a site and proposed project. By submitting the PAS, a prospective applicant acknowledges that they intend to file a land use application with NYC Planning. Submission allows staff to be assigned from appropriate divisions and project tracking to commence.
-    </p>
-
-    <p>
-      NYC Planning understands that some projects may not be fully formed at the submission of the PAS. Give as much detailed information as possible. Failure to provide detailed, relevant information will result in the PAS being rejected.
-    </p>
-
-    <section class="form-section">
-      <h3 class="section-header">
-        <span id="project-info" class="section-anchor"></span>
-        Project Information
-      </h3>
-
-      <label>
-        <strong>Project Name</strong>
-        <Input
-          @type="text"
-          @value={{@package.pasForm.dcpRevisedprojectname}}
-          data-test-dcprevisedprojectname
-        />
-      </label>
-    </section>
-
-    <section class="form-section">
-      <h3 class="section-header">
-        <span id="applicant-team" class="section-anchor"></span>
-        Applicant Team
-      </h3>
+  {{#with (changeset @package.pasForm this.pasFormValidations) as |pasFormChangeset|}}
+    <div class="cell large-8">
 
       <p>
-        Add all applicants and applicant representatives, including land use consultants and environmental consultants.
+        The <strong>Pre-Application Statement</strong> requests pertinent information about a site and proposed project. By submitting the PAS, a prospective applicant acknowledges that they intend to file a land use application with NYC Planning. Submission allows staff to be assigned from appropriate divisions and project tracking to commence.
       </p>
-
-      <Packages::ApplicantTeamEditor
-        @applicants={{@package.pasForm.applicants}}
-      />
-    </section>
-
-    <section class="form-section">
-      <h3 class="section-header">
-        <span id="project-geography" class="section-anchor"></span>
-        Project Geography
-      </h3>
-
-      <ProjectGeography @bbls={{@package.pasForm.bbls}} />
-
-      <label>
-        <strong>Description of geography</strong>
-        <Textarea @value={{@package.pasForm.dcpDescriptionofprojectareageography}} rows="5" />
-      </label>
-    </section>
-
-    <section class="form-section">
-      <h3 class="section-header">
-        <span id="proposed-land-use-actions" class="section-anchor"></span>
-        Proposed Land Use Actions
-      </h3>
 
       <p>
-        What land use actions does the proposed project require? Identify all that apply and fill in the appropriate related information.
+        NYC Planning understands that some projects may not be fully formed at the submission of the PAS. Give as much detailed information as possible. Failure to provide detailed, relevant information will result in the PAS being rejected.
       </p>
+        <section class="form-section">
+          <h3 class="section-header">
+            <span id="project-info" class="section-anchor"></span>
+            Project Information
+          </h3>
 
-      <p class="text-small">
-        Note: This is preliminary information and may change following discussion with NYC Planning.
-      </p>
-
-      <LandUseAction
-        @pasForm={{@package.pasForm}}
-      />
-    </section>
-
-    <section class="form-section">
-      <h3 class="section-header">
-        <span id="project-area" class="section-anchor"></span>
-        Project Area
-      </h3>
-
-      <p>
-        Project Area refers to all property that would be subject to the proposed actions.
-      </p>
-
-      <fieldset class="medium-margin-bottom">
-        <legend>
-          <strong>Does the proposed Project, or portion thereof, require a NYC DEP Storm Water Construction Permit?</strong>
-        </legend>
-        <Input
-          @type="radio"
-          @name="dcpproposedprojectorportionconstruction"
-          id="dcpproposedprojectorportionconstruction-yes"
-          @value='717170000'
-          checked={{if (eq @package.pasForm.dcpProposedprojectorportionconstruction "717170000") true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpProposedprojectorportionconstruction" "717170000"}}
-          data-test-dcpproposedprojectorportionconstruction-yes
-        /><label for="dcpproposedprojectorportionconstruction-yes">Yes</label>
-        <Input
-          @type="radio"
-          @name="dcpproposedprojectorportionconstruction"
-          id="dcpproposedprojectorportionconstruction-no"
-          @value='717170000'
-          checked={{if (eq @package.pasForm.dcpProposedprojectorportionconstruction "717170001") true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpProposedprojectorportionconstruction" "717170001"}}
-          data-test-dcpproposedprojectorportionconstruction-no
-        /><label for="dcpproposedprojectorportionconstruction-no">No</label>
-        <Input
-          @type="radio"
-          @name="dcpproposedprojectorportionconstruction"
-          id="dcpproposedprojectorportionconstruction-unsure"
-          @value='717170002'
-          checked={{if (eq @package.pasForm.dcpProposedprojectorportionconstruction "717170002") true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpProposedprojectorportionconstruction" "717170002"}}
-          data-test-dcpproposedprojectorportionconstruction-unsure
-        /><label for="dcpproposedprojectorportionconstruction-unsure">Unsure at this time</label>
-      </fieldset>
-
-      <fieldset class="medium-margin-bottom">
-        <legend>
-          <strong>Is the proposed Project Area located in a current or former <a href="https://www1.nyc.gov/site/hpd/services-and-information/urban-renewal.page">Urban Renewal Area</a>?</strong>
-        </legend>
-        <Input
-          @type="radio"
-          @name="dcpurbanrenewalarea"
-          id="dcpurbanrenewalarea-yes"
-          @value='717170000'
-          checked={{if (eq @package.pasForm.dcpUrbanrenewalarea "717170000") true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpUrbanrenewalarea" "717170000"}}
-          data-test-dcpurbanrenewalarea-yes
-        /><label for="dcpurbanrenewalarea-yes">Yes</label>
-        <Input
-          @type="radio"
-          @name="dcpurbanrenewalarea"
-          id="dcpurbanrenewalarea-no"
-          @value='717170001'
-          checked={{if (eq @package.pasForm.dcpUrbanrenewalarea "717170001") true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpUrbanrenewalarea" "717170001"}}
-          data-test-dcpurbanrenewalarea-no
-        /><label for="dcpurbanrenewalarea-no">No</label>
-        <Input
-          @type="radio"
-          @name="dcpurbanrenewalarea"
-          id="dcpurbanrenewalarea-unsure"
-          @value='717170002'
-          checked={{if (eq @package.pasForm.dcpUrbanrenewalarea "717170002") true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpUrbanrenewalarea" "717170002"}}
-          data-test-dcpurbanrenewalarea-unsure
-        /><label for="dcpurbanrenewalarea-unsure">Unsure at this time</label>
-        {{#if (eq @package.pasForm.dcpUrbanrenewalarea "717170000")}}
           <label>
-            What is the name of the Urban Renewal Area?
+            <strong>Project Name</strong>
             <Input
               @type="text"
-              @value={{@package.pasForm.dcpUrbanareaname}}
-              data-test-dcpurbanrenewalarea
+              @value={{mut pasFormChangeset.dcpRevisedprojectname}}
+              minLength="4"
+              maxlength="50"
+              data-test-dcprevisedprojectname
             />
           </label>
-        {{/if}}
-      </fieldset>
+          <ValidationMessage
+            @changeset={{pasFormChangeset}}
+            @field="dcpRevisedprojectname"
+          />
+        </section>
 
-      <fieldset class="medium-margin-bottom">
-        <legend>
-          <strong>What is the <a href="https://streets.planning.nyc.gov/about">Legal Street Frontage Status in the Project Area</a>?</strong>
-        </legend>
-        <span class="nowrap">
-          <Input
-            @type="radio"
-            @name="dcplegalstreetfrontage"
-            id="dcplegalstreetfrontage-mapped-and-build"
-            @value='717170000'
-            checked={{if (eq @package.pasForm.dcpLegalstreetfrontage "717170000") true}}
-            onClick={{fn this.updateAttr @package.pasForm "dcpLegalstreetfrontage" "717170000"}}
-            data-test-dcplegalstreetfrontage-mapped-and-build
-          /><label for="dcplegalstreetfrontage-mapped-and-build">Mapped and Build</label>
-        </span>
-        <span class="nowrap">
-          <Input
-            @type="radio"
-            @name="dcplegalstreetfrontage"
-            id="dcplegalstreetfrontage-private-road"
-            @value='717170001'
-            checked={{if (eq @package.pasForm.dcpLegalstreetfrontage "717170001") true}}
-            onClick={{fn this.updateAttr @package.pasForm "dcpLegalstreetfrontage" "717170001"}}
-            data-test-dcplegalstreetfrontage-private-road
-          /><label for="dcplegalstreetfrontage-private-road">Private Road</label>
-        </span>
-        <span class="nowrap">
-          <Input
-            @type="radio"
-            @name="dcplegalstreetfrontage"
-            id="dcplegalstreetfrontage-record-street"
-            @value='717170002'
-            checked={{if (eq @package.pasForm.dcpLegalstreetfrontage "717170002") true}}
-            onClick={{fn this.updateAttr @package.pasForm "dcpLegalstreetfrontage" "717170002"}}
-            data-test-dcplegalstreetfrontage-record-street
-          /><label for="dcplegalstreetfrontage-record-street">Record Street</label>
-        </span>
-        <span class="nowrap">
-          <Input
-            @type="radio"
-            @name="dcplegalstreetfrontage"
-            id="dcplegalstreetfrontage-corporation-counsel-opinion"
-            @value='717170003'
-            checked={{if (eq @package.pasForm.dcpLegalstreetfrontage "717170003") true}}
-            onClick={{fn this.updateAttr @package.pasForm "dcpLegalstreetfrontage" "717170003"}}
-            data-test-dcplegalstreetfrontage-corporation-counsel-opinion
-          /><label for="dcplegalstreetfrontage-corporation-counsel-opinion">Corporation Counsel Opinion</label>
-        </span>
-        <span class="nowrap">
-          <Input
-            @type="radio"
-            @name="dcplegalstreetfrontage"
-            id="dcplegalstreetfrontage-mapped-but-not-build"
-            @value='717170004'
-            checked={{if (eq @package.pasForm.dcpLegalstreetfrontage "717170004") true}}
-            onClick={{fn this.updateAttr @package.pasForm "dcpLegalstreetfrontage" "717170004"}}
-            data-test-dcplegalstreetfrontage-mapped-but-not-build
-          /><label for="dcplegalstreetfrontage-mapped-but-not-build">Mapped but not Build</label>
-        </span>
-      </fieldset>
+        <section class="form-section">
+          <h3 class="section-header">
+            <span id="applicant-team" class="section-anchor"></span>
+            Applicant Team
+          </h3>
 
-      <fieldset class="medium-margin-bottom">
-        <legend>
-          <strong>Do all land use actions meet <a href="https://govt.westlaw.com/nycrr/Document/I4ec3a767cd1711dda432a117e6e0f345?viewType=FullText&originationContext=documenttoc&transitionType=CategoryPageItem&contextData=(sc.Default)">SEQRA or CEQR criteria</a> for Type II status?</strong>
-        </legend>
-        <Input
-          @type="radio"
-          @name="dcplanduseactiontype2"
-          id="dcplanduseactiontype2-yes"
-          @value='717170000'
-          checked={{if (eq @package.pasForm.dcpLanduseactiontype2 "717170000") true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpLanduseactiontype2" "717170000"}}
-          data-test-dcplanduseactiontype2-yes
-        /><label for="dcplanduseactiontype2-yes">Yes</label>
-        <Input
-          @type="radio"
-          @name="dcplanduseactiontype2"
-          id="dcplanduseactiontype2-no"
-          @value='717170001'
-          checked={{if (eq @package.pasForm.dcpLanduseactiontype2 "717170001") true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpLanduseactiontype2" "717170001"}}
-          data-test-dcplanduseactiontype2-no
-        /><label for="dcplanduseactiontype2-no">No</label>
-        <Input
-          @type="radio"
-          @name="dcplanduseactiontype2"
-          id="dcplanduseactiontype2-unsure"
-          @value='717170002'
-          checked={{if (eq @package.pasForm.dcpLanduseactiontype2 "717170002") true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpLanduseactiontype2" "717170002"}}
-          data-test-dcplanduseactiontype2-unsure
-        /><label for="dcplanduseactiontype2-unsure">Unsure at this time</label>
-        {{#if (eq @package.pasForm.dcpLanduseactiontype2 "717170000")}}
+          <p>
+            Add all applicants and applicant representatives, including land use consultants and environmental consultants.
+          </p>
+
+          <Packages::ApplicantTeamEditor
+            @applicants={{@package.pasForm.applicants}}
+          />
+        </section>
+
+        <section class="form-section">
+          <h3 class="section-header">
+            <span id="project-geography" class="section-anchor"></span>
+            Project Geography
+          </h3>
+
+          <ProjectGeography @bbls={{@package.pasForm.bbls}} />
+
           <label>
-            Indicate which SEQRA or CEQR category each action fulfills
-            <Input
-              @type="text"
-              @value={{@package.pasForm.dcpPleaseexplaintypeiienvreview}}
-              data-test-dcppleaseexplaintypeiienvreview
+            <strong>Description of geography</strong>
+            <Textarea
+              @value={{mut pasFormChangeset.dcpDescriptionofprojectareageography}}
+              maxlength="2000"
+              rows="5"
+            />
+            <ValidationMessage
+              @changeset={{pasFormChangeset}}
+              @field="dcpDescriptionofprojectareageography"
             />
           </label>
-        {{/if}}
-      </fieldset>
+        </section>
 
-      <fieldset class="medium-margin-bottom">
-        <legend>
-          <strong>Is the proposed Project Area in an <a href="https://zola.planning.nyc.gov/">Industrial Business Zone</a>?</strong>
-        </legend>
-        <Input
-          @type="radio"
-          @name="dcpprojectareaindustrialbusinesszone"
-          id="dcpprojectareaindustrialbusinesszone-yes"
-          @value={{true}}
-          checked={{if (eq @package.pasForm.dcpProjectareaindustrialbusinesszone true) true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpProjectareaindustrialbusinesszone" true}}
-          data-test-dcpprojectareaindustrialbusinesszone-yes
-        /><label for="dcpprojectareaindustrialbusinesszone-yes">Yes</label>
-        <Input
-          @type="radio"
-          @name="dcpprojectareaindustrialbusinesszone"
-          id="dcpprojectareaindustrialbusinesszone-no"
-          @value={{false}}
-          checked={{if (eq @package.pasForm.dcpProjectareaindustrialbusinesszone false) true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpProjectareaindustrialbusinesszone" false}}
-          data-test-dcpprojectareaindustrialbusinesszone-no
-        /><label for="dcpprojectareaindustrialbusinesszone-no">No</label>
-        {{#if (eq @package.pasForm.dcpProjectareaindustrialbusinesszone true)}}
-          <label>
-            Name of Industrial Business Zone
-            <Input
-              @type="text"
-              @value={{@package.pasForm.dcpProjectareaindutrialzonename}}
-              data-test-dcpprojectareaindustrialbusinesszone
-            />
-          </label>
-        {{/if}}
-      </fieldset>
+        <section class="form-section">
+          <h3 class="section-header">
+            <span id="proposed-land-use-actions" class="section-anchor"></span>
+            Proposed Land Use Actions
+          </h3>
 
-      <fieldset class="medium-margin-bottom">
-        <legend>
-          <strong>Is the proposed Project Area within or adjacent to a designated (City or State) <a href="https://zola.planning.nyc.gov/">Landmark or Historic District</a>?</strong>
-        </legend>
-        <Input
-          @type="radio"
-          @name="dcpisprojectarealandmark"
-          id="dcpisprojectarealandmark-yes"
-          @value={{true}}
-          checked={{if (eq @package.pasForm.dcpIsprojectarealandmark true) true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpIsprojectarealandmark" true}}
-          data-test-dcpisprojectarealandmark-yes
-        /><label for="dcpisprojectarealandmark-yes">Yes</label>
-        <Input
-          @type="radio"
-          @name="dcpisprojectarealandmark"
-          id="dcpisprojectarealandmark-no"
-          @value={{false}}
-          checked={{if (eq @package.pasForm.dcpIsprojectarealandmark false) true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpIsprojectarealandmark" false}}
-          data-test-dcpisprojectarealandmark-no
-        /><label for="dcpisprojectarealandmark-no">No</label>
-        {{#if (eq @package.pasForm.dcpIsprojectarealandmark true)}}
-          <label>
-            Name of Landmark or Historic District
-            <Input
-              @type="text"
-              @value={{@package.pasForm.dcpProjectarealandmarkname}}
-              data-test-dcpisprojectarealandmark
-            />
-          </label>
-        {{/if}}
-      </fieldset>
+          <p>
+            What land use actions does the proposed project require? Identify all that apply and fill in the appropriate related information.
+          </p>
 
-      <fieldset class="medium-margin-bottom">
-        <legend>
-          <strong>Is the proposed Project Area located within the <a href="https://dcp.maps.arcgis.com/apps/View/index.html?appid=90e3a9f927c2471483631a20e8a41d8d">NYC Coastal Zone</a>?</strong>
-        </legend>
-        <Input
-          @type="radio"
-          @name="dcpprojectareacoastalzonelocatedin"
-          id="dcpprojectareacoastalzonelocatedin-yes"
-          @value={{true}}
-          checked={{if (eq @package.pasForm.dcpProjectareacoastalzonelocatedin true) true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpProjectareacoastalzonelocatedin" true}}
-          data-test-dcpprojectareacoastalzonelocatedin-yes
-        /><label for="dcpprojectareacoastalzonelocatedin-yes">Yes</label>
-        <Input
-          @type="radio"
-          @name="dcpprojectareacoastalzonelocatedin"
-          id="dcpprojectareacoastalzonelocatedin-no"
-          @value={{false}}
-          checked={{if (eq @package.pasForm.dcpProjectareacoastalzonelocatedin false) true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpProjectareacoastalzonelocatedin" false}}
-          data-test-dcpprojectareacoastalzonelocatedin-no
-        /><label for="dcpprojectareacoastalzonelocatedin-no">No</label>
-      </fieldset>
+          <p class="text-small">
+            Note: This is preliminary information and may change following discussion with NYC Planning.
+          </p>
 
-      <fieldset class="medium-margin-bottom">
-        <legend>
-          <strong>Is the Project Area located within the <a href="https://dcp.maps.arcgis.com/apps/webappviewer/index.html?id=1c37d271fba14163bbb520517153d6d5">1% annual chance floodplain</a>?</strong>
-        </legend>
-        <Input
-          @type="radio"
-          @name="dcpprojectareaischancefloodplain"
-          id="dcpprojectareaischancefloodplain-yes"
-          @value='717170000'
-          checked={{if (eq @package.pasForm.dcpProjectareaischancefloodplain "717170000") true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpProjectareaischancefloodplain" "717170000"}}
-          data-test-dcpprojectareaischancefloodplain-yes
-        /><label for="dcpprojectareaischancefloodplain-yes">Yes</label>
-        <Input
-          @type="radio"
-          @name="dcpprojectareaischancefloodplain"
-          id="dcpprojectareaischancefloodplain-no"
-          @value='717170001'
-          checked={{if (eq @package.pasForm.dcpProjectareaischancefloodplain "717170001") true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpProjectareaischancefloodplain" "717170001"}}
-          data-test-dcpprojectareaischancefloodplain-no
-        /><label for="dcpprojectareaischancefloodplain-no">No</label>
-        <Input
-          @type="radio"
-          @name="dcpprojectareaischancefloodplain"
-          id="dcpprojectareaischancefloodplain-unsure"
-          @value='717170002'
-          checked={{if (eq @package.pasForm.dcpProjectareaischancefloodplain "717170002") true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpProjectareaischancefloodplain" "717170002"}}
-          data-test-dcpprojectareaischancefloodplain-unsure
-        /><label for="dcpprojectareaischancefloodplain-unsure">Unsure at this time</label>
-      </fieldset>
+          <LandUseAction
+            @pasForm={{@package.pasForm}}
+          />
+        </section>
 
-      <fieldset class="medium-margin-bottom">
-        <legend>
-          <strong>Is a <a href="https://a836-acris.nyc.gov/CP/">legal instrument</a> associated with a previous CPC or CPC Chair action recorded against the project site?</strong>
-        </legend>
-        <Input
-          @type="radio"
-          @name="dcprestrictivedeclaration"
-          id="dcprestrictivedeclaration-yes"
-          @value={{true}}
-          checked={{if (eq @package.pasForm.dcpRestrictivedeclaration true) true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpRestrictivedeclaration" true}}
-          data-test-dcprestrictivedeclaration-yes
-        /><label for="dcprestrictivedeclaration-yes">Yes</label>
-        <Input
-          @type="radio"
-          @name="dcprestrictivedeclaration"
-          id="dcprestrictivedeclaration-no"
-          @value={{false}}
-          checked={{if (eq @package.pasForm.dcpRestrictivedeclaration false) true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpRestrictivedeclaration" false}}
-          data-test-dcprestrictivedeclaration-no
-        /><label for="dcprestrictivedeclaration-no">No</label>
-        {{#if (eq @package.pasForm.dcpRestrictivedeclaration true)}}
-          <label>
-            <strong>City Register File Number</strong>
-            <Input
-              @type="text"
-              @value={{@package.pasForm.dcpCityregisterfilenumber}}
-              data-test-dcpcityregisterfilenumber
-            />
-          </label>
-        {{/if}}
-      </fieldset>
+        <section class="form-section">
+          <h3 class="section-header">
+            <span id="project-area" class="section-anchor"></span>
+            Project Area
+          </h3>
 
-      <fieldset class="medium-margin-bottom">
-        <legend>
-          <strong>Will a new legal instrument or modification of a current legal instrument be necessary to approve/implement these actions?</strong>
-        </legend>
-        <Input
-          @type="radio"
-          @name="dcprestrictivedeclarationrequired"
-          id="dcprestrictivedeclarationrequired-yes"
-          @value='717170000'
-          checked={{if (eq @package.pasForm.dcpRestrictivedeclarationrequired "717170000") true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpRestrictivedeclarationrequired" "717170000"}}
-          data-test-dcprestrictivedeclarationrequired-yes
-        /><label for="dcprestrictivedeclarationrequired-yes">Yes</label>
-        <Input
-          @type="radio"
-          @name="dcprestrictivedeclarationrequired"
-          id="dcprestrictivedeclarationrequired-no"
-          @value='717170001'
-          checked={{if (eq @package.pasForm.dcpRestrictivedeclarationrequired "717170001") true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpRestrictivedeclarationrequired" "717170001"}}
-          data-test-dcprestrictivedeclarationrequired-no
-        /><label for="dcprestrictivedeclarationrequired-no">No</label>
-        <Input
-          @type="radio"
-          @name="dcprestrictivedeclarationrequired"
-          id="dcprestrictivedeclarationrequired-unsure"
-          @value='717170002'
-          checked={{if (eq @package.pasForm.dcpRestrictivedeclarationrequired "717170002") true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpRestrictivedeclarationrequired" "717170002"}}
-          data-test-dcprestrictivedeclarationrequired-unsure
-        /><label for="dcprestrictivedeclarationrequired-unsure">Unsure at this time</label>
-      </fieldset>
-    </section>
+          <p>
+            Project Area refers to all property that would be subject to the proposed actions.
+          </p>
 
-    <section class="form-section">
-      <h3 class="section-header">
-        <span id="proposed-development-site" class="section-anchor"></span>
-        Proposed Development Site
-      </h3>
-
-      <p>
-        Development Site refers to all property to be developed as part of the applicant’s specific proposal which the land use actions would facilitate. Typically, the Development Site and the Project Area will comprise the same property(ies) unless the application is requesting a zoning map amendment covering an area greater than an applicant’s property to be developed or a large-scale special approval involving multiple tax lots. In these cases, the Development Site may be one or several tax lots within a broader Project Area.
-      </p>
-
-      <label>
-        <strong>In what year do you expect the development to complete?</strong>
-        <Input
-          @type="text"
-          @value={{@package.pasForm.dcpEstimatedcompletiondate}}
-          data-test-dcpestimatedcompletiondate
-        />
-        {{!-- QUESTION: Should this be a date picker? --}}
-      </label>
-
-      <fieldset class="medium-margin-bottom">
-        <legend>
-          <strong>What type of development is proposed? (select all that apply)</strong>
-        </legend>
-        <ul class="no-bullet no-margin">
-          <li>
-            <Input
-              @type="checkbox"
-              @checked={{@package.pasForm.dcpProposeddevelopmentsitenewconstruction}}
-              id="dcpproposeddevelopmentsitenewconstruction"
-            /><label for="dcpproposeddevelopmentsitenewconstruction">Newly constructed buildings</label>
-          </li>
-          <li>
-            <Input
-              @type="checkbox"
-              @checked={{@package.pasForm.dcpProposeddevelopmentsitedemolition}}
-              id="dcpproposeddevelopmentsitedemolition"
-            /><label for="dcpproposeddevelopmentsitedemolition">Demolition</label>
-          </li>
-          <li>
-            <Input
-              @type="checkbox"
-              @checked={{@package.pasForm.dcpProposeddevelopmentsiteinfoalteration}}
-              id="dcpproposeddevelopmentsiteinfoalteration"
-            /><label for="dcpproposeddevelopmentsiteinfoalteration">Alteration</label>
-          </li>
-          <li>
-            <Input
-              @type="checkbox"
-              @checked={{@package.pasForm.dcpProposeddevelopmentsiteinfoaddition}}
-              id="dcpproposeddevelopmentsiteinfoaddition"
-            /><label for="dcpproposeddevelopmentsiteinfoaddition">Addition</label>
-          </li>
-          <li>
-            <Input
-              @type="checkbox"
-              @checked={{@package.pasForm.dcpProposeddevelopmentsitechnageofuse}}
-              id="dcpproposeddevelopmentsitechnageofuse"
-            /><label for="dcpproposeddevelopmentsitechnageofuse">Change of use</label>
-          </li>
-          <li>
-            <Input
-              @type="checkbox"
-              @checked={{@package.pasForm.dcpProposeddevelopmentsiteenlargement}}
-              id="dcpproposeddevelopmentsiteenlargement"
-            /><label for="dcpproposeddevelopmentsiteenlargement">Enlargement</label>
-          </li>
-          <li>
-            <Input
-              @type="checkbox"
-              @checked={{@package.pasForm.dcpProposeddevelopmentsiteinfoother}}
-              id="dcpproposeddevelopmentsiteinfoother"
-              data-test-dcpproposeddevelopmentsiteinfoother
-            /><label for="dcpproposeddevelopmentsiteinfoother">Other&hellip;</label>
-          </li>
-        </ul>
-        {{#if @package.pasForm.dcpProposeddevelopmentsiteinfoother}}
-          <label>
-            Explain:
-            <Input
-              @type="text"
-              @value={{@package.pasForm.dcpProposeddevelopmentsiteotherexplanation}}
-              data-test-dcpproposeddevelopmentsiteotherexplanation
-            />
-          </label>
-        {{/if}}
-      </fieldset>
-
-      <fieldset class="medium-margin-bottom">
-        <legend>
-          <strong>Is the Development Site in an <a href="https://zola.planning.nyc.gov/">Inclusionary Housing Designated Area/Mandatory Inclusionary Housing Area</a>?</strong>
-        </legend>
-        <Input
-          @type="radio"
-          @name="dcpisinclusionaryhousingdesignatedarea"
-          id="dcpisinclusionaryhousingdesignatedarea-yes"
-          @value={{true}}
-          checked={{if (eq @package.pasForm.dcpIsinclusionaryhousingdesignatedarea true) true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpIsinclusionaryhousingdesignatedarea" true}}
-          data-test-dcpisinclusionaryhousingdesignatedarea-yes
-        /><label for="dcpisinclusionaryhousingdesignatedarea-yes">Yes</label>
-        <Input
-          @type="radio"
-          @name="dcpisinclusionaryhousingdesignatedarea"
-          id="dcpisinclusionaryhousingdesignatedarea-no"
-          @value={{false}}
-          checked={{if (eq @package.pasForm.dcpIsinclusionaryhousingdesignatedarea false) true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpIsinclusionaryhousingdesignatedarea" false}}
-          data-test-dcpisinclusionaryhousingdesignatedarea-no
-        /><label for="dcpisinclusionaryhousingdesignatedarea-no">No</label>
-        <p class="help-text">
-          Refer to <a  href="https://zr.planning.nyc.gov/appendix-f-inclusionary-housing-designated-areas-and-mandatory-inclusionary-housing-areas">Appendix F</a> of the Zoning Resolution for full list of all inclusionary housing areas which are areas that incentivize or require affordable housing in certain areas.
-        </p>
-        {{#if (eq @package.pasForm.dcpIsinclusionaryhousingdesignatedarea true)}}
-          <label>
-            Name of Inclusionary Housing Designated Area/Mandatory Inclusionary Housing Area
-            <Input
-              @type="text"
-              @value={{@package.pasForm.dcpInclusionaryhousingdesignatedareaname}}
-              data-test-dcpinclusionaryhousingdesignatedareaname
-            />
-          </label>
-        {{/if}}
-      </fieldset>
-
-      <fieldset class="medium-margin-bottom">
-        <legend>
-          <strong>Does the proposed development involve discretionary funding for Affordable Housing Units?</strong>
-        </legend>
-        <Input
-          @type="radio"
-          @name="dcpdiscressionaryfundingforffordablehousing"
-          id="dcpdiscressionaryfundingforffordablehousing-yes"
-          @value='717170000'
-          checked={{if (eq @package.pasForm.dcpDiscressionaryfundingforffordablehousing "717170000") true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpDiscressionaryfundingforffordablehousing" "717170000"}}
-          data-test-dcpdiscressionaryfundingforffordablehousing-yes
-        /><label for="dcpdiscressionaryfundingforffordablehousing-yes">Yes</label>
-        <Input
-          @type="radio"
-          @name="dcpdiscressionaryfundingforffordablehousing"
-          id="dcpdiscressionaryfundingforffordablehousing-no"
-          @value='717170001'
-          checked={{if (eq @package.pasForm.dcpDiscressionaryfundingforffordablehousing "717170001") true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpDiscressionaryfundingforffordablehousing" "717170001"}}
-          data-test-dcpdiscressionaryfundingforffordablehousing-no
-        /><label for="dcpdiscressionaryfundingforffordablehousing-no">No</label>
-        <Input
-          @type="radio"
-          @name="dcpdiscressionaryfundingforffordablehousing"
-          id="dcpdiscressionaryfundingforffordablehousing-unsure"
-          @value='717170002'
-          checked={{if (eq @package.pasForm.dcpDiscressionaryfundingforffordablehousing "717170002") true}}
-          onClick={{fn this.updateAttr @package.pasForm "dcpDiscressionaryfundingforffordablehousing" "717170002"}}
-          data-test-dcpdiscressionaryfundingforffordablehousing-unsure
-        /><label for="dcpdiscressionaryfundingforffordablehousing-unsure">Unsure at this time</label>
-        {{#if (eq @package.pasForm.dcpDiscressionaryfundingforffordablehousing "717170000")}}
           <fieldset class="medium-margin-bottom">
             <legend>
-              Funding source
+              <strong>Does the proposed Project, or portion thereof, require a NYC DEP Storm Water Construction Permit?</strong>
             </legend>
             <Input
               @type="radio"
-              @name="dcphousingunittype"
-              id="dcphousingunittype-city"
+              @name="dcpproposedprojectorportionconstruction"
+              id="dcpproposedprojectorportionconstruction-yes"
               @value='717170000'
-              checked={{if (eq @package.pasForm.dcpHousingunittypeCity "717170000") true}}
-              onClick={{fn this.updateAttr @package.pasForm "dcpHousingunittypeCity" "717170000"}}
-              data-test-dcphousingunittype-city
-            /><label for="dcphousingunittype-city">City</label>
+              checked={{if (eq @package.pasForm.dcpProposedprojectorportionconstruction "717170000") true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpProposedprojectorportionconstruction" "717170000"}}
+              data-test-dcpproposedprojectorportionconstruction-yes
+            /><label for="dcpproposedprojectorportionconstruction-yes">Yes</label>
             <Input
               @type="radio"
-              @name="dcphousingunittype"
-              id="dcphousingunittype-state"
-              @value='717170001'
-              checked={{if (eq @package.pasForm.dcpHousingunittypeCity "717170001") true}}
-              onClick={{fn this.updateAttr @package.pasForm "dcpHousingunittypeCity" "717170001"}}
-              data-test-dcphousingunittype-state
-            /><label for="dcphousingunittype-state">State</label>
+              @name="dcpproposedprojectorportionconstruction"
+              id="dcpproposedprojectorportionconstruction-no"
+              @value='717170000'
+              checked={{if (eq @package.pasForm.dcpProposedprojectorportionconstruction "717170001") true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpProposedprojectorportionconstruction" "717170001"}}
+              data-test-dcpproposedprojectorportionconstruction-no
+            /><label for="dcpproposedprojectorportionconstruction-no">No</label>
             <Input
               @type="radio"
-              @name="dcphousingunittype"
-              id="dcphousingunittype-federal"
+              @name="dcpproposedprojectorportionconstruction"
+              id="dcpproposedprojectorportionconstruction-unsure"
               @value='717170002'
-              checked={{if (eq @package.pasForm.dcpHousingunittypeCity "717170002") true}}
-              onClick={{fn this.updateAttr @package.pasForm "dcpHousingunittypeCity" "717170002"}}
-              data-test-dcphousingunittype-federal
-            /><label for="dcphousingunittype-federal">Federal</label>
+              checked={{if (eq @package.pasForm.dcpProposedprojectorportionconstruction "717170002") true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpProposedprojectorportionconstruction" "717170002"}}
+              data-test-dcpproposedprojectorportionconstruction-unsure
+            /><label for="dcpproposedprojectorportionconstruction-unsure">Unsure at this time</label>
+          </fieldset>
+
+          <fieldset class="medium-margin-bottom">
+            <legend>
+              <strong>Is the proposed Project Area located in a current or former <a href="https://www1.nyc.gov/site/hpd/services-and-information/urban-renewal.page">Urban Renewal Area</a>?</strong>
+            </legend>
             <Input
               @type="radio"
-              @name="dcphousingunittype"
-              id="dcphousingunittype-other"
-              @value='717170003'
-              checked={{if (eq @package.pasForm.dcpHousingunittypeCity "717170003") true}}
-              onClick={{fn this.updateAttr @package.pasForm "dcpHousingunittypeCity" "717170003"}}
-              data-test-dcphousingunittype-other
-            /><label for="dcphousingunittype-other">Other</label>
+              @name="dcpurbanrenewalarea"
+              id="dcpurbanrenewalarea-yes"
+              @value='717170000'
+              checked={{if (eq @package.pasForm.dcpUrbanrenewalarea "717170000") true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpUrbanrenewalarea" "717170000"}}
+              data-test-dcpurbanrenewalarea-yes
+            /><label for="dcpurbanrenewalarea-yes">Yes</label>
+            <Input
+              @type="radio"
+              @name="dcpurbanrenewalarea"
+              id="dcpurbanrenewalarea-no"
+              @value='717170001'
+              checked={{if (eq @package.pasForm.dcpUrbanrenewalarea "717170001") true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpUrbanrenewalarea" "717170001"}}
+              data-test-dcpurbanrenewalarea-no
+            /><label for="dcpurbanrenewalarea-no">No</label>
+            <Input
+              @type="radio"
+              @name="dcpurbanrenewalarea"
+              id="dcpurbanrenewalarea-unsure"
+              @value='717170002'
+              checked={{if (eq @package.pasForm.dcpUrbanrenewalarea "717170002") true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpUrbanrenewalarea" "717170002"}}
+              data-test-dcpurbanrenewalarea-unsure
+            /><label for="dcpurbanrenewalarea-unsure">Unsure at this time</label>
+            {{#if (eq @package.pasForm.dcpUrbanrenewalarea "717170000")}}
+              <label>
+                What is the name of the Urban Renewal Area?
+                <Input
+                  @type="text"
+                  @value={{mut pasFormChangeset.dcpUrbanareaname}}
+                  maxlength="250"
+                  data-test-dcpurbanrenewalarea
+                />
+                <ValidationMessage
+                  @changeset={{pasFormChangeset}}
+                  @field="dcpUrbanareaname"
+                />
+              </label>
+            {{/if}}
           </fieldset>
-        {{/if}}
-      </fieldset>
-    </section>
 
-    <section class="form-section">
-      <h3 class="section-header">
-        <span id="project-description" class="section-anchor"></span>
-        Project Description
-      </h3>
+          <fieldset class="medium-margin-bottom">
+            <legend>
+              <strong>What is the <a href="https://streets.planning.nyc.gov/about">Legal Street Frontage Status in the Project Area</a>?</strong>
+            </legend>
+            <span class="nowrap">
+              <Input
+                @type="radio"
+                @name="dcplegalstreetfrontage"
+                id="dcplegalstreetfrontage-mapped-and-build"
+                @value='717170000'
+                checked={{if (eq @package.pasForm.dcpLegalstreetfrontage "717170000") true}}
+                onClick={{fn this.updateAttr @package.pasForm "dcpLegalstreetfrontage" "717170000"}}
+                data-test-dcplegalstreetfrontage-mapped-and-build
+              /><label for="dcplegalstreetfrontage-mapped-and-build">Mapped and Build</label>
+            </span>
+            <span class="nowrap">
+              <Input
+                @type="radio"
+                @name="dcplegalstreetfrontage"
+                id="dcplegalstreetfrontage-private-road"
+                @value='717170001'
+                checked={{if (eq @package.pasForm.dcpLegalstreetfrontage "717170001") true}}
+                onClick={{fn this.updateAttr @package.pasForm "dcpLegalstreetfrontage" "717170001"}}
+                data-test-dcplegalstreetfrontage-private-road
+              /><label for="dcplegalstreetfrontage-private-road">Private Road</label>
+            </span>
+            <span class="nowrap">
+              <Input
+                @type="radio"
+                @name="dcplegalstreetfrontage"
+                id="dcplegalstreetfrontage-record-street"
+                @value='717170002'
+                checked={{if (eq @package.pasForm.dcpLegalstreetfrontage "717170002") true}}
+                onClick={{fn this.updateAttr @package.pasForm "dcpLegalstreetfrontage" "717170002"}}
+                data-test-dcplegalstreetfrontage-record-street
+              /><label for="dcplegalstreetfrontage-record-street">Record Street</label>
+            </span>
+            <span class="nowrap">
+              <Input
+                @type="radio"
+                @name="dcplegalstreetfrontage"
+                id="dcplegalstreetfrontage-corporation-counsel-opinion"
+                @value='717170003'
+                checked={{if (eq @package.pasForm.dcpLegalstreetfrontage "717170003") true}}
+                onClick={{fn this.updateAttr @package.pasForm "dcpLegalstreetfrontage" "717170003"}}
+                data-test-dcplegalstreetfrontage-corporation-counsel-opinion
+              /><label for="dcplegalstreetfrontage-corporation-counsel-opinion">Corporation Counsel Opinion</label>
+            </span>
+            <span class="nowrap">
+              <Input
+                @type="radio"
+                @name="dcplegalstreetfrontage"
+                id="dcplegalstreetfrontage-mapped-but-not-build"
+                @value='717170004'
+                checked={{if (eq @package.pasForm.dcpLegalstreetfrontage "717170004") true}}
+                onClick={{fn this.updateAttr @package.pasForm "dcpLegalstreetfrontage" "717170004"}}
+                data-test-dcplegalstreetfrontage-mapped-but-not-build
+              /><label for="dcplegalstreetfrontage-mapped-but-not-build">Mapped but not Build</label>
+            </span>
+          </fieldset>
 
-      <label>
-        <strong>Description of the proposed development being facilitated by the land use actions</strong>
-        <Textarea
-          @value={{@package.pasForm.dcpProjectdescriptionproposeddevelopment}}
-          rows="5"
-          data-test-dcpprojectdescriptionproposeddevelopment
-        />
-      </label>
+          <fieldset class="medium-margin-bottom">
+            <legend>
+              <strong>Do all land use actions meet&nbsp;
+                <a
+                  href="https://govt.westlaw.com/nycrr/Document/I4ec3a767cd1711dda432a117e6e0f345?viewType=FullText&originationContext=documenttoc&transitionType=CategoryPageItem&contextData=(sc.Default)">
+                  SEQRA or CEQR criteria&nbsp;
+                </a>
+                for Type II status?
+              </strong>
+            </legend>
+            <Input
+              @type="radio"
+              @name="dcplanduseactiontype2"
+              id="dcplanduseactiontype2-yes"
+              @value='717170000'
+              checked={{if (eq @package.pasForm.dcpLanduseactiontype2 "717170000") true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpLanduseactiontype2" "717170000"}}
+              data-test-dcplanduseactiontype2-yes
+            /><label for="dcplanduseactiontype2-yes">Yes</label>
+            <Input
+              @type="radio"
+              @name="dcplanduseactiontype2"
+              id="dcplanduseactiontype2-no"
+              @value='717170001'
+              checked={{if (eq @package.pasForm.dcpLanduseactiontype2 "717170001") true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpLanduseactiontype2" "717170001"}}
+              data-test-dcplanduseactiontype2-no
+            /><label for="dcplanduseactiontype2-no">No</label>
+            <Input
+              @type="radio"
+              @name="dcplanduseactiontype2"
+              id="dcplanduseactiontype2-unsure"
+              @value='717170002'
+              checked={{if (eq @package.pasForm.dcpLanduseactiontype2 "717170002") true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpLanduseactiontype2" "717170002"}}
+              data-test-dcplanduseactiontype2-unsure
+            /><label for="dcplanduseactiontype2-unsure">Unsure at this time</label>
+            {{#if (eq @package.pasForm.dcpLanduseactiontype2 "717170000")}}
+              <label>
+                Indicate which SEQRA or CEQR category each action fulfills
+                <Input
+                  @type="text"
+                  @value={{mut pasFormChangeset.dcpPleaseexplaintypeiienvreview}}
+                  maxlength="200"
+                  data-test-dcppleaseexplaintypeiienvreview
+                />
+                <ValidationMessage
+                  @changeset={{pasFormChangeset}}
+                  @field="dcpPleaseexplaintypeiienvreview"
+                />
+              </label>
+            {{/if}}
+          </fieldset>
 
-      <label>
-        <strong>Why is this application being proposed? What is the legal, environmental, or land use background?</strong>
-        <Textarea
-          @value={{@package.pasForm.dcpProjectdescriptionbackground}}
-          rows="5"
-          data-test-dcpprojectdescriptionbackground
-        />
-      </label>
+          <fieldset class="medium-margin-bottom">
+            <legend>
+              <strong>Is the proposed Project Area in an <a href="https://zola.planning.nyc.gov/">Industrial Business Zone</a>?</strong>
+            </legend>
+            <Input
+              @type="radio"
+              @name="dcpprojectareaindustrialbusinesszone"
+              id="dcpprojectareaindustrialbusinesszone-yes"
+              @value={{true}}
+              checked={{if (eq @package.pasForm.dcpProjectareaindustrialbusinesszone true) true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpProjectareaindustrialbusinesszone" true}}
+              data-test-dcpprojectareaindustrialbusinesszone-yes
+            /><label for="dcpprojectareaindustrialbusinesszone-yes">Yes</label>
+            <Input
+              @type="radio"
+              @name="dcpprojectareaindustrialbusinesszone"
+              id="dcpprojectareaindustrialbusinesszone-no"
+              @value={{false}}
+              checked={{if (eq @package.pasForm.dcpProjectareaindustrialbusinesszone false) true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpProjectareaindustrialbusinesszone" false}}
+              data-test-dcpprojectareaindustrialbusinesszone-no
+            /><label for="dcpprojectareaindustrialbusinesszone-no">No</label>
+            {{#if (eq @package.pasForm.dcpProjectareaindustrialbusinesszone true)}}
+              <label>
+                Name of Industrial Business Zone
+                <Input
+                  @type="text"
+                  @value={{mut pasFormChangeset.dcpProjectareaindutrialzonename}}
+                  maxlength="200"
+                  data-test-dcpprojectareaindustrialbusinesszone
+                />
+                <ValidationMessage
+                  @changeset={{pasFormChangeset}}
+                  @field="dcpProjectareaindutrialzonename"
+                />
+              </label>
+            {{/if}}
+          </fieldset>
 
-      <label>
-        <strong>What is the land use rationale for all the proposed actions?</strong>
-        <Textarea
-          @value={{@package.pasForm.dcpProjectdescriptionproposedactions}}
-          rows="5"
-          data-test-dcpprojectdescriptionproposedactions
-        />
-      </label>
+          <fieldset class="medium-margin-bottom">
+            <legend>
+              <strong>Is the proposed Project Area within or adjacent to a designated (City or State) <a href="https://zola.planning.nyc.gov/">Landmark or Historic District</a>?</strong>
+            </legend>
+            <Input
+              @type="radio"
+              @name="dcpisprojectarealandmark"
+              id="dcpisprojectarealandmark-yes"
+              @value={{true}}
+              checked={{if (eq @package.pasForm.dcpIsprojectarealandmark true) true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpIsprojectarealandmark" true}}
+              data-test-dcpisprojectarealandmark-yes
+            /><label for="dcpisprojectarealandmark-yes">Yes</label>
+            <Input
+              @type="radio"
+              @name="dcpisprojectarealandmark"
+              id="dcpisprojectarealandmark-no"
+              @value={{false}}
+              checked={{if (eq @package.pasForm.dcpIsprojectarealandmark false) true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpIsprojectarealandmark" false}}
+              data-test-dcpisprojectarealandmark-no
+            /><label for="dcpisprojectarealandmark-no">No</label>
+            {{#if (eq @package.pasForm.dcpIsprojectarealandmark true)}}
+              <label>
+                Name of Landmark or Historic District
+                <Input
+                  @type="text"
+                  @value={{mut pasFormChangeset.dcpProjectarealandmarkname}}
+                  maxlength="250"
+                  data-test-dcpisprojectarealandmark
+                />
+                <ValidationMessage
+                  @changeset={{pasFormChangeset}}
+                  @field="dcpProjectarealandmarkname"
+                />
+              </label>
+            {{/if}}
+          </fieldset>
 
-      <label>
-        <strong>Description of existing land uses and structures in the proposed Project Area and Development Site</strong>
-        <Textarea
-          @value={{@package.pasForm.dcpProjectdescriptionproposedarea}}
-          rows="5"
-          data-test-dcpprojectdescriptionproposedarea
-        />
-      </label>
+          <fieldset class="medium-margin-bottom">
+            <legend>
+              <strong>Is the proposed Project Area located within the <a href="https://dcp.maps.arcgis.com/apps/View/index.html?appid=90e3a9f927c2471483631a20e8a41d8d">NYC Coastal Zone</a>?</strong>
+            </legend>
+            <Input
+              @type="radio"
+              @name="dcpprojectareacoastalzonelocatedin"
+              id="dcpprojectareacoastalzonelocatedin-yes"
+              @value={{true}}
+              checked={{if (eq @package.pasForm.dcpProjectareacoastalzonelocatedin true) true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpProjectareacoastalzonelocatedin" true}}
+              data-test-dcpprojectareacoastalzonelocatedin-yes
+            /><label for="dcpprojectareacoastalzonelocatedin-yes">Yes</label>
+            <Input
+              @type="radio"
+              @name="dcpprojectareacoastalzonelocatedin"
+              id="dcpprojectareacoastalzonelocatedin-no"
+              @value={{false}}
+              checked={{if (eq @package.pasForm.dcpProjectareacoastalzonelocatedin false) true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpProjectareacoastalzonelocatedin" false}}
+              data-test-dcpprojectareacoastalzonelocatedin-no
+            /><label for="dcpprojectareacoastalzonelocatedin-no">No</label>
+          </fieldset>
 
-      <label>
-        <strong>Description of land uses and built context in surrounding area (within 1000 ft)</strong>
-        <Textarea
-          @value={{@package.pasForm.dcpProjectdescriptionsurroundingarea}}
-          rows="5"
-          data-test-dcpprojectdescriptionsurroundingarea
-        />
-      </label>
+          <fieldset class="medium-margin-bottom">
+            <legend>
+              <strong>Is the Project Area located within the <a href="https://dcp.maps.arcgis.com/apps/webappviewer/index.html?id=1c37d271fba14163bbb520517153d6d5">1% annual chance floodplain</a>?</strong>
+            </legend>
+            <Input
+              @type="radio"
+              @name="dcpprojectareaischancefloodplain"
+              id="dcpprojectareaischancefloodplain-yes"
+              @value='717170000'
+              checked={{if (eq @package.pasForm.dcpProjectareaischancefloodplain "717170000") true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpProjectareaischancefloodplain" "717170000"}}
+              data-test-dcpprojectareaischancefloodplain-yes
+            /><label for="dcpprojectareaischancefloodplain-yes">Yes</label>
+            <Input
+              @type="radio"
+              @name="dcpprojectareaischancefloodplain"
+              id="dcpprojectareaischancefloodplain-no"
+              @value='717170001'
+              checked={{if (eq @package.pasForm.dcpProjectareaischancefloodplain "717170001") true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpProjectareaischancefloodplain" "717170001"}}
+              data-test-dcpprojectareaischancefloodplain-no
+            /><label for="dcpprojectareaischancefloodplain-no">No</label>
+            <Input
+              @type="radio"
+              @name="dcpprojectareaischancefloodplain"
+              id="dcpprojectareaischancefloodplain-unsure"
+              @value='717170002'
+              checked={{if (eq @package.pasForm.dcpProjectareaischancefloodplain "717170002") true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpProjectareaischancefloodplain" "717170002"}}
+              data-test-dcpprojectareaischancefloodplain-unsure
+            /><label for="dcpprojectareaischancefloodplain-unsure">Unsure at this time</label>
+          </fieldset>
 
-      <label>
-        <strong>Description of proposed CEQR scope</strong>
-        <Textarea
-          @value={{@package.pasForm.dcpProjectattachmentsotherinformation}}
-          rows="5"
-          data-test-dcpprojectattachmentsotherinformation
-        />
-      </label>
-      <p class="help-text">
-        Include to expedite CEQR guidance: If proposed actions are not approved, what is the applicant’s as-of-right development (CEQR “no-action”) proposal? What would be expected to occur on non-applicant-controlled sites because of the Proposed Actions (CEQR “with-action”)?
-      </p>
-    </section>
+          <fieldset class="medium-margin-bottom">
+            <legend>
+              <strong>Is a <a href="https://a836-acris.nyc.gov/CP/">legal instrument</a> associated with a previous CPC or CPC Chair action recorded against the project site?</strong>
+            </legend>
+            <Input
+              @type="radio"
+              @name="dcprestrictivedeclaration"
+              id="dcprestrictivedeclaration-yes"
+              @value={{true}}
+              checked={{if (eq @package.pasForm.dcpRestrictivedeclaration true) true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpRestrictivedeclaration" true}}
+              data-test-dcprestrictivedeclaration-yes
+            /><label for="dcprestrictivedeclaration-yes">Yes</label>
+            <Input
+              @type="radio"
+              @name="dcprestrictivedeclaration"
+              id="dcprestrictivedeclaration-no"
+              @value={{false}}
+              checked={{if (eq @package.pasForm.dcpRestrictivedeclaration false) true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpRestrictivedeclaration" false}}
+              data-test-dcprestrictivedeclaration-no
+            /><label for="dcprestrictivedeclaration-no">No</label>
+            {{#if (eq @package.pasForm.dcpRestrictivedeclaration true)}}
+              <label>
+                <strong>City Register File Number</strong>
+                <Input
+                  @type="text"
+                  @value={{mut pasFormChangeset.dcpCityregisterfilenumber}}
+                  maxlength="25"
+                  data-test-dcpcityregisterfilenumber
+                />
+                <ValidationMessage
+                  @changeset={{pasFormChangeset}}
+                  @field="dcpCityregisterfilenumber"
+                />
+              </label>
+            {{/if}}
+          </fieldset>
 
-    <section class="form-section">
-      <h3 class="section-header">
-        <span id="attached-documents" class="section-anchor"></span>
-        Attached Documents
-      </h3>
+          <fieldset class="medium-margin-bottom">
+            <legend>
+              <strong>Will a new legal instrument or modification of a current legal instrument be necessary to approve/implement these actions?</strong>
+            </legend>
+            <Input
+              @type="radio"
+              @name="dcprestrictivedeclarationrequired"
+              id="dcprestrictivedeclarationrequired-yes"
+              @value='717170000'
+              checked={{if (eq @package.pasForm.dcpRestrictivedeclarationrequired "717170000") true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpRestrictivedeclarationrequired" "717170000"}}
+              data-test-dcprestrictivedeclarationrequired-yes
+            /><label for="dcprestrictivedeclarationrequired-yes">Yes</label>
+            <Input
+              @type="radio"
+              @name="dcprestrictivedeclarationrequired"
+              id="dcprestrictivedeclarationrequired-no"
+              @value='717170001'
+              checked={{if (eq @package.pasForm.dcpRestrictivedeclarationrequired "717170001") true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpRestrictivedeclarationrequired" "717170001"}}
+              data-test-dcprestrictivedeclarationrequired-no
+            /><label for="dcprestrictivedeclarationrequired-no">No</label>
+            <Input
+              @type="radio"
+              @name="dcprestrictivedeclarationrequired"
+              id="dcprestrictivedeclarationrequired-unsure"
+              @value='717170002'
+              checked={{if (eq @package.pasForm.dcpRestrictivedeclarationrequired "717170002") true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpRestrictivedeclarationrequired" "717170002"}}
+              data-test-dcprestrictivedeclarationrequired-unsure
+            /><label for="dcprestrictivedeclarationrequired-unsure">Unsure at this time</label>
+          </fieldset>
+        </section>
 
-      <p>
-        Please attach the following required documents. (Additional materials that help to explain the proposed project may also be submitted.)
-      </p>
+        <section class="form-section">
+          <h3 class="section-header">
+            <span id="proposed-development-site" class="section-anchor"></span>
+            Proposed Development Site
+          </h3>
 
-      <div class="grid-x grid-margin-x">
-        <div class="cell large-6">
-          <h5>Required for all projects:</h5>
-          <ul class="text-small">
-            <li class="small-margin-bottom">
-              <a href="http://gis.nyc.gov/taxmap/map.htm">Tax Map(s)</a> — if project area has more than one tax block submit a separate map for each tax block
-            </li>
-            <li class="small-margin-bottom">
-              <a href="https://www1.nyc.gov/site/planning/zoning/index- map.page">Official Zoning Map</a> — circle the project area
-            </li>
-            <li class="small-margin-bottom">
-              <a href="https://applicantmaps.planning.nyc.gov/">Land Use Map</a>
-            </li>
-            <li class="small-margin-bottom">
-              Site Plan — include building heights, unit counts and square footage calculations (GSF & ZSF) for proposed project (certain exceptions apply, consult the Lead Planner)
-            </li>
-            <li class="small-margin-bottom">
-              Photographs
-            </li>
-            <li class="small-margin-bottom">
-              Signature Form
-            </li>
-          </ul>
-        </div>
-        <div class="cell large-6">
-          <h5>For projects in the NYC Coastal Zone: </h5>
-          <ul class="text-small">
-            <li class="small-margin-bottom">
-              Map of <a href="https://dcp.maps.arcgis.com/apps/View/index.html?app id=90e3a9f927c2471483631a20e8a41d8d">project location within the NYC coastal zone</a> including Special Area Designations
-            </li>
-          </ul>
+          <p>
+            Development Site refers to all property to be developed as part of the applicant’s specific proposal which the land use actions would facilitate. Typically, the Development Site and the Project Area will comprise the same property(ies) unless the application is requesting a zoning map amendment covering an area greater than an applicant’s property to be developed or a large-scale special approval involving multiple tax lots. In these cases, the Development Site may be one or several tax lots within a broader Project Area.
+          </p>
 
-          <h5>
-            For <a href="https://streets.planning.nyc.gov/about">City Map changes</a>:
-          </h5>
-          <ul class="text-small">
-            <li class="small-margin-bottom">Most recent Borough President’s final Section Map or most recent approved and filed Alteration Map for the project area</li>
-            <li class="small-margin-bottom">Site survey — recommended but not required</li>
-          </ul>
-        </div>
-      </div>
+          <label>
+            <strong>In what year do you expect the development to complete?</strong>
+            <Input
+              @type="text"
+              @value={{mut pasFormChangeset.dcpEstimatedcompletiondate}}
+              minlength="4"
+              maxlength="4"
+              data-test-dcpestimatedcompletiondate
+            />
+            <ValidationMessage
+              @changeset={{pasFormChangeset}}
+              @field="dcpEstimatedcompletiondate"
+            />
+            {{!-- QUESTION: Should this be a date picker? --}}
+          </label>
 
-      <Packages::Attachments
-        @package={{@package}}
-        @fileManager={{@package.fileManager}}
-      />
-    </section>
+          <fieldset class="medium-margin-bottom">
+            <legend>
+              <strong>What type of development is proposed? (select all that apply)</strong>
+            </legend>
+            <ul class="no-bullet no-margin">
+              <li>
+                <Input
+                  @type="checkbox"
+                  @checked={{@package.pasForm.dcpProposeddevelopmentsitenewconstruction}}
+                  id="dcpproposeddevelopmentsitenewconstruction"
+                /><label for="dcpproposeddevelopmentsitenewconstruction">Newly constructed buildings</label>
+              </li>
+              <li>
+                <Input
+                  @type="checkbox"
+                  @checked={{@package.pasForm.dcpProposeddevelopmentsitedemolition}}
+                  id="dcpproposeddevelopmentsitedemolition"
+                /><label for="dcpproposeddevelopmentsitedemolition">Demolition</label>
+              </li>
+              <li>
+                <Input
+                  @type="checkbox"
+                  @checked={{@package.pasForm.dcpProposeddevelopmentsiteinfoalteration}}
+                  id="dcpproposeddevelopmentsiteinfoalteration"
+                /><label for="dcpproposeddevelopmentsiteinfoalteration">Alteration</label>
+              </li>
+              <li>
+                <Input
+                  @type="checkbox"
+                  @checked={{@package.pasForm.dcpProposeddevelopmentsiteinfoaddition}}
+                  id="dcpproposeddevelopmentsiteinfoaddition"
+                /><label for="dcpproposeddevelopmentsiteinfoaddition">Addition</label>
+              </li>
+              <li>
+                <Input
+                  @type="checkbox"
+                  @checked={{@package.pasForm.dcpProposeddevelopmentsitechnageofuse}}
+                  id="dcpproposeddevelopmentsitechnageofuse"
+                /><label for="dcpproposeddevelopmentsitechnageofuse">Change of use</label>
+              </li>
+              <li>
+                <Input
+                  @type="checkbox"
+                  @checked={{@package.pasForm.dcpProposeddevelopmentsiteenlargement}}
+                  id="dcpproposeddevelopmentsiteenlargement"
+                /><label for="dcpproposeddevelopmentsiteenlargement">Enlargement</label>
+              </li>
+              <li>
+                <Input
+                  @type="checkbox"
+                  @checked={{@package.pasForm.dcpProposeddevelopmentsiteinfoother}}
+                  id="dcpproposeddevelopmentsiteinfoother"
+                  data-test-dcpproposeddevelopmentsiteinfoother
+                /><label for="dcpproposeddevelopmentsiteinfoother">Other&hellip;</label>
+              </li>
+            </ul>
+            {{#if @package.pasForm.dcpProposeddevelopmentsiteinfoother}}
+              <label>
+                Explain:
+                <Input
+                  @type="text"
+                  @value={{@package.pasForm.dcpProposeddevelopmentsiteotherexplanation}}
+                  data-test-dcpproposeddevelopmentsiteotherexplanation
+                />
+              </label>
+            {{/if}}
+          </fieldset>
 
-  </div>
-  <div class="cell large-4">
+          <fieldset class="medium-margin-bottom">
+            <legend>
+              <strong>Is the Development Site in an <a href="https://zola.planning.nyc.gov/">Inclusionary Housing Designated Area/Mandatory Inclusionary Housing Area</a>?</strong>
+            </legend>
+            <Input
+              @type="radio"
+              @name="dcpisinclusionaryhousingdesignatedarea"
+              id="dcpisinclusionaryhousingdesignatedarea-yes"
+              @value={{true}}
+              checked={{if (eq @package.pasForm.dcpIsinclusionaryhousingdesignatedarea true) true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpIsinclusionaryhousingdesignatedarea" true}}
+              data-test-dcpisinclusionaryhousingdesignatedarea-yes
+            /><label for="dcpisinclusionaryhousingdesignatedarea-yes">Yes</label>
+            <Input
+              @type="radio"
+              @name="dcpisinclusionaryhousingdesignatedarea"
+              id="dcpisinclusionaryhousingdesignatedarea-no"
+              @value={{false}}
+              checked={{if (eq @package.pasForm.dcpIsinclusionaryhousingdesignatedarea false) true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpIsinclusionaryhousingdesignatedarea" false}}
+              data-test-dcpisinclusionaryhousingdesignatedarea-no
+            /><label for="dcpisinclusionaryhousingdesignatedarea-no">No</label>
+            <p class="help-text">
+              Refer to <a  href="https://zr.planning.nyc.gov/appendix-f-inclusionary-housing-designated-areas-and-mandatory-inclusionary-housing-areas">Appendix F</a> of the Zoning Resolution for full list of all inclusionary housing areas which are areas that incentivize or require affordable housing in certain areas.
+            </p>
+            {{#if (eq @package.pasForm.dcpIsinclusionaryhousingdesignatedarea true)}}
+              <label>
+                Name of Inclusionary Housing Designated Area/Mandatory Inclusionary Housing Area
+                <Input
+                  @type="text"
+                  @value={{@package.pasForm.dcpInclusionaryhousingdesignatedareaname}}
+                  data-test-dcpinclusionaryhousingdesignatedareaname
+                />
+              </label>
+            {{/if}}
+          </fieldset>
 
-    <div class="sticky-sidebar">
-      <p>
-        <button
-          type="button"
-          class="button expanded large"
-          onClick={{fn this.save @package}}
-          disabled={{not this.isDirty}}
-          data-test-save-button
-        >
-          {{!-- TODO: Make this button work with the action passed in @save--}}
-          Save
-        </button>
-        <button
-          type="button"
-          class="button expanded large secondary"
-          {{on "click" this.toggleModal}}
-          data-test-submit-button
-        >
-          {{!-- TODO: Disable this button if model dirty/invaild --}}
-          Submit
-        </button>
-      </p>
-      {{#if this.modalIsOpen}}
-        <EmberWormhole @to="reveal-modal-container">
-          <RevealModal @toggle={{this.toggleModal}}>
-            <h6>Confirm Pre-Applicant Statement submission</h6>
-            <p class="header-large medium-margin-top small-margin-bottom">Are you sure?</p>
-            <p>Before submitting, ensure that your answers are accurate and complete, and that necessary attachments (including the signature form) have been uploaded. If City Planning does not receive enough accurate information to provide guidance, the lead planner will notify you and request that this form be resubmitted with needed materials, corrections, or clarifications.</p>
-            <hr>
-            <div class="grid-x grid-margin-x">
-              <div class="cell large-6">
-                <button
-                  type="button"
-                  class="button large secondary no-margin"
-                  {{on "click" this.toggleModal}}
-                >
-                  Continue Editing
-                </button>
-              </div>
-              <div class="cell large-6 text-right">
-                <button
-                  type="button"
-                  class="button large no-margin"
-                  {{on "click" (fn this.submit @package)}}
-                  data-test-confirm-submit-button
-                >
-                  Submit
-                </button>
-              </div>
+          <fieldset class="medium-margin-bottom">
+            <legend>
+              <strong>Does the proposed development involve discretionary funding for Affordable Housing Units?</strong>
+            </legend>
+            <Input
+              @type="radio"
+              @name="dcpdiscressionaryfundingforffordablehousing"
+              id="dcpdiscressionaryfundingforffordablehousing-yes"
+              @value='717170000'
+              checked={{if (eq @package.pasForm.dcpDiscressionaryfundingforffordablehousing "717170000") true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpDiscressionaryfundingforffordablehousing" "717170000"}}
+              data-test-dcpdiscressionaryfundingforffordablehousing-yes
+            /><label for="dcpdiscressionaryfundingforffordablehousing-yes">Yes</label>
+            <Input
+              @type="radio"
+              @name="dcpdiscressionaryfundingforffordablehousing"
+              id="dcpdiscressionaryfundingforffordablehousing-no"
+              @value='717170001'
+              checked={{if (eq @package.pasForm.dcpDiscressionaryfundingforffordablehousing "717170001") true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpDiscressionaryfundingforffordablehousing" "717170001"}}
+              data-test-dcpdiscressionaryfundingforffordablehousing-no
+            /><label for="dcpdiscressionaryfundingforffordablehousing-no">No</label>
+            <Input
+              @type="radio"
+              @name="dcpdiscressionaryfundingforffordablehousing"
+              id="dcpdiscressionaryfundingforffordablehousing-unsure"
+              @value='717170002'
+              checked={{if (eq @package.pasForm.dcpDiscressionaryfundingforffordablehousing "717170002") true}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpDiscressionaryfundingforffordablehousing" "717170002"}}
+              data-test-dcpdiscressionaryfundingforffordablehousing-unsure
+            /><label for="dcpdiscressionaryfundingforffordablehousing-unsure">Unsure at this time</label>
+            {{#if (eq @package.pasForm.dcpDiscressionaryfundingforffordablehousing "717170000")}}
+              <fieldset class="medium-margin-bottom">
+                <legend>
+                  Funding source
+                </legend>
+                <Input
+                  @type="radio"
+                  @name="dcphousingunittype"
+                  id="dcphousingunittype-city"
+                  @value='717170000'
+                  checked={{if (eq @package.pasForm.dcpHousingunittypeCity "717170000") true}}
+                  onClick={{fn this.updateAttr @package.pasForm "dcpHousingunittypeCity" "717170000"}}
+                  data-test-dcphousingunittype-city
+                /><label for="dcphousingunittype-city">City</label>
+                <Input
+                  @type="radio"
+                  @name="dcphousingunittype"
+                  id="dcphousingunittype-state"
+                  @value='717170001'
+                  checked={{if (eq @package.pasForm.dcpHousingunittypeCity "717170001") true}}
+                  onClick={{fn this.updateAttr @package.pasForm "dcpHousingunittypeCity" "717170001"}}
+                  data-test-dcphousingunittype-state
+                /><label for="dcphousingunittype-state">State</label>
+                <Input
+                  @type="radio"
+                  @name="dcphousingunittype"
+                  id="dcphousingunittype-federal"
+                  @value='717170002'
+                  checked={{if (eq @package.pasForm.dcpHousingunittypeCity "717170002") true}}
+                  onClick={{fn this.updateAttr @package.pasForm "dcpHousingunittypeCity" "717170002"}}
+                  data-test-dcphousingunittype-federal
+                /><label for="dcphousingunittype-federal">Federal</label>
+                <Input
+                  @type="radio"
+                  @name="dcphousingunittype"
+                  id="dcphousingunittype-other"
+                  @value='717170003'
+                  checked={{if (eq @package.pasForm.dcpHousingunittypeCity "717170003") true}}
+                  onClick={{fn this.updateAttr @package.pasForm "dcpHousingunittypeCity" "717170003"}}
+                  data-test-dcphousingunittype-other
+                /><label for="dcphousingunittype-other">Other</label>
+              </fieldset>
+            {{/if}}
+          </fieldset>
+        </section>
+
+        <section class="form-section">
+          <h3 class="section-header">
+            <span id="project-description" class="section-anchor"></span>
+            Project Description
+          </h3>
+
+          <label>
+            <strong>Description of the proposed development being facilitated by the land use actions</strong>
+            <Textarea
+              @value={{mut pasFormChangeset.dcpProjectdescriptionproposeddevelopment}}
+              rows="5"
+              maxlength="3000"
+              data-test-dcpprojectdescriptionproposeddevelopment
+            />
+            <ValidationMessage
+              @changeset={{pasFormChangeset}}
+              @field="dcpProjectdescriptionproposeddevelopment"
+            />
+          </label>
+
+          <label>
+            <strong>Why is this application being proposed? What is the legal, environmental, or land use background?</strong>
+            <Textarea
+              @value={{mut pasFormChangeset.dcpProjectdescriptionbackground}}
+              rows="5"
+              maxlength="2000"
+              data-test-dcpprojectdescriptionbackground
+            />
+            <ValidationMessage
+              @changeset={{pasFormChangeset}}
+              @field="dcpProjectdescriptionbackground"
+            />
+          </label>
+
+          <label>
+            <strong>What is the land use rationale for all the proposed actions?</strong>
+            <Textarea
+              @value={{mut pasFormChangeset.dcpProjectdescriptionproposedactions}}
+              rows="5"
+              maxlength="2000"
+              data-test-dcpprojectdescriptionproposedactions
+            />
+            <ValidationMessage
+              @changeset={{pasFormChangeset}}
+              @field="dcpProjectdescriptionproposedactions"
+            />
+          </label>
+
+          <label>
+            <strong>Description of existing land uses and structures in the proposed Project Area and Development Site</strong>
+            <Textarea
+              @value={{mut pasFormChangeset.dcpProjectdescriptionproposedarea}}
+              rows="5"
+              maxlength="3000"
+              data-test-dcpprojectdescriptionproposedarea
+            />
+            <ValidationMessage
+              @changeset={{pasFormChangeset}}
+              @field="dcpProjectdescriptionproposedarea"
+            />
+          </label>
+
+          <label>
+            <strong>Description of land uses and built context in surrounding area (within 1000 ft)</strong>
+            <Textarea
+              @value={{mut pasFormChangeset.dcpProjectdescriptionsurroundingarea}}
+              rows="5"
+              maxlength="3000"
+              data-test-dcpprojectdescriptionsurroundingarea
+            />
+            <ValidationMessage
+              @changeset={{pasFormChangeset}}
+              @field="dcpProjectdescriptionsurroundingarea"
+            />
+          </label>
+
+          <label>
+            <strong>Description of proposed CEQR scope</strong>
+            <Textarea
+              @value={{mut pasFormChangeset.dcpProjectattachmentsotherinformation}}
+              rows="5"
+              maxlength="3000"
+              data-test-dcpprojectattachmentsotherinformation
+            />
+            <ValidationMessage
+              @changeset={{pasFormChangeset}}
+              @field="dcpProjectattachmentsotherinformation"
+            />
+          </label>
+          <p class="help-text">
+            Include to expedite CEQR guidance: If proposed actions are not approved, what is the applicant’s as-of-right development (CEQR “no-action”) proposal? What would be expected to occur on non-applicant-controlled sites because of the Proposed Actions (CEQR “with-action”)?
+          </p>
+        </section>
+
+        <section class="form-section">
+          <h3 class="section-header">
+            <span id="attached-documents" class="section-anchor"></span>
+            Attached Documents
+          </h3>
+
+          <p>
+            Please attach the following required documents. (Additional materials that help to explain the proposed project may also be submitted.)
+          </p>
+
+          <div class="grid-x grid-margin-x">
+            <div class="cell large-6">
+              <h5>Required for all projects:</h5>
+              <ul class="text-small">
+                <li class="small-margin-bottom">
+                  <a href="http://gis.nyc.gov/taxmap/map.htm">Tax Map(s)</a> — if project area has more than one tax block submit a separate map for each tax block
+                </li>
+                <li class="small-margin-bottom">
+                  <a href="https://www1.nyc.gov/site/planning/zoning/index- map.page">Official Zoning Map</a> — circle the project area
+                </li>
+                <li class="small-margin-bottom">
+                  <a href="https://applicantmaps.planning.nyc.gov/">Land Use Map</a>
+                </li>
+                <li class="small-margin-bottom">
+                  Site Plan — include building heights, unit counts and square footage calculations (GSF & ZSF) for proposed project (certain exceptions apply, consult the Lead Planner)
+                </li>
+                <li class="small-margin-bottom">
+                  Photographs
+                </li>
+                <li class="small-margin-bottom">
+                  Signature Form
+                </li>
+              </ul>
             </div>
-          </RevealModal>
-        </EmberWormhole>
-      {{/if}}
-      <nav>
+            <div class="cell large-6">
+              <h5>For projects in the NYC Coastal Zone: </h5>
+              <ul class="text-small">
+                <li class="small-margin-bottom">
+                  Map of <a href="https://dcp.maps.arcgis.com/apps/View/index.html?app id=90e3a9f927c2471483631a20e8a41d8d">project location within the NYC coastal zone</a> including Special Area Designations
+                </li>
+              </ul>
 
-        <ul class="no-bullet text-weight-bold">
-          <li class="medium-margin-bottom">
-            <a href="#project-info">
-              <FaIcon @icon="chevron-circle-down" @fixedWidth={{true}} class="text-silver" />
-              Project Information
-            </a>
-          </li>
-          <li class="medium-margin-bottom">
-            <a href="#applicant-team">
-              <FaIcon @icon="chevron-circle-down" @fixedWidth={{true}} class="text-silver" />
-              Applicant Team
-            </a>
-          </li>
-          <li class="medium-margin-bottom">
-            <a href="#project-geography">
-              <FaIcon @icon="chevron-circle-down" @fixedWidth={{true}} class="text-silver" />
-              Project Geography
-            </a>
-          </li>
-          <li class="medium-margin-bottom">
-            <a href="#proposed-land-use-actions">
-              <FaIcon @icon="chevron-circle-down" @fixedWidth={{true}} class="text-silver" />
-              Proposed Land Use Actions
-            </a>
-          </li>
-          <li class="medium-margin-bottom">
-            <a href="#project-area">
-              <FaIcon @icon="chevron-circle-down" @fixedWidth={{true}} class="text-silver" />
-              Project Area
-            </a>
-          </li>
-          <li class="medium-margin-bottom">
-            <a href="#proposed-development-site">
-              <FaIcon @icon="chevron-circle-down" @fixedWidth={{true}} class="text-silver" />
-              Proposed Development Site
-            </a>
-          </li>
-          <li class="medium-margin-bottom">
-            <a href="#project-description">
-              <FaIcon @icon="chevron-circle-down" @fixedWidth={{true}} class="text-silver" />
-              Project Description
-            </a>
-          </li>
-          <li class="medium-margin-bottom">
-            <a href="#attached-documents">
-              <FaIcon @icon="chevron-circle-down" @fixedWidth={{true}} class="text-silver" />
-              Attached Documents
-            </a>
-          </li>
-        </ul>
-      </nav>
-    </div>{{!-- end .sticky-sidebar --}}
+              <h5>
+                For <a href="https://streets.planning.nyc.gov/about">City Map changes</a>:
+              </h5>
+              <ul class="text-small">
+                <li class="small-margin-bottom">Most recent Borough President’s final Section Map or most recent approved and filed Alteration Map for the project area</li>
+                <li class="small-margin-bottom">Site survey — recommended but not required</li>
+              </ul>
+            </div>
+          </div>
 
-  </div>
+          <Packages::Attachments
+            @package={{@package}}
+            @fileManager={{@package.fileManager}}
+          />
+        </section>
+
+    </div>
+    <div class="cell large-4">
+
+      <div class="sticky-sidebar">
+        <p>
+          <button
+            type="button"
+            class="button expanded large"
+            onClick={{fn this.save @package pasFormChangeset}}
+            disabled={{not this.isDirty}}
+            data-test-save-button
+          >
+            {{!-- TODO: Make this button work with the action passed in @save--}}
+            Save
+          </button>
+          <button
+            type="button"
+            class="button expanded large secondary"
+            {{on "click" this.toggleModal}}
+            data-test-submit-button
+          >
+            {{!-- TODO: Disable this button if model dirty/invaild --}}
+            Submit
+          </button>
+        </p>
+        {{#if this.modalIsOpen}}
+          <EmberWormhole @to="reveal-modal-container">
+            <RevealModal @toggle={{this.toggleModal}}>
+              <h6>Confirm Pre-Applicant Statement submission</h6>
+              <p class="header-large medium-margin-top small-margin-bottom">Are you sure?</p>
+              <p>Before submitting, ensure that your answers are accurate and complete, and that necessary attachments (including the signature form) have been uploaded. If City Planning does not receive enough accurate information to provide guidance, the lead planner will notify you and request that this form be resubmitted with needed materials, corrections, or clarifications.</p>
+              <hr>
+              <div class="grid-x grid-margin-x">
+                <div class="cell large-6">
+                  <button
+                    type="button"
+                    class="button large secondary no-margin"
+                    {{on "click" this.toggleModal}}
+                  >
+                    Continue Editing
+                  </button>
+                </div>
+                <div class="cell large-6 text-right">
+                  <button
+                    type="button"
+                    class="button large no-margin"
+                    {{on "click" (fn this.submit @package)}}
+                    data-test-confirm-submit-button
+                  >
+                    Submit
+                  </button>
+                </div>
+              </div>
+            </RevealModal>
+          </EmberWormhole>
+        {{/if}}
+        <nav>
+
+          <ul class="no-bullet text-weight-bold">
+            <li class="medium-margin-bottom">
+              <a href="#project-info">
+                <FaIcon @icon="chevron-circle-down" @fixedWidth={{true}} class="text-silver" />
+                Project Information
+              </a>
+            </li>
+            <li class="medium-margin-bottom">
+              <a href="#applicant-team">
+                <FaIcon @icon="chevron-circle-down" @fixedWidth={{true}} class="text-silver" />
+                Applicant Team
+              </a>
+            </li>
+            <li class="medium-margin-bottom">
+              <a href="#project-geography">
+                <FaIcon @icon="chevron-circle-down" @fixedWidth={{true}} class="text-silver" />
+                Project Geography
+              </a>
+            </li>
+            <li class="medium-margin-bottom">
+              <a href="#proposed-land-use-actions">
+                <FaIcon @icon="chevron-circle-down" @fixedWidth={{true}} class="text-silver" />
+                Proposed Land Use Actions
+              </a>
+            </li>
+            <li class="medium-margin-bottom">
+              <a href="#project-area">
+                <FaIcon @icon="chevron-circle-down" @fixedWidth={{true}} class="text-silver" />
+                Project Area
+              </a>
+            </li>
+            <li class="medium-margin-bottom">
+              <a href="#proposed-development-site">
+                <FaIcon @icon="chevron-circle-down" @fixedWidth={{true}} class="text-silver" />
+                Proposed Development Site
+              </a>
+            </li>
+            <li class="medium-margin-bottom">
+              <a href="#project-description">
+                <FaIcon @icon="chevron-circle-down" @fixedWidth={{true}} class="text-silver" />
+                Project Description
+              </a>
+            </li>
+            <li class="medium-margin-bottom">
+              <a href="#attached-documents">
+                <FaIcon @icon="chevron-circle-down" @fixedWidth={{true}} class="text-silver" />
+                Attached Documents
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>{{!-- end .sticky-sidebar --}}
+
+    </div>
+  {{/with}}
 </div>
 
 

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -19,14 +19,13 @@
             <strong>Project Name</strong>
             <Input
               @type="text"
-              @value={{mut this.changeset.dcpRevisedprojectname}}
+              @value={{this.changeset.dcpRevisedprojectname}}
               maxlength="50"
               data-test-dcprevisedprojectname
             />
           </label>
           <ValidationMessage
-            @changeset={{this.changeset}}
-            @field="dcpRevisedprojectname"
+            @changesetError={{this.changeset.error.dcpRevisedprojectname}}
           />
         </section>
 
@@ -56,13 +55,12 @@
           <label>
             <strong>Description of geography</strong>
             <Textarea
-              @value={{mut this.changeset.dcpDescriptionofprojectareageography}}
+              @value={{this.changeset.dcpDescriptionofprojectareageography}}
               maxlength="2000"
               rows="5"
             />
             <ValidationMessage
-              @changeset={{this.changeset}}
-              @field="dcpDescriptionofprojectareageography"
+              @changeset={{this.changeset.error.dcpDescriptionofprojectareageography}}
             />
           </label>
         </section>
@@ -165,13 +163,12 @@
                 What is the name of the Urban Renewal Area?
                 <Input
                   @type="text"
-                  @value={{mut this.changeset.dcpUrbanareaname}}
+                  @value={{this.changeset.dcpUrbanareaname}}
                   maxlength="250"
                   data-test-dcpurbanrenewalarea
                 />
                 <ValidationMessage
-                  @changeset={{this.changeset}}
-                  @field="dcpUrbanareaname"
+                  @changeset={{this.changeset.error.dcpUrbanareaname}}
                 />
               </label>
             {{/if}}
@@ -280,13 +277,12 @@
                 Indicate which SEQRA or CEQR category each action fulfills
                 <Input
                   @type="text"
-                  @value={{mut this.changeset.dcpPleaseexplaintypeiienvreview}}
+                  @value={{this.changeset.dcpPleaseexplaintypeiienvreview}}
                   maxlength="200"
                   data-test-dcppleaseexplaintypeiienvreview
                 />
                 <ValidationMessage
-                  @changeset={{this.changeset}}
-                  @field="dcpPleaseexplaintypeiienvreview"
+                  @changeset={{this.changeset.error.dcpPleaseexplaintypeiienvreview}}
                 />
               </label>
             {{/if}}
@@ -319,13 +315,12 @@
                 Name of Industrial Business Zone
                 <Input
                   @type="text"
-                  @value={{mut this.changeset.dcpProjectareaindutrialzonename}}
+                  @value={{this.changeset.dcpProjectareaindutrialzonename}}
                   maxlength="200"
                   data-test-dcpprojectareaindustrialbusinesszone
                 />
                 <ValidationMessage
-                  @changeset={{this.changeset}}
-                  @field="dcpProjectareaindutrialzonename"
+                  @changeset={{this.changeset.error.dcpProjectareaindutrialzonename}}
                 />
               </label>
             {{/if}}
@@ -358,13 +353,12 @@
                 Name of Landmark or Historic District
                 <Input
                   @type="text"
-                  @value={{mut this.changeset.dcpProjectarealandmarkname}}
+                  @value={{this.changeset.dcpProjectarealandmarkname}}
                   maxlength="250"
                   data-test-dcpisprojectarealandmark
                 />
                 <ValidationMessage
-                  @changeset={{this.changeset}}
-                  @field="dcpProjectarealandmarkname"
+                  @changeset={{this.changeset.error.dcpProjectarealandmarkname}}
                 />
               </label>
             {{/if}}
@@ -454,13 +448,12 @@
                 <strong>City Register File Number</strong>
                 <Input
                   @type="text"
-                  @value={{mut this.changeset.dcpCityregisterfilenumber}}
+                  @value={{this.changeset.dcpCityregisterfilenumber}}
                   maxlength="25"
                   data-test-dcpcityregisterfilenumber
                 />
                 <ValidationMessage
-                  @changeset={{this.changeset}}
-                  @field="dcpCityregisterfilenumber"
+                  @changeset={{this.changeset.error.dcpCityregisterfilenumber}}
                 />
               </label>
             {{/if}}
@@ -514,13 +507,12 @@
             <strong>In what year do you expect the development to complete?</strong>
             <Input
               @type="text"
-              @value={{mut this.changeset.dcpEstimatedcompletiondate}}
+              @value={{this.changeset.dcpEstimatedcompletiondate}}
               maxlength="4"
               data-test-dcpestimatedcompletiondate
             />
             <ValidationMessage
-              @changeset={{this.changeset}}
-              @field="dcpEstimatedcompletiondate"
+              @changeset={{this.changeset.error.dcpEstimatedcompletiondate}}
             />
             {{!-- QUESTION: Should this be a date picker? --}}
           </label>
@@ -716,84 +708,78 @@
           <label>
             <strong>Description of the proposed development being facilitated by the land use actions</strong>
             <Textarea
-              @value={{mut this.changeset.dcpProjectdescriptionproposeddevelopment}}
+              @value={{this.changeset.dcpProjectdescriptionproposeddevelopment}}
               rows="5"
               maxlength="3000"
               data-test-dcpprojectdescriptionproposeddevelopment
             />
             <ValidationMessage
-              @changeset={{this.changeset}}
-              @field="dcpProjectdescriptionproposeddevelopment"
+              @changeset={{this.changeset.error.dcpProjectdescriptionproposeddevelopment}}
             />
           </label>
 
           <label>
             <strong>Why is this application being proposed? What is the legal, environmental, or land use background?</strong>
             <Textarea
-              @value={{mut this.changeset.dcpProjectdescriptionbackground}}
+              @value={{this.changeset.dcpProjectdescriptionbackground}}
               rows="5"
               maxlength="2000"
               data-test-dcpprojectdescriptionbackground
             />
             <ValidationMessage
-              @changeset={{this.changeset}}
-              @field="dcpProjectdescriptionbackground"
+              @changeset={{this.changeset.error.dcpProjectdescriptionbackground}}
             />
           </label>
 
           <label>
             <strong>What is the land use rationale for all the proposed actions?</strong>
             <Textarea
-              @value={{mut this.changeset.dcpProjectdescriptionproposedactions}}
+              @value={{this.changeset.dcpProjectdescriptionproposedactions}}
               rows="5"
               maxlength="2000"
               data-test-dcpprojectdescriptionproposedactions
             />
             <ValidationMessage
-              @changeset={{this.changeset}}
-              @field="dcpProjectdescriptionproposedactions"
+              @changeset={{this.changeset.error.dcpProjectdescriptionproposedactions}}
             />
           </label>
 
           <label>
             <strong>Description of existing land uses and structures in the proposed Project Area and Development Site</strong>
             <Textarea
-              @value={{mut this.changeset.dcpProjectdescriptionproposedarea}}
+              @value={{this.changeset.dcpProjectdescriptionproposedarea}}
               rows="5"
               maxlength="3000"
               data-test-dcpprojectdescriptionproposedarea
             />
             <ValidationMessage
-              @changeset={{this.changeset}}
-              @field="dcpProjectdescriptionproposedarea"
+              @changeset={{this.changeset.error.dcpProjectdescriptionproposedarea}}
             />
           </label>
 
           <label>
             <strong>Description of land uses and built context in surrounding area (within 1000 ft)</strong>
             <Textarea
-              @value={{mut this.changeset.dcpProjectdescriptionsurroundingarea}}
+              @value={{this.changeset.dcpProjectdescriptionsurroundingarea}}
               rows="5"
               maxlength="3000"
               data-test-dcpprojectdescriptionsurroundingarea
             />
             <ValidationMessage
-              @changeset={{this.changeset}}
-              @field="dcpProjectdescriptionsurroundingarea"
+              @changeset={{this.changeset.error.dcpProjectdescriptionsurroundingarea}}
             />
           </label>
 
           <label>
             <strong>Description of proposed CEQR scope</strong>
             <Textarea
-              @value={{mut this.changeset.dcpProjectattachmentsotherinformation}}
+              @value={{this.changeset.dcpProjectattachmentsotherinformation}}
               rows="5"
               maxlength="3000"
               data-test-dcpprojectattachmentsotherinformation
             />
             <ValidationMessage
-              @changeset={{this.changeset}}
-              @field="dcpProjectattachmentsotherinformation"
+              @changeset={{this.changeset.error.dcpProjectattachmentsotherinformation}}
             />
           </label>
           <p class="help-text">

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -1,5 +1,5 @@
 <div class="grid-x grid-margin-x">
-  {{#with (changeset @package.pasForm this.pasFormValidations) as |pasFormChangeset|}}
+
     <div class="cell large-8">
 
       <p>
@@ -19,14 +19,13 @@
             <strong>Project Name</strong>
             <Input
               @type="text"
-              @value={{mut pasFormChangeset.dcpRevisedprojectname}}
-              minLength="4"
+              @value={{mut this.changeset.dcpRevisedprojectname}}
               maxlength="50"
               data-test-dcprevisedprojectname
             />
           </label>
           <ValidationMessage
-            @changeset={{pasFormChangeset}}
+            @changeset={{this.changeset}}
             @field="dcpRevisedprojectname"
           />
         </section>
@@ -57,12 +56,12 @@
           <label>
             <strong>Description of geography</strong>
             <Textarea
-              @value={{mut pasFormChangeset.dcpDescriptionofprojectareageography}}
+              @value={{mut this.changeset.dcpDescriptionofprojectareageography}}
               maxlength="2000"
               rows="5"
             />
             <ValidationMessage
-              @changeset={{pasFormChangeset}}
+              @changeset={{this.changeset}}
               @field="dcpDescriptionofprojectareageography"
             />
           </label>
@@ -166,12 +165,12 @@
                 What is the name of the Urban Renewal Area?
                 <Input
                   @type="text"
-                  @value={{mut pasFormChangeset.dcpUrbanareaname}}
+                  @value={{mut this.changeset.dcpUrbanareaname}}
                   maxlength="250"
                   data-test-dcpurbanrenewalarea
                 />
                 <ValidationMessage
-                  @changeset={{pasFormChangeset}}
+                  @changeset={{this.changeset}}
                   @field="dcpUrbanareaname"
                 />
               </label>
@@ -281,12 +280,12 @@
                 Indicate which SEQRA or CEQR category each action fulfills
                 <Input
                   @type="text"
-                  @value={{mut pasFormChangeset.dcpPleaseexplaintypeiienvreview}}
+                  @value={{mut this.changeset.dcpPleaseexplaintypeiienvreview}}
                   maxlength="200"
                   data-test-dcppleaseexplaintypeiienvreview
                 />
                 <ValidationMessage
-                  @changeset={{pasFormChangeset}}
+                  @changeset={{this.changeset}}
                   @field="dcpPleaseexplaintypeiienvreview"
                 />
               </label>
@@ -320,12 +319,12 @@
                 Name of Industrial Business Zone
                 <Input
                   @type="text"
-                  @value={{mut pasFormChangeset.dcpProjectareaindutrialzonename}}
+                  @value={{mut this.changeset.dcpProjectareaindutrialzonename}}
                   maxlength="200"
                   data-test-dcpprojectareaindustrialbusinesszone
                 />
                 <ValidationMessage
-                  @changeset={{pasFormChangeset}}
+                  @changeset={{this.changeset}}
                   @field="dcpProjectareaindutrialzonename"
                 />
               </label>
@@ -359,12 +358,12 @@
                 Name of Landmark or Historic District
                 <Input
                   @type="text"
-                  @value={{mut pasFormChangeset.dcpProjectarealandmarkname}}
+                  @value={{mut this.changeset.dcpProjectarealandmarkname}}
                   maxlength="250"
                   data-test-dcpisprojectarealandmark
                 />
                 <ValidationMessage
-                  @changeset={{pasFormChangeset}}
+                  @changeset={{this.changeset}}
                   @field="dcpProjectarealandmarkname"
                 />
               </label>
@@ -455,12 +454,12 @@
                 <strong>City Register File Number</strong>
                 <Input
                   @type="text"
-                  @value={{mut pasFormChangeset.dcpCityregisterfilenumber}}
+                  @value={{mut this.changeset.dcpCityregisterfilenumber}}
                   maxlength="25"
                   data-test-dcpcityregisterfilenumber
                 />
                 <ValidationMessage
-                  @changeset={{pasFormChangeset}}
+                  @changeset={{this.changeset}}
                   @field="dcpCityregisterfilenumber"
                 />
               </label>
@@ -515,13 +514,12 @@
             <strong>In what year do you expect the development to complete?</strong>
             <Input
               @type="text"
-              @value={{mut pasFormChangeset.dcpEstimatedcompletiondate}}
-              minlength="4"
+              @value={{mut this.changeset.dcpEstimatedcompletiondate}}
               maxlength="4"
               data-test-dcpestimatedcompletiondate
             />
             <ValidationMessage
-              @changeset={{pasFormChangeset}}
+              @changeset={{this.changeset}}
               @field="dcpEstimatedcompletiondate"
             />
             {{!-- QUESTION: Should this be a date picker? --}}
@@ -718,13 +716,13 @@
           <label>
             <strong>Description of the proposed development being facilitated by the land use actions</strong>
             <Textarea
-              @value={{mut pasFormChangeset.dcpProjectdescriptionproposeddevelopment}}
+              @value={{mut this.changeset.dcpProjectdescriptionproposeddevelopment}}
               rows="5"
               maxlength="3000"
               data-test-dcpprojectdescriptionproposeddevelopment
             />
             <ValidationMessage
-              @changeset={{pasFormChangeset}}
+              @changeset={{this.changeset}}
               @field="dcpProjectdescriptionproposeddevelopment"
             />
           </label>
@@ -732,13 +730,13 @@
           <label>
             <strong>Why is this application being proposed? What is the legal, environmental, or land use background?</strong>
             <Textarea
-              @value={{mut pasFormChangeset.dcpProjectdescriptionbackground}}
+              @value={{mut this.changeset.dcpProjectdescriptionbackground}}
               rows="5"
               maxlength="2000"
               data-test-dcpprojectdescriptionbackground
             />
             <ValidationMessage
-              @changeset={{pasFormChangeset}}
+              @changeset={{this.changeset}}
               @field="dcpProjectdescriptionbackground"
             />
           </label>
@@ -746,13 +744,13 @@
           <label>
             <strong>What is the land use rationale for all the proposed actions?</strong>
             <Textarea
-              @value={{mut pasFormChangeset.dcpProjectdescriptionproposedactions}}
+              @value={{mut this.changeset.dcpProjectdescriptionproposedactions}}
               rows="5"
               maxlength="2000"
               data-test-dcpprojectdescriptionproposedactions
             />
             <ValidationMessage
-              @changeset={{pasFormChangeset}}
+              @changeset={{this.changeset}}
               @field="dcpProjectdescriptionproposedactions"
             />
           </label>
@@ -760,13 +758,13 @@
           <label>
             <strong>Description of existing land uses and structures in the proposed Project Area and Development Site</strong>
             <Textarea
-              @value={{mut pasFormChangeset.dcpProjectdescriptionproposedarea}}
+              @value={{mut this.changeset.dcpProjectdescriptionproposedarea}}
               rows="5"
               maxlength="3000"
               data-test-dcpprojectdescriptionproposedarea
             />
             <ValidationMessage
-              @changeset={{pasFormChangeset}}
+              @changeset={{this.changeset}}
               @field="dcpProjectdescriptionproposedarea"
             />
           </label>
@@ -774,13 +772,13 @@
           <label>
             <strong>Description of land uses and built context in surrounding area (within 1000 ft)</strong>
             <Textarea
-              @value={{mut pasFormChangeset.dcpProjectdescriptionsurroundingarea}}
+              @value={{mut this.changeset.dcpProjectdescriptionsurroundingarea}}
               rows="5"
               maxlength="3000"
               data-test-dcpprojectdescriptionsurroundingarea
             />
             <ValidationMessage
-              @changeset={{pasFormChangeset}}
+              @changeset={{this.changeset}}
               @field="dcpProjectdescriptionsurroundingarea"
             />
           </label>
@@ -788,13 +786,13 @@
           <label>
             <strong>Description of proposed CEQR scope</strong>
             <Textarea
-              @value={{mut pasFormChangeset.dcpProjectattachmentsotherinformation}}
+              @value={{mut this.changeset.dcpProjectattachmentsotherinformation}}
               rows="5"
               maxlength="3000"
               data-test-dcpprojectattachmentsotherinformation
             />
             <ValidationMessage
-              @changeset={{pasFormChangeset}}
+              @changeset={{this.changeset}}
               @field="dcpProjectattachmentsotherinformation"
             />
           </label>
@@ -869,7 +867,7 @@
           <button
             type="button"
             class="button expanded large"
-            onClick={{fn this.save @package pasFormChangeset}}
+            onClick={{fn this.save @package this.changeset}}
             disabled={{not this.isDirty}}
             data-test-save-button
           >
@@ -973,7 +971,6 @@
       </div>{{!-- end .sticky-sidebar --}}
 
     </div>
-  {{/with}}
 </div>
 
 

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -100,29 +100,29 @@
             </legend>
             <Input
               @type="radio"
-              @name="dcpproposedprojectorportionconstruction"
+              name="dcpproposedprojectorportionconstruction"
               id="dcpproposedprojectorportionconstruction-yes"
-              @value='717170000'
-              checked={{if (eq @package.pasForm.dcpProposedprojectorportionconstruction "717170000") true}}
-              onClick={{fn this.updateAttr @package.pasForm "dcpProposedprojectorportionconstruction" "717170000"}}
+              @value={{717170000}}
+              checked={{if (eq @package.pasForm.dcpProposedprojectorportionconstruction 717170000) "checked"}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpProposedprojectorportionconstruction" 717170000}}
               data-test-dcpproposedprojectorportionconstruction-yes
             /><label for="dcpproposedprojectorportionconstruction-yes">Yes</label>
             <Input
               @type="radio"
-              @name="dcpproposedprojectorportionconstruction"
+              name="dcpproposedprojectorportionconstruction"
               id="dcpproposedprojectorportionconstruction-no"
-              @value='717170000'
-              checked={{if (eq @package.pasForm.dcpProposedprojectorportionconstruction "717170001") true}}
-              onClick={{fn this.updateAttr @package.pasForm "dcpProposedprojectorportionconstruction" "717170001"}}
+              @value={{717170000}}
+              checked={{if (eq @package.pasForm.dcpProposedprojectorportionconstruction 717170001) "checked"}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpProposedprojectorportionconstruction" 717170001}}
               data-test-dcpproposedprojectorportionconstruction-no
             /><label for="dcpproposedprojectorportionconstruction-no">No</label>
             <Input
               @type="radio"
-              @name="dcpproposedprojectorportionconstruction"
+              name="dcpproposedprojectorportionconstruction"
               id="dcpproposedprojectorportionconstruction-unsure"
-              @value='717170002'
-              checked={{if (eq @package.pasForm.dcpProposedprojectorportionconstruction "717170002") true}}
-              onClick={{fn this.updateAttr @package.pasForm "dcpProposedprojectorportionconstruction" "717170002"}}
+              @value={{717170002}}
+              checked={{if (eq @package.pasForm.dcpProposedprojectorportionconstruction 717170002) "checked"}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpProposedprojectorportionconstruction" 717170002}}
               data-test-dcpproposedprojectorportionconstruction-unsure
             /><label for="dcpproposedprojectorportionconstruction-unsure">Unsure at this time</label>
           </fieldset>
@@ -133,32 +133,32 @@
             </legend>
             <Input
               @type="radio"
-              @name="dcpurbanrenewalarea"
+              name="dcpurbanrenewalarea"
               id="dcpurbanrenewalarea-yes"
-              @value='717170000'
-              checked={{if (eq @package.pasForm.dcpUrbanrenewalarea "717170000") true}}
-              onClick={{fn this.updateAttr @package.pasForm "dcpUrbanrenewalarea" "717170000"}}
+              @value={{717170000}}
+              checked={{if (eq @package.pasForm.dcpUrbanrenewalarea 717170000) "checked"}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpUrbanrenewalarea" 717170000}}
               data-test-dcpurbanrenewalarea-yes
             /><label for="dcpurbanrenewalarea-yes">Yes</label>
             <Input
               @type="radio"
-              @name="dcpurbanrenewalarea"
+              name="dcpurbanrenewalarea"
               id="dcpurbanrenewalarea-no"
-              @value='717170001'
-              checked={{if (eq @package.pasForm.dcpUrbanrenewalarea "717170001") true}}
-              onClick={{fn this.updateAttr @package.pasForm "dcpUrbanrenewalarea" "717170001"}}
+              @value={{717170001}}
+              checked={{if (eq @package.pasForm.dcpUrbanrenewalarea 717170001) "checked"}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpUrbanrenewalarea" 717170001}}
               data-test-dcpurbanrenewalarea-no
             /><label for="dcpurbanrenewalarea-no">No</label>
             <Input
               @type="radio"
-              @name="dcpurbanrenewalarea"
+              name="dcpurbanrenewalarea"
               id="dcpurbanrenewalarea-unsure"
-              @value='717170002'
-              checked={{if (eq @package.pasForm.dcpUrbanrenewalarea "717170002") true}}
-              onClick={{fn this.updateAttr @package.pasForm "dcpUrbanrenewalarea" "717170002"}}
+              @value={{717170002}}
+              checked={{if (eq @package.pasForm.dcpUrbanrenewalarea 717170002) "checked"}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpUrbanrenewalarea" 717170002}}
               data-test-dcpurbanrenewalarea-unsure
             /><label for="dcpurbanrenewalarea-unsure">Unsure at this time</label>
-            {{#if (eq @package.pasForm.dcpUrbanrenewalarea "717170000")}}
+            {{#if (eq @package.pasForm.dcpUrbanrenewalarea 717170000)}}
               <label>
                 What is the name of the Urban Renewal Area?
                 <Input
@@ -181,55 +181,55 @@
             <span class="nowrap">
               <Input
                 @type="radio"
-                @name="dcplegalstreetfrontage"
+                name="dcplegalstreetfrontage"
                 id="dcplegalstreetfrontage-mapped-and-build"
-                @value='717170000'
-                checked={{if (eq @package.pasForm.dcpLegalstreetfrontage "717170000") true}}
-                onClick={{fn this.updateAttr @package.pasForm "dcpLegalstreetfrontage" "717170000"}}
+                @value={{717170000}}
+                checked={{if (eq @package.pasForm.dcpLegalstreetfrontage 717170000) "checked"}}
+                onClick={{fn this.updateAttr @package.pasForm "dcpLegalstreetfrontage" 717170000}}
                 data-test-dcplegalstreetfrontage-mapped-and-build
               /><label for="dcplegalstreetfrontage-mapped-and-build">Mapped and Build</label>
             </span>
             <span class="nowrap">
               <Input
                 @type="radio"
-                @name="dcplegalstreetfrontage"
+                name="dcplegalstreetfrontage"
                 id="dcplegalstreetfrontage-private-road"
-                @value='717170001'
-                checked={{if (eq @package.pasForm.dcpLegalstreetfrontage "717170001") true}}
-                onClick={{fn this.updateAttr @package.pasForm "dcpLegalstreetfrontage" "717170001"}}
+                @value={{717170001}}
+                checked={{if (eq @package.pasForm.dcpLegalstreetfrontage 717170001) "checked"}}
+                onClick={{fn this.updateAttr @package.pasForm "dcpLegalstreetfrontage" 717170001}}
                 data-test-dcplegalstreetfrontage-private-road
               /><label for="dcplegalstreetfrontage-private-road">Private Road</label>
             </span>
             <span class="nowrap">
               <Input
                 @type="radio"
-                @name="dcplegalstreetfrontage"
+                name="dcplegalstreetfrontage"
                 id="dcplegalstreetfrontage-record-street"
-                @value='717170002'
-                checked={{if (eq @package.pasForm.dcpLegalstreetfrontage "717170002") true}}
-                onClick={{fn this.updateAttr @package.pasForm "dcpLegalstreetfrontage" "717170002"}}
+                @value={{717170002}}
+                checked={{if (eq @package.pasForm.dcpLegalstreetfrontage 717170002) "checked"}}
+                onClick={{fn this.updateAttr @package.pasForm "dcpLegalstreetfrontage" 717170002}}
                 data-test-dcplegalstreetfrontage-record-street
               /><label for="dcplegalstreetfrontage-record-street">Record Street</label>
             </span>
             <span class="nowrap">
               <Input
                 @type="radio"
-                @name="dcplegalstreetfrontage"
+                name="dcplegalstreetfrontage"
                 id="dcplegalstreetfrontage-corporation-counsel-opinion"
-                @value='717170003'
-                checked={{if (eq @package.pasForm.dcpLegalstreetfrontage "717170003") true}}
-                onClick={{fn this.updateAttr @package.pasForm "dcpLegalstreetfrontage" "717170003"}}
+                @value={{717170003}}
+                checked={{if (eq @package.pasForm.dcpLegalstreetfrontage 717170003) "checked"}}
+                onClick={{fn this.updateAttr @package.pasForm "dcpLegalstreetfrontage" 717170003}}
                 data-test-dcplegalstreetfrontage-corporation-counsel-opinion
               /><label for="dcplegalstreetfrontage-corporation-counsel-opinion">Corporation Counsel Opinion</label>
             </span>
             <span class="nowrap">
               <Input
                 @type="radio"
-                @name="dcplegalstreetfrontage"
+                name="dcplegalstreetfrontage"
                 id="dcplegalstreetfrontage-mapped-but-not-build"
-                @value='717170004'
-                checked={{if (eq @package.pasForm.dcpLegalstreetfrontage "717170004") true}}
-                onClick={{fn this.updateAttr @package.pasForm "dcpLegalstreetfrontage" "717170004"}}
+                @value={{717170004}}
+                checked={{if (eq @package.pasForm.dcpLegalstreetfrontage 717170004) "checked"}}
+                onClick={{fn this.updateAttr @package.pasForm "dcpLegalstreetfrontage" 717170004}}
                 data-test-dcplegalstreetfrontage-mapped-but-not-build
               /><label for="dcplegalstreetfrontage-mapped-but-not-build">Mapped but not Build</label>
             </span>
@@ -247,32 +247,32 @@
             </legend>
             <Input
               @type="radio"
-              @name="dcplanduseactiontype2"
+              name="dcplanduseactiontype2"
               id="dcplanduseactiontype2-yes"
-              @value='717170000'
-              checked={{if (eq @package.pasForm.dcpLanduseactiontype2 "717170000") true}}
-              onClick={{fn this.updateAttr @package.pasForm "dcpLanduseactiontype2" "717170000"}}
+              @value={{717170000}}
+              checked={{if (eq @package.pasForm.dcpLanduseactiontype2 717170000) "checked"}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpLanduseactiontype2" 717170000}}
               data-test-dcplanduseactiontype2-yes
             /><label for="dcplanduseactiontype2-yes">Yes</label>
             <Input
               @type="radio"
-              @name="dcplanduseactiontype2"
+              name="dcplanduseactiontype2"
               id="dcplanduseactiontype2-no"
-              @value='717170001'
-              checked={{if (eq @package.pasForm.dcpLanduseactiontype2 "717170001") true}}
-              onClick={{fn this.updateAttr @package.pasForm "dcpLanduseactiontype2" "717170001"}}
+              @value={{717170001}}
+              checked={{if (eq @package.pasForm.dcpLanduseactiontype2 717170001) "checked"}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpLanduseactiontype2" 717170001}}
               data-test-dcplanduseactiontype2-no
             /><label for="dcplanduseactiontype2-no">No</label>
             <Input
               @type="radio"
-              @name="dcplanduseactiontype2"
+              name="dcplanduseactiontype2"
               id="dcplanduseactiontype2-unsure"
-              @value='717170002'
-              checked={{if (eq @package.pasForm.dcpLanduseactiontype2 "717170002") true}}
-              onClick={{fn this.updateAttr @package.pasForm "dcpLanduseactiontype2" "717170002"}}
+              @value={{717170002}}
+              checked={{if (eq @package.pasForm.dcpLanduseactiontype2 717170002) "checked"}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpLanduseactiontype2" 717170002}}
               data-test-dcplanduseactiontype2-unsure
             /><label for="dcplanduseactiontype2-unsure">Unsure at this time</label>
-            {{#if (eq @package.pasForm.dcpLanduseactiontype2 "717170000")}}
+            {{#if (eq @package.pasForm.dcpLanduseactiontype2 717170000)}}
               <label>
                 Indicate which SEQRA or CEQR category each action fulfills
                 <Input
@@ -294,19 +294,19 @@
             </legend>
             <Input
               @type="radio"
-              @name="dcpprojectareaindustrialbusinesszone"
+              name="dcpprojectareaindustrialbusinesszone"
               id="dcpprojectareaindustrialbusinesszone-yes"
               @value={{true}}
-              checked={{if (eq @package.pasForm.dcpProjectareaindustrialbusinesszone true) true}}
+              checked={{if (eq @package.pasForm.dcpProjectareaindustrialbusinesszone true) "checked"}}
               onClick={{fn this.updateAttr @package.pasForm "dcpProjectareaindustrialbusinesszone" true}}
               data-test-dcpprojectareaindustrialbusinesszone-yes
             /><label for="dcpprojectareaindustrialbusinesszone-yes">Yes</label>
             <Input
               @type="radio"
-              @name="dcpprojectareaindustrialbusinesszone"
+              name="dcpprojectareaindustrialbusinesszone"
               id="dcpprojectareaindustrialbusinesszone-no"
               @value={{false}}
-              checked={{if (eq @package.pasForm.dcpProjectareaindustrialbusinesszone false) true}}
+              checked={{if (eq @package.pasForm.dcpProjectareaindustrialbusinesszone false) "checked"}}
               onClick={{fn this.updateAttr @package.pasForm "dcpProjectareaindustrialbusinesszone" false}}
               data-test-dcpprojectareaindustrialbusinesszone-no
             /><label for="dcpprojectareaindustrialbusinesszone-no">No</label>
@@ -332,19 +332,19 @@
             </legend>
             <Input
               @type="radio"
-              @name="dcpisprojectarealandmark"
+              name="dcpisprojectarealandmark"
               id="dcpisprojectarealandmark-yes"
               @value={{true}}
-              checked={{if (eq @package.pasForm.dcpIsprojectarealandmark true) true}}
+              checked={{if (eq @package.pasForm.dcpIsprojectarealandmark true) "checked"}}
               onClick={{fn this.updateAttr @package.pasForm "dcpIsprojectarealandmark" true}}
               data-test-dcpisprojectarealandmark-yes
             /><label for="dcpisprojectarealandmark-yes">Yes</label>
             <Input
               @type="radio"
-              @name="dcpisprojectarealandmark"
+              name="dcpisprojectarealandmark"
               id="dcpisprojectarealandmark-no"
               @value={{false}}
-              checked={{if (eq @package.pasForm.dcpIsprojectarealandmark false) true}}
+              checked={{if (eq @package.pasForm.dcpIsprojectarealandmark false) "checked"}}
               onClick={{fn this.updateAttr @package.pasForm "dcpIsprojectarealandmark" false}}
               data-test-dcpisprojectarealandmark-no
             /><label for="dcpisprojectarealandmark-no">No</label>
@@ -370,19 +370,19 @@
             </legend>
             <Input
               @type="radio"
-              @name="dcpprojectareacoastalzonelocatedin"
+              name="dcpprojectareacoastalzonelocatedin"
               id="dcpprojectareacoastalzonelocatedin-yes"
               @value={{true}}
-              checked={{if (eq @package.pasForm.dcpProjectareacoastalzonelocatedin true) true}}
+              checked={{if (eq @package.pasForm.dcpProjectareacoastalzonelocatedin true) "checked"}}
               onClick={{fn this.updateAttr @package.pasForm "dcpProjectareacoastalzonelocatedin" true}}
               data-test-dcpprojectareacoastalzonelocatedin-yes
             /><label for="dcpprojectareacoastalzonelocatedin-yes">Yes</label>
             <Input
               @type="radio"
-              @name="dcpprojectareacoastalzonelocatedin"
+              name="dcpprojectareacoastalzonelocatedin"
               id="dcpprojectareacoastalzonelocatedin-no"
               @value={{false}}
-              checked={{if (eq @package.pasForm.dcpProjectareacoastalzonelocatedin false) true}}
+              checked={{if (eq @package.pasForm.dcpProjectareacoastalzonelocatedin false) "checked"}}
               onClick={{fn this.updateAttr @package.pasForm "dcpProjectareacoastalzonelocatedin" false}}
               data-test-dcpprojectareacoastalzonelocatedin-no
             /><label for="dcpprojectareacoastalzonelocatedin-no">No</label>
@@ -394,29 +394,29 @@
             </legend>
             <Input
               @type="radio"
-              @name="dcpprojectareaischancefloodplain"
+              name="dcpprojectareaischancefloodplain"
               id="dcpprojectareaischancefloodplain-yes"
-              @value='717170000'
-              checked={{if (eq @package.pasForm.dcpProjectareaischancefloodplain "717170000") true}}
-              onClick={{fn this.updateAttr @package.pasForm "dcpProjectareaischancefloodplain" "717170000"}}
+              @value={{717170000}}
+              checked={{if (eq @package.pasForm.dcpProjectareaischancefloodplain 717170000) "checked"}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpProjectareaischancefloodplain" 717170000}}
               data-test-dcpprojectareaischancefloodplain-yes
             /><label for="dcpprojectareaischancefloodplain-yes">Yes</label>
             <Input
               @type="radio"
-              @name="dcpprojectareaischancefloodplain"
+              name="dcpprojectareaischancefloodplain"
               id="dcpprojectareaischancefloodplain-no"
-              @value='717170001'
-              checked={{if (eq @package.pasForm.dcpProjectareaischancefloodplain "717170001") true}}
-              onClick={{fn this.updateAttr @package.pasForm "dcpProjectareaischancefloodplain" "717170001"}}
+              @value={{717170001}}
+              checked={{if (eq @package.pasForm.dcpProjectareaischancefloodplain 717170001) "checked"}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpProjectareaischancefloodplain" 717170001}}
               data-test-dcpprojectareaischancefloodplain-no
             /><label for="dcpprojectareaischancefloodplain-no">No</label>
             <Input
               @type="radio"
-              @name="dcpprojectareaischancefloodplain"
+              name="dcpprojectareaischancefloodplain"
               id="dcpprojectareaischancefloodplain-unsure"
-              @value='717170002'
-              checked={{if (eq @package.pasForm.dcpProjectareaischancefloodplain "717170002") true}}
-              onClick={{fn this.updateAttr @package.pasForm "dcpProjectareaischancefloodplain" "717170002"}}
+              @value={{717170002}}
+              checked={{if (eq @package.pasForm.dcpProjectareaischancefloodplain 717170002) "checked"}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpProjectareaischancefloodplain" 717170002}}
               data-test-dcpprojectareaischancefloodplain-unsure
             /><label for="dcpprojectareaischancefloodplain-unsure">Unsure at this time</label>
           </fieldset>
@@ -427,19 +427,19 @@
             </legend>
             <Input
               @type="radio"
-              @name="dcprestrictivedeclaration"
+              name="dcprestrictivedeclaration"
               id="dcprestrictivedeclaration-yes"
               @value={{true}}
-              checked={{if (eq @package.pasForm.dcpRestrictivedeclaration true) true}}
+              checked={{if (eq @package.pasForm.dcpRestrictivedeclaration true) "checked"}}
               onClick={{fn this.updateAttr @package.pasForm "dcpRestrictivedeclaration" true}}
               data-test-dcprestrictivedeclaration-yes
             /><label for="dcprestrictivedeclaration-yes">Yes</label>
             <Input
               @type="radio"
-              @name="dcprestrictivedeclaration"
+              name="dcprestrictivedeclaration"
               id="dcprestrictivedeclaration-no"
               @value={{false}}
-              checked={{if (eq @package.pasForm.dcpRestrictivedeclaration false) true}}
+              checked={{if (eq @package.pasForm.dcpRestrictivedeclaration false) "checked"}}
               onClick={{fn this.updateAttr @package.pasForm "dcpRestrictivedeclaration" false}}
               data-test-dcprestrictivedeclaration-no
             /><label for="dcprestrictivedeclaration-no">No</label>
@@ -465,29 +465,29 @@
             </legend>
             <Input
               @type="radio"
-              @name="dcprestrictivedeclarationrequired"
+              name="dcprestrictivedeclarationrequired"
               id="dcprestrictivedeclarationrequired-yes"
-              @value='717170000'
-              checked={{if (eq @package.pasForm.dcpRestrictivedeclarationrequired "717170000") true}}
-              onClick={{fn this.updateAttr @package.pasForm "dcpRestrictivedeclarationrequired" "717170000"}}
+              @value={{717170000}}
+              checked={{if (eq @package.pasForm.dcpRestrictivedeclarationrequired 717170000) "checked"}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpRestrictivedeclarationrequired" 717170000}}
               data-test-dcprestrictivedeclarationrequired-yes
             /><label for="dcprestrictivedeclarationrequired-yes">Yes</label>
             <Input
               @type="radio"
-              @name="dcprestrictivedeclarationrequired"
+              name="dcprestrictivedeclarationrequired"
               id="dcprestrictivedeclarationrequired-no"
-              @value='717170001'
-              checked={{if (eq @package.pasForm.dcpRestrictivedeclarationrequired "717170001") true}}
-              onClick={{fn this.updateAttr @package.pasForm "dcpRestrictivedeclarationrequired" "717170001"}}
+              @value={{717170001}}
+              checked={{if (eq @package.pasForm.dcpRestrictivedeclarationrequired 717170001) "checked"}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpRestrictivedeclarationrequired" 717170001}}
               data-test-dcprestrictivedeclarationrequired-no
             /><label for="dcprestrictivedeclarationrequired-no">No</label>
             <Input
               @type="radio"
-              @name="dcprestrictivedeclarationrequired"
+              name="dcprestrictivedeclarationrequired"
               id="dcprestrictivedeclarationrequired-unsure"
-              @value='717170002'
-              checked={{if (eq @package.pasForm.dcpRestrictivedeclarationrequired "717170002") true}}
-              onClick={{fn this.updateAttr @package.pasForm "dcpRestrictivedeclarationrequired" "717170002"}}
+              @value={{717170002}}
+              checked={{if (eq @package.pasForm.dcpRestrictivedeclarationrequired 717170002) "checked"}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpRestrictivedeclarationrequired" 717170002}}
               data-test-dcprestrictivedeclarationrequired-unsure
             /><label for="dcprestrictivedeclarationrequired-unsure">Unsure at this time</label>
           </fieldset>
@@ -591,19 +591,19 @@
             </legend>
             <Input
               @type="radio"
-              @name="dcpisinclusionaryhousingdesignatedarea"
+              name="dcpisinclusionaryhousingdesignatedarea"
               id="dcpisinclusionaryhousingdesignatedarea-yes"
               @value={{true}}
-              checked={{if (eq @package.pasForm.dcpIsinclusionaryhousingdesignatedarea true) true}}
+              checked={{if (eq @package.pasForm.dcpIsinclusionaryhousingdesignatedarea true) "checked"}}
               onClick={{fn this.updateAttr @package.pasForm "dcpIsinclusionaryhousingdesignatedarea" true}}
               data-test-dcpisinclusionaryhousingdesignatedarea-yes
             /><label for="dcpisinclusionaryhousingdesignatedarea-yes">Yes</label>
             <Input
               @type="radio"
-              @name="dcpisinclusionaryhousingdesignatedarea"
+              name="dcpisinclusionaryhousingdesignatedarea"
               id="dcpisinclusionaryhousingdesignatedarea-no"
               @value={{false}}
-              checked={{if (eq @package.pasForm.dcpIsinclusionaryhousingdesignatedarea false) true}}
+              checked={{if (eq @package.pasForm.dcpIsinclusionaryhousingdesignatedarea false) "checked"}}
               onClick={{fn this.updateAttr @package.pasForm "dcpIsinclusionaryhousingdesignatedarea" false}}
               data-test-dcpisinclusionaryhousingdesignatedarea-no
             /><label for="dcpisinclusionaryhousingdesignatedarea-no">No</label>
@@ -628,70 +628,70 @@
             </legend>
             <Input
               @type="radio"
-              @name="dcpdiscressionaryfundingforffordablehousing"
+              name="dcpdiscressionaryfundingforffordablehousing"
               id="dcpdiscressionaryfundingforffordablehousing-yes"
-              @value='717170000'
-              checked={{if (eq @package.pasForm.dcpDiscressionaryfundingforffordablehousing "717170000") true}}
-              onClick={{fn this.updateAttr @package.pasForm "dcpDiscressionaryfundingforffordablehousing" "717170000"}}
+              @value={{717170000}}
+              checked={{if (eq @package.pasForm.dcpDiscressionaryfundingforffordablehousing 717170000) "checked"}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpDiscressionaryfundingforffordablehousing" 717170000}}
               data-test-dcpdiscressionaryfundingforffordablehousing-yes
             /><label for="dcpdiscressionaryfundingforffordablehousing-yes">Yes</label>
             <Input
               @type="radio"
-              @name="dcpdiscressionaryfundingforffordablehousing"
+              name="dcpdiscressionaryfundingforffordablehousing"
               id="dcpdiscressionaryfundingforffordablehousing-no"
-              @value='717170001'
-              checked={{if (eq @package.pasForm.dcpDiscressionaryfundingforffordablehousing "717170001") true}}
-              onClick={{fn this.updateAttr @package.pasForm "dcpDiscressionaryfundingforffordablehousing" "717170001"}}
+              @value={{717170001}}
+              checked={{if (eq @package.pasForm.dcpDiscressionaryfundingforffordablehousing 717170001) "checked"}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpDiscressionaryfundingforffordablehousing" 717170001}}
               data-test-dcpdiscressionaryfundingforffordablehousing-no
             /><label for="dcpdiscressionaryfundingforffordablehousing-no">No</label>
             <Input
               @type="radio"
-              @name="dcpdiscressionaryfundingforffordablehousing"
+              name="dcpdiscressionaryfundingforffordablehousing"
               id="dcpdiscressionaryfundingforffordablehousing-unsure"
-              @value='717170002'
-              checked={{if (eq @package.pasForm.dcpDiscressionaryfundingforffordablehousing "717170002") true}}
-              onClick={{fn this.updateAttr @package.pasForm "dcpDiscressionaryfundingforffordablehousing" "717170002"}}
+              @value={{717170002}}
+              checked={{if (eq @package.pasForm.dcpDiscressionaryfundingforffordablehousing 717170002) "checked"}}
+              onClick={{fn this.updateAttr @package.pasForm "dcpDiscressionaryfundingforffordablehousing" 717170002}}
               data-test-dcpdiscressionaryfundingforffordablehousing-unsure
             /><label for="dcpdiscressionaryfundingforffordablehousing-unsure">Unsure at this time</label>
-            {{#if (eq @package.pasForm.dcpDiscressionaryfundingforffordablehousing "717170000")}}
+            {{#if (eq @package.pasForm.dcpDiscressionaryfundingforffordablehousing 717170000)}}
               <fieldset class="medium-margin-bottom">
                 <legend>
                   Funding source
                 </legend>
                 <Input
                   @type="radio"
-                  @name="dcphousingunittype"
+                  name="dcphousingunittype"
                   id="dcphousingunittype-city"
-                  @value='717170000'
-                  checked={{if (eq @package.pasForm.dcpHousingunittypeCity "717170000") true}}
-                  onClick={{fn this.updateAttr @package.pasForm "dcpHousingunittypeCity" "717170000"}}
+                  @value={{717170000}}
+                  checked={{if (eq @package.pasForm.dcpHousingunittype 717170000) "checked"}}
+                  onClick={{fn this.updateAttr @package.pasForm "dcpHousingunittype" 717170000}}
                   data-test-dcphousingunittype-city
                 /><label for="dcphousingunittype-city">City</label>
                 <Input
                   @type="radio"
-                  @name="dcphousingunittype"
+                  name="dcphousingunittype"
                   id="dcphousingunittype-state"
-                  @value='717170001'
-                  checked={{if (eq @package.pasForm.dcpHousingunittypeCity "717170001") true}}
-                  onClick={{fn this.updateAttr @package.pasForm "dcpHousingunittypeCity" "717170001"}}
+                  @value={{717170001}}
+                  checked={{if (eq @package.pasForm.dcpHousingunittype 717170001) "checked"}}
+                  onClick={{fn this.updateAttr @package.pasForm "dcpHousingunittype" 717170001}}
                   data-test-dcphousingunittype-state
                 /><label for="dcphousingunittype-state">State</label>
                 <Input
                   @type="radio"
-                  @name="dcphousingunittype"
+                  name="dcphousingunittype"
                   id="dcphousingunittype-federal"
-                  @value='717170002'
-                  checked={{if (eq @package.pasForm.dcpHousingunittypeCity "717170002") true}}
-                  onClick={{fn this.updateAttr @package.pasForm "dcpHousingunittypeCity" "717170002"}}
+                  @value={{717170002}}
+                  checked={{if (eq @package.pasForm.dcpHousingunittype 717170002) "checked"}}
+                  onClick={{fn this.updateAttr @package.pasForm "dcpHousingunittype" 717170002}}
                   data-test-dcphousingunittype-federal
                 /><label for="dcphousingunittype-federal">Federal</label>
                 <Input
                   @type="radio"
-                  @name="dcphousingunittype"
+                  name="dcphousingunittype"
                   id="dcphousingunittype-other"
-                  @value='717170003'
-                  checked={{if (eq @package.pasForm.dcpHousingunittypeCity "717170003") true}}
-                  onClick={{fn this.updateAttr @package.pasForm "dcpHousingunittypeCity" "717170003"}}
+                  @value={{717170003}}
+                  checked={{if (eq @package.pasForm.dcpHousingunittype 717170003) "checked"}}
+                  onClick={{fn this.updateAttr @package.pasForm "dcpHousingunittype" 717170003}}
                   data-test-dcphousingunittype-other
                 /><label for="dcphousingunittype-other">Other</label>
               </fieldset>

--- a/client/app/components/packages/pas-form/edit.js
+++ b/client/app/components/packages/pas-form/edit.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
+import PasFormValidations from '../../../validations/pas-form';
 
 export default class PasFormComponent extends Component {
   @service router;
@@ -9,6 +10,8 @@ export default class PasFormComponent extends Component {
   @tracked modalIsOpen = false;
 
   @tracked package;
+
+  pasFormValidations = PasFormValidations;
 
   get isDirty() {
     const isPasFormDirty = this.args.package.pasForm.hasDirtyAttributes;
@@ -21,7 +24,8 @@ export default class PasFormComponent extends Component {
   // TODO: consider decoupling the PAS Form from the Package
   // for better modularity and avoiding "inappropriate intimacy"
   @action
-  save(projectPackage) {
+  save(projectPackage, pasFormChangeset) {
+    pasFormChangeset.save();
     projectPackage.saveDescendants();
   }
 

--- a/client/app/components/packages/pas-form/edit.js
+++ b/client/app/components/packages/pas-form/edit.js
@@ -2,14 +2,19 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
+import { Changeset } from 'ember-changeset';
 import PasFormValidations from '../../../validations/pas-form';
 
 export default class PasFormComponent extends Component {
+  constructor(...args) {
+    super(...args);
+
+    this.changeset = Changeset(this.args.package, this.pasFormValidations);
+  }
+
   @service router;
 
   @tracked modalIsOpen = false;
-
-  @tracked package;
 
   pasFormValidations = PasFormValidations;
 

--- a/client/app/components/packages/pas-form/edit.js
+++ b/client/app/components/packages/pas-form/edit.js
@@ -3,24 +3,22 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { Changeset } from 'ember-changeset';
+import lookupValidator from 'ember-changeset-validations';
 import PasFormValidations from '../../../validations/pas-form';
 
 export default class PasFormComponent extends Component {
   constructor(...args) {
     super(...args);
 
-    this.changeset = Changeset(this.args.package, this.pasFormValidations);
+    this.changeset = new Changeset(this.args.package.pasForm, lookupValidator(PasFormValidations));
   }
 
   @service router;
 
   @tracked modalIsOpen = false;
 
-  pasFormValidations = PasFormValidations;
-
   get isDirty() {
-    const isPasFormDirty = this.args.package.pasForm.hasDirtyAttributes;
-
+    const { isDirty: isPasFormDirty } = this.changeset;
     const { isBblsDirty, isApplicantsDirty } = this.args.package.pasForm;
 
     return isPasFormDirty || isBblsDirty || isApplicantsDirty;
@@ -29,9 +27,9 @@ export default class PasFormComponent extends Component {
   // TODO: consider decoupling the PAS Form from the Package
   // for better modularity and avoiding "inappropriate intimacy"
   @action
-  save(projectPackage, pasFormChangeset) {
-    pasFormChangeset.save();
-    projectPackage.saveDescendants();
+  async save(projectPackage) {
+    await this.changeset.save();
+    await projectPackage.saveDescendants();
   }
 
   @action

--- a/client/app/components/validation-message.hbs
+++ b/client/app/components/validation-message.hbs
@@ -1,0 +1,8 @@
+{{#if (get (get @changeset "error") @field)}}
+  <span
+    class="text-red"
+    data-test-validation={{@field}}
+  >
+    {{get (get (get @changeset "error") @field) "validation"}}
+  </span>
+{{/if}}

--- a/client/app/components/validation-message.hbs
+++ b/client/app/components/validation-message.hbs
@@ -1,8 +1,8 @@
-{{#if (get (get @changeset "error") @field)}}
+{{#if (get @changeset (concat 'error.' @field))}}
   <span
     class="text-red"
     data-test-validation={{@field}}
   >
-    {{get (get (get @changeset "error") @field) "validation"}}
+    {{get @changeset (concat 'error.' @field '.validation')}}
   </span>
 {{/if}}

--- a/client/app/components/validation-message.hbs
+++ b/client/app/components/validation-message.hbs
@@ -1,8 +1,7 @@
-{{#if (get @changeset (concat 'error.' @field))}}
+{{#if @changesetError}}
   <span
     class="text-red"
-    data-test-validation={{@field}}
   >
-    {{get @changeset (concat 'error.' @field '.validation')}}
+    {{@changesetError.validation}}
   </span>
 {{/if}}

--- a/client/app/models/pas-form.js
+++ b/client/app/models/pas-form.js
@@ -45,7 +45,12 @@ export default class PasFormModel extends Model {
 
   @attr('number') dcpProjectblock;
 
-  @attr('string') dcpRevisedprojectname;
+  @attr({
+    defaultValue(pasForm) {
+      return pasForm.package.project.dcpProjectname;
+    },
+  })
+  dcpRevisedprojectname;
 
   @attr('boolean') dcpExistingbuildingoccupied;
 

--- a/client/app/routes/packages/edit.js
+++ b/client/app/routes/packages/edit.js
@@ -4,7 +4,7 @@ export default class PackagesEditRoute extends Route {
   model(params) {
     return this.store.findRecord('package', params.id, {
       reload: true,
-      include: 'pasForm',
+      include: 'pasForm,project',
     });
   }
 }

--- a/client/app/styles/modules/_login.scss
+++ b/client/app/styles/modules/_login.scss
@@ -7,6 +7,7 @@
   color: #828892;
   font-size: 0.875rem;
   padding: 0 1.25rem;
+  min-height: rem-calc(75);
 }
 
 .auth--container .auth--icon {
@@ -19,7 +20,7 @@
   font-weight: normal;
 }
 
-.site-header .menu a.auth--logout-button {
+.site-header .menu .auth--logout-button {
   display: inline-block;
   padding: 0;
   color: #ae561f;
@@ -27,7 +28,7 @@
   font-size: 0.75rem;
 }
 
-.site-header .menu a.auth--logout-button:hover {
+.site-header .menu .auth--logout-button:hover {
   color:#8b4519;
   background-color:transparent
 }

--- a/client/app/templates/application.hbs
+++ b/client/app/templates/application.hbs
@@ -12,19 +12,28 @@
   </banner.title>
   <banner.nav>
     <ul class="menu vertical medium-horizontal">
-      <li>
-        {{#if this.session.isAuthenticated}}
-          <button {{on "click" this.doLogout}}
-            href="#"
-            type="button"
-            data-test-auth="logout"
-          >
-            Logout
-          </button>
-        {{else}}
+      {{#if this.session.isAuthenticated}}
+        <li class="auth--container">
+          <FaIcon @icon="user-circle" @prefix="fas" @size="2x" class="auth--icon" />
+          <div>
+            <span class="auth--name">
+              {{this.session.data.authenticated.emailaddress1}}
+            </span>
+            <button
+              type="button"
+              class="auth--logout-button"
+              {{on "click" this.doLogout}}
+              data-test-auth="logout"
+            >
+              Sign Out
+            </button>
+          </div>
+        </li>
+      {{else}}
+        <li>
           <SignInButton />
-        {{/if}}
-      </li>
+        </li>
+      {{/if}}
     </ul>
   </banner.nav>
 </LabsUi::SiteHeader>

--- a/client/app/validations/pas-form.js
+++ b/client/app/validations/pas-form.js
@@ -1,0 +1,103 @@
+import {
+  validateLength,
+} from 'ember-changeset-validations/validators';
+
+export default {
+  dcpRevisedprojectname: [
+    validateLength({
+      max: 50,
+      message: 'Name is too long (max 50 characters)',
+    }),
+  ],
+
+  dcpDescriptionofprojectareageography: [
+    validateLength({
+      max: 2000,
+      message: 'Description is too long (max 2000 characters)',
+    }),
+  ],
+
+  dcpUrbanareaname: [
+    validateLength({
+      max: 250,
+      message: 'Name is too long (max 250 characters)',
+    }),
+  ],
+
+  dcpPleaseexplaintypeiienvreview: [
+    validateLength({
+      max: 200,
+      message: 'Text is too long (max 200 characters)',
+    }),
+  ],
+
+  dcpProjectareaindutrialzonename: [
+    validateLength({
+      max: 250,
+      message: 'Name is too long (max 250 characters)',
+    }),
+  ],
+
+  dcpProjectarealandmarkname: [
+    validateLength({
+      max: 250,
+      message: 'Name is too long (max 250 characters)',
+    }),
+  ],
+
+  dcpCityregisterfilenumber: [
+    validateLength({
+      max: 25,
+      message: 'File Number is too long (max 25 characters)',
+    }),
+  ],
+
+  dcpEstimatedcompletiondate: [
+    validateLength({
+      max: 4,
+      message: 'Please enter a valid year in YYYY format',
+    }),
+  ],
+
+  dcpProjectdescriptionproposeddevelopment: [
+    validateLength({
+      max: 3000,
+      message: 'Text is too long (max 3000 characters)',
+    }),
+  ],
+
+  dcpProjectdescriptionbackground: [
+    validateLength({
+      max: 2000,
+      message: 'Text is too long (max 2000 characters)',
+    }),
+  ],
+
+  dcpProjectdescriptionproposedactions: [
+    validateLength({
+      max: 2000,
+      message: 'Text is too long (max 2000 characters)',
+    }),
+  ],
+
+  dcpProjectdescriptionproposedarea: [
+    validateLength({
+      max: 3000,
+      message: 'Text is too long (max 3000 characters)',
+    }),
+  ],
+
+  dcpProjectdescriptionsurroundingarea: [
+    validateLength({
+      max: 3000,
+      message: 'Text is too long (max 3000 characters)',
+    }),
+  ],
+
+  dcpProjectattachmentsotherinformation: [
+    validateLength({
+      max: 2000,
+      message: 'Text is too long (max 2000 characters)',
+    }),
+  ],
+};

--- a/client/mirage/factories/contact.js
+++ b/client/mirage/factories/contact.js
@@ -1,4 +1,5 @@
 import { Factory } from 'ember-cli-mirage';
 
 export default Factory.extend({
+  emailaddress1: 'email@example.org',
 });

--- a/client/mirage/factories/package.js
+++ b/client/mirage/factories/package.js
@@ -20,18 +20,14 @@ const PACKAGE_VISIBILITY_CODES = {
   LUP: 717170004,
 };
 
+// Note: It's better to create packages through a
+// project
 export default Factory.extend({
   dcpPackagetype: 'PAS Package',
 
   afterCreate(projectPackage, server) {
     server.create('pas-form', { package: projectPackage });
   },
-
-  withLandUseActions: trait({
-    afterCreate(projectPackage, server) {
-      server.create('pas-form', 'withLandUseActions', { package: projectPackage });
-    },
-  }),
 
   applicant: trait({
     statuscode(i) {
@@ -126,6 +122,19 @@ export default Factory.extend({
       ];
 
       return visibility[i % visibility.length];
+    },
+  }),
+
+  withLandUseActions: trait({
+    afterCreate(projectPackage, server) {
+      server.create('pas-form', 'withLandUseActions', { package: projectPackage });
+    },
+  }),
+
+
+  withRadioButtonAnswers: trait({
+    afterCreate(projectPackage, server) {
+      server.create('pas-form', 'withRadioButtonAnswers', { package: projectPackage });
     },
   }),
 

--- a/client/mirage/factories/pas-form.js
+++ b/client/mirage/factories/pas-form.js
@@ -11,4 +11,30 @@ export default Factory.extend({
     dcpZoningresolutiontitle: '',
     dcpPfchangeincitymap: 4,
   }),
+
+  withRadioButtonAnswers: trait({
+    dcpProposedprojectorportionconstruction: 717170000,
+    dcpUrbanrenewalarea: 717170001,
+    dcpLegalstreetfrontage: 717170003,
+    dcpLanduseactiontype2: 717170001,
+    dcpProjectareaindustrialbusinesszone: false,
+    dcpIsprojectarealandmark: false,
+    dcpProjectareacoastalzonelocatedin: true,
+    dcpProjectareaischancefloodplain: 717170002,
+    dcpRestrictivedeclaration: true,
+    dcpRestrictivedeclarationrequired: 717170002,
+    dcpIsinclusionaryhousingdesignatedarea: true,
+    dcpDiscressionaryfundingforffordablehousing: 717170000,
+    dcpHousingunittype: 717170002,
+  }),
+
+  withEstimatedCompletionDate: trait({
+    dcpEstimatedcompletiondate: new Date('November 1, 2050 03:22:10'),
+  }),
+
+  withCheckboxAnswers: trait({
+    dcpProposeddevelopmentsitedemolition: true,
+    dcpProposeddevelopmentsiteinfoaddition: true,
+    dcpProposeddevelopmentsitechnageofuse: true,
+  }),
 });

--- a/client/package.json
+++ b/client/package.json
@@ -30,6 +30,8 @@
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-auto-import": "^1.5.3",
+    "ember-changeset": "^3.3.4",
+    "ember-changeset-validations": "^3.3.1",
     "ember-cli": "~3.17.0",
     "ember-cli-app-version": "^3.2.0",
     "ember-cli-babel": "^7.18.0",

--- a/client/tests/acceptance/user-can-click-package-show-test.js
+++ b/client/tests/acceptance/user-can-click-package-show-test.js
@@ -8,7 +8,10 @@ module('Acceptance | user can interact with packages', function(hooks) {
   setupMirage(hooks);
 
   test('User can visit view-only (show) package route', async function(assert) {
-    this.server.create('project', 1, 'applicant');
+    const ourProject = this.server.create('project');
+    const projectPackage = this.server.create('package', { project: ourProject });
+
+    this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form,project' });
 
     await visit('/packages/1');
 

--- a/client/tests/integration/components/land-use-action-test.js
+++ b/client/tests/integration/components/land-use-action-test.js
@@ -91,7 +91,7 @@ module('Integration | Component | land-use-action', function(hooks) {
   });
 
   test('User can load PAS Form with existing Land Use Actions', async function(assert) {
-    const projectPackage = this.server.create('package', 1, 'applicant', 'withLandUseActions');
+    const projectPackage = this.server.create('package', 'applicant', 'withLandUseActions');
 
     this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form' });
 

--- a/client/tests/integration/components/pas-form-test.js
+++ b/client/tests/integration/components/pas-form-test.js
@@ -112,16 +112,16 @@ module('Integration | Component | pas-form', function(hooks) {
     await render(hbs`<Packages::PasForm::Edit @package={{this.package}} />`);
 
     // should be pre-populated with project.dcpProjectname
-    assert.equal((this.element.querySelector('[data-test-project-name-input]')).value, 'Frozen Banana Castle');
+    assert.equal((this.element.querySelector('[data-test-dcprevisedprojectname]')).value, 'Frozen Banana Castle');
 
     // save button should start disabled
     // TODO: fix this test.  The form starts dirty because we implicitly create a new applicant when the applicants array is empty
     // assert.dom('[data-test-save-button').hasProperty('disabled', true);
 
     // edit a field to make it pasForm dirty
-    await fillIn('[data-test-project-name-input]', 'Some Cool New Project Name');
+    await fillIn('[data-test-dcprevisedprojectname]', 'Some Cool New Project Name');
 
-    assert.equal((this.element.querySelector('[data-test-project-name-input]')).value, 'Some Cool New Project Name');
+    assert.equal((this.element.querySelector('[data-test-dcprevisedprojectname]')).value, 'Some Cool New Project Name');
 
     // save button should become active when dirty
     assert.dom('[data-test-save-button').hasProperty('disabled', false);
@@ -164,5 +164,25 @@ module('Integration | Component | pas-form', function(hooks) {
     assert.dom('[data-test-confirm-submit-button]').exists();
 
     await click('[data-test-confirm-submit-button]');
+  });
+
+
+  test('PAS Form radio button answers are restored on reload', async function(assert) {
+    const ourProject = this.server.create('project', { dcpProjectname: 'Frozen Banana Castle' });
+
+    const projectPackage = this.server.create('package', 'applicant', 'withRadioButtonAnswers', {
+      project: ourProject,
+    });
+
+    this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id,
+      { include: 'pas-form,project' });
+
+    await render(hbs`
+      <Packages::PasForm::Edit
+        @package={{this.package}}
+      />
+    `);
+
+    assert.dom('input[type="radio"]:checked').exists({ count: 13 });
   });
 });

--- a/client/tests/integration/components/pas-form-test.js
+++ b/client/tests/integration/components/pas-form-test.js
@@ -12,9 +12,10 @@ module('Integration | Component | pas-form', function(hooks) {
   setupMirage(hooks);
 
   test('Urban Renewal Area sub Q shows conditionally', async function(assert) {
-    const projectPackage = this.server.create('package');
+    const ourProject = this.server.create('project');
+    const projectPackage = this.server.create('package', { project: ourProject });
 
-    this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form' });
+    this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form,project' });
 
     await render(hbs`<Packages::PasForm::Edit @package={{this.package}} />`);
     assert.dom('[data-test-dcpurbanrenewalarea]').doesNotExist();
@@ -23,9 +24,10 @@ module('Integration | Component | pas-form', function(hooks) {
   });
 
   test('SEQRA or CEQR sub Q shows conditionally', async function(assert) {
-    const projectPackage = this.server.create('package');
+    const ourProject = this.server.create('project');
+    const projectPackage = this.server.create('package', { project: ourProject });
 
-    this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form' });
+    this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form,project' });
 
     await render(hbs`<Packages::PasForm::Edit @package={{this.package}} />`);
     assert.dom('[data-test-dcppleaseexplaintypeiienvreview]').doesNotExist();
@@ -34,9 +36,10 @@ module('Integration | Component | pas-form', function(hooks) {
   });
 
   test('Industrial Business Zone sub Q shows conditionally', async function(assert) {
-    const projectPackage = this.server.create('package');
+    const ourProject = this.server.create('project');
+    const projectPackage = this.server.create('package', { project: ourProject });
 
-    this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form' });
+    this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form,project' });
 
     await render(hbs`<Packages::PasForm::Edit @package={{this.package}} />`);
     assert.dom('[data-test-dcpprojectareaindustrialbusinesszone]').doesNotExist();
@@ -45,9 +48,10 @@ module('Integration | Component | pas-form', function(hooks) {
   });
 
   test('Landmark or Historic District sub Q shows conditionally', async function(assert) {
-    const projectPackage = this.server.create('package');
+    const ourProject = this.server.create('project');
+    const projectPackage = this.server.create('package', { project: ourProject });
 
-    this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form' });
+    this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form,project' });
 
 
     await render(hbs`<Packages::PasForm::Edit @package={{this.package}} />`);
@@ -57,9 +61,10 @@ module('Integration | Component | pas-form', function(hooks) {
   });
 
   test('Other Type sub Q shows conditionally', async function(assert) {
-    const projectPackage = this.server.create('package');
+    const ourProject = this.server.create('project');
+    const projectPackage = this.server.create('package', { project: ourProject });
 
-    this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form' });
+    this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form,project' });
 
     await render(hbs`<Packages::PasForm::Edit @package={{this.package}} />`);
     assert.dom('[data-test-dcpproposeddevelopmentsiteotherexplanation]').doesNotExist();
@@ -68,9 +73,10 @@ module('Integration | Component | pas-form', function(hooks) {
   });
 
   test('MIH sub Q shows conditionally', async function(assert) {
-    const projectPackage = this.server.create('package');
+    const ourProject = this.server.create('project');
+    const projectPackage = this.server.create('package', { project: ourProject });
 
-    this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form' });
+    this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form,project' });
 
     await render(hbs`<Packages::PasForm::Edit @package={{this.package}} />`);
     assert.dom('[data-test-dcpinclusionaryhousingdesignatedareaname]').doesNotExist();
@@ -79,9 +85,10 @@ module('Integration | Component | pas-form', function(hooks) {
   });
 
   test('Funding Source sub Q shows conditionally', async function(assert) {
-    const projectPackage = this.server.create('package');
+    const ourProject = this.server.create('project');
+    const projectPackage = this.server.create('package', { project: ourProject });
 
-    this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form' });
+    this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form,project' });
 
     await render(hbs`<Packages::PasForm::Edit @package={{this.package}} />`);
     assert.dom('[data-test-dcphousingunittype-city]').doesNotExist();
@@ -96,19 +103,25 @@ module('Integration | Component | pas-form', function(hooks) {
   });
 
   test('user can save pas form', async function(assert) {
-    const projectPackage = this.server.create('package');
+    const ourProject = this.server.create('project', { dcpProjectname: 'Frozen Banana Castle' });
+    const projectPackage = this.server.create('package', { project: ourProject });
 
-    this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form' });
+    this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form,project' });
 
     // render form
     await render(hbs`<Packages::PasForm::Edit @package={{this.package}} />`);
+
+    // should be pre-populated with project.dcpProjectname
+    assert.equal((this.element.querySelector('[data-test-project-name-input]')).value, 'Frozen Banana Castle');
 
     // save button should start disabled
     // TODO: fix this test.  The form starts dirty because we implicitly create a new applicant when the applicants array is empty
     // assert.dom('[data-test-save-button').hasProperty('disabled', true);
 
     // edit a field to make it pasForm dirty
-    await fillIn('[data-test-dcprevisedprojectname]', 'Some Cool New Project Name');
+    await fillIn('[data-test-project-name-input]', 'Some Cool New Project Name');
+
+    assert.equal((this.element.querySelector('[data-test-project-name-input]')).value, 'Some Cool New Project Name');
 
     // save button should become active when dirty
     assert.dom('[data-test-save-button').hasProperty('disabled', false);
@@ -122,9 +135,10 @@ module('Integration | Component | pas-form', function(hooks) {
   });
 
   test('user sees a confirmation modal upon submit', async function(assert) {
-    const projectPackage = this.server.create('package');
+    const ourProject = this.server.create('project');
+    const projectPackage = this.server.create('package', { project: ourProject });
 
-    this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form' });
+    this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form,project' });
 
     class LocationStub extends Service {
       transitionTo() {}

--- a/client/tests/integration/components/validation-message-test.js
+++ b/client/tests/integration/components/validation-message-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | validation-message', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<ValidationMessage />`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      <ValidationMessage>
+        template block text
+      </ValidationMessage>
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});

--- a/client/tests/integration/components/validation-message-test.js
+++ b/client/tests/integration/components/validation-message-test.js
@@ -17,8 +17,7 @@ module('Integration | Component | validation-message', function(hooks) {
 
     await render(hbs`
       <ValidationMessage
-        @field='dcpSomeField'
-        @changeset={{this.changeset}}
+        @changesetError={{this.changeset.error.dcpSomeField}}
       />
     `);
 

--- a/client/tests/integration/components/validation-message-test.js
+++ b/client/tests/integration/components/validation-message-test.js
@@ -6,21 +6,22 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Component | validation-message', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
+  test('it displays a deeply nested error message', async function(assert) {
+    this.changeset = {
+      error: {
+        dcpSomeField: {
+          validation: 'Something went wrong',
+        },
+      },
+    };
 
-    await render(hbs`<ValidationMessage />`);
-
-    assert.equal(this.element.textContent.trim(), '');
-
-    // Template block usage:
     await render(hbs`
-      <ValidationMessage>
-        template block text
-      </ValidationMessage>
+      <ValidationMessage
+        @field='dcpSomeField'
+        @changeset={{this.changeset}}
+      />
     `);
 
-    assert.equal(this.element.textContent.trim(), 'template block text');
+    assert.dom().hasText('Something went wrong');
   });
 });

--- a/client/tests/unit/models/package-test.js
+++ b/client/tests/unit/models/package-test.js
@@ -10,7 +10,9 @@ module('Unit | Model | package', function(hooks) {
   test('it exists', async function(assert) {
     const store = this.owner.lookup('service:store');
     const bbl = store.createRecord('bbl');
+    const ourProject = store.createRecord('project');
     const model = store.createRecord('package', {
+      project: ourProject,
       pasForm: store.createRecord('pas-form', {
         bbls: [bbl],
         applicants: [store.createRecord('applicant')],

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4860,7 +4860,7 @@ ember-ast-helpers@0.3.5:
     "@glimmer/compiler" "^0.27.0"
     "@glimmer/syntax" "^0.27.0"
 
-ember-auto-import@^1.2.19, ember-auto-import@^1.5.3:
+ember-auto-import@^1.2.19, ember-auto-import@^1.5.2, ember-auto-import@^1.5.3:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-1.5.3.tgz#b32936f874d1ed7057ad2ed3f6116357820be44b"
   integrity sha512-7JfdunM1BmLy/lyUXu7uEoi0Gi4+dxkGM23FgIEyW5g7z4MidhP53Fc61t49oPSnq7+J4lLpbH1f6C+mDMgb4A==
@@ -4918,6 +4918,27 @@ ember-basic-dropdown@^3.0.1:
     ember-maybe-in-element "^0.4.0"
     ember-truth-helpers "2.1.0"
 
+ember-changeset-validations@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/ember-changeset-validations/-/ember-changeset-validations-3.3.1.tgz#851974da2d4338391262ee34b51bda5ce0a4549b"
+  integrity sha512-4Sgckw+rEgRWSoYC3AMhmNlzw9WwRkJhsocSy62HolaCOHyhcWtOS+WbEpwFJEsj5mPBiRK1SgOyNI07kjUaow==
+  dependencies:
+    ember-changeset "^3.3.1"
+    ember-cli-babel "^7.8.0"
+    ember-cli-htmlbars "^4.0.5"
+    ember-get-config "^0.2.4"
+    ember-validators "^2.0.0"
+
+ember-changeset@^3.3.1, ember-changeset@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/ember-changeset/-/ember-changeset-3.3.4.tgz#af70f2b1f840f41b45a6d4af36bd314bb05e5347"
+  integrity sha512-dZUMMpXzojJIXcsunhTTds+kyaXMw7aIR1++MvonIBlk0KXRrrPbPe8Lx3pwOjQtXjIUqjvF3QCjmMQcZ8rUqQ==
+  dependencies:
+    "@glimmer/tracking" "^1.0.0"
+    ember-auto-import "^1.5.2"
+    ember-cli-babel "^7.19.0"
+    validated-changeset "~0.4.1"
+
 ember-cli-app-version@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ember-cli-app-version/-/ember-cli-app-version-3.2.0.tgz#7b9ad0e1b63ae0518648356ee24c703e922bc26e"
@@ -4931,7 +4952,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0:
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.0.tgz#de3baedd093163b6c2461f95964888c1676325ac"
   integrity sha512-Zr4my8Xn+CzO0gIuFNXji0eTRml5AxZUTDQz/wsNJ5AJAtyFWCY4QtKdoELNNbiCVGt1lq5yLiwTm4scGKu6xA==
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.10.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
+ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.10.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.2:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -4950,7 +4971,7 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.10.0, ember-cli-babel@^6.12.0,
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.0, ember-cli-babel@^7.12.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.2.0, ember-cli-babel@^7.4.1, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.3, ember-cli-babel@^7.9.0:
+ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.0, ember-cli-babel@^7.12.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.2.0, ember-cli-babel@^7.4.1, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.3, ember-cli-babel@^7.8.0, ember-cli-babel@^7.9.0:
   version "7.19.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.19.0.tgz#e6eddea18a867231fcf90a80689e92b98be9a63b"
   integrity sha512-HiWKuoyy35vGEr+iCw6gUnQ3pS5qslyTlKEDW8cVoMbvZNGYBgRxHed5nklVUh+BS74AwR9lsp25BTAagYAP9Q==
@@ -5069,7 +5090,7 @@ ember-cli-htmlbars@^3.0.0, ember-cli-htmlbars@^3.0.1:
     json-stable-stringify "^1.0.1"
     strip-bom "^3.0.0"
 
-ember-cli-htmlbars@^4.2.0, ember-cli-htmlbars@^4.2.3:
+ember-cli-htmlbars@^4.0.5, ember-cli-htmlbars@^4.2.0, ember-cli-htmlbars@^4.2.3:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-4.3.1.tgz#4af8adc21ab3c4953f768956b7f7d207782cb175"
   integrity sha512-CW6AY/yzjeVqoRtItOKj3hcYzc5dWPRETmeCzr2Iqjt5vxiVtpl0z5VTqHqIlT5fsFx6sGWBQXNHIe+ivYsxXQ==
@@ -5656,6 +5677,13 @@ ember-qunit@^4.6.0:
     ember-cli-test-loader "^2.2.0"
     qunit "^2.9.3"
 
+ember-require-module@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ember-require-module/-/ember-require-module-0.3.0.tgz#65aff7908b5b846467e4526594d33cfe0c23456b"
+  integrity sha512-rYN4YoWbR9VlJISSmx0ZcYZOgMcXZLGR7kdvp3zDerjIvYmHm/3p+K56fEAYmJILA6W4F+cBe41Tq2HuQAZizA==
+  dependencies:
+    ember-cli-babel "^6.9.2"
+
 ember-resolver@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/ember-resolver/-/ember-resolver-7.0.0.tgz#07ca86b3bae373395b44bba784b8c133f75d61c2"
@@ -5808,6 +5836,14 @@ ember-truth-helpers@2.1.0, ember-truth-helpers@^2.0.0, ember-truth-helpers@^2.1.
   integrity sha512-BQlU8aTNl1XHKTYZ243r66yqtR9JU7XKWQcmMA+vkqfkE/c9WWQ9hQZM8YABihCmbyxzzZsngvldokmeX5GhAw==
   dependencies:
     ember-cli-babel "^6.6.0"
+
+ember-validators@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ember-validators/-/ember-validators-2.0.0.tgz#4100e17feb9c3a6cf4072732010697bbd674f8cb"
+  integrity sha512-OhXGN2UbFQY+lhkWOdW347NZsIWGj/fpTJbOfNxjyMQW/c3fvPEIvrhlvWf1JwHGKQTJDHpMQJgA/Luq39GDgQ==
+  dependencies:
+    ember-cli-babel "^6.9.2"
+    ember-require-module "^0.3.0"
 
 ember-welcome-page@^4.0.0:
   version "4.0.0"
@@ -12353,6 +12389,11 @@ validate-npm-package-name@^3.0.0:
   integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
   dependencies:
     builtins "^1.0.3"
+
+validated-changeset@~0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/validated-changeset/-/validated-changeset-0.4.1.tgz#74208c439cb03b7ba69af6819c722768678fffeb"
+  integrity sha512-Q7pvZaWPdqn0Zo/Xpddp9zQ2abqXJLEyyiJbym+O2H2pH5KPOBTB/5UXBvkaQ7zvK6exWBjZnNzzoo1dBWeoAQ==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This PR builds off #200  , so inspect the last commit for this PR's changes.

Restores radio button answers by making sure templates are matching
number properties to numbers, not strings.

Also changes input checked attribute values to "checked" instead of
true. This conforms with spec.

https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attribute

Also removes @ from input name attributes, since they are not Ember
attributes.
