### PR TITLE
Dirty state touchups

### DIFF
--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -1,3 +1,5 @@
+{{log this.submittableChanges.error}}
+
 <div class="grid-x grid-margin-x">
 
     <div class="cell large-8">
@@ -105,7 +107,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.unifiedChanges.dcpProposedprojectorportionconstruction}}
-                @changed={{fn (mut this.unifiedChanges.dcpProposedprojectorportionconstruction) radio.code}}
+                @changed={{fn this.updateAttr radio.code}}
                  data-test-dcpproposedprojectorportionconstruction={{radio.label}}
               >
                 {{radio.label}}
@@ -126,7 +128,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.unifiedChanges.dcpUrbanrenewalarea}}
-                @changed={{fn (mut this.unifiedChanges.dcpUrbanrenewalarea) radio.code}}
+                @changed={{fn this.updateAttr radio.code}}
                  data-test-dcpurbanrenewalarea={{radio.label}}
               >
                 {{radio.label}}
@@ -165,7 +167,7 @@
                 <RadioButton
                   @value={{radio.code}}
                   @groupValue={{this.unifiedChanges.dcpLegalstreetfrontage}}
-                  @changed={{fn (mut this.unifiedChanges.dcpLegalstreetfrontage) radio.code}}
+                  @changed={{fn this.updateAttr radio.code}}
                   data-test-dcplegalstreetfrontage={{radio.label}}
                 >
                   {{radio.label}}
@@ -192,7 +194,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.unifiedChanges.dcpLanduseactiontype2}}
-                @changed={{fn (mut this.unifiedChanges.dcpLanduseactiontype2) radio.code}}
+                @changed={{fn this.updateAttr radio.code}}
                 data-test-dcplanduseactiontype2={{radio.label}}
               >
                 {{radio.label}}
@@ -226,7 +228,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.unifiedChanges.dcpProjectareaindustrialbusinesszone}}
-                @changed={{fn (mut this.unifiedChanges.dcpProjectareaindustrialbusinesszone) radio.code}}
+                @changed={{fn this.updateAttr radio.code}}
                 data-test-dcpprojectareaindustrialbusinesszone={{radio.label}}
               >
                 {{radio.label}}
@@ -259,7 +261,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.unifiedChanges.dcpIsprojectarealandmark}}
-                @changed={{fn (mut this.unifiedChanges.dcpIsprojectarealandmark) radio.code}}
+                @changed={{fn this.updateAttr radio.code}}
                 data-test-dcpisprojectarealandmark={{radio.label}}
               >
                 {{radio.label}}
@@ -293,7 +295,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.unifiedChanges.dcpProjectareacoastalzonelocatedin}}
-                @changed={{fn (mut this.unifiedChanges.dcpProjectareacoastalzonelocatedin) radio.code}}
+                @changed={{fn this.updateAttr radio.code}}
                 data-test-dcpprojectareacoastalzonelocatedin={{radio.label}}
               >
                 {{radio.label}}
@@ -313,7 +315,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.unifiedChanges.dcpProjectareaischancefloodplain}}
-                @changed={{fn (mut this.unifiedChanges.dcpProjectareaischancefloodplain) radio.code}}
+                @changed={{fn this.updateAttr radio.code}}
                 data-test-dcpprojectareaischancefloodplain={{radio.label}}
               >
                 {{radio.label}}
@@ -332,7 +334,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.unifiedChanges.dcpRestrictivedeclaration}}
-                @changed={{fn (mut this.unifiedChanges.dcpRestrictivedeclaration) radio.code}}
+                @changed={{fn this.updateAttr radio.code}}
                 data-test-dcprestrictivedeclaration={{radio.label}}
               >
                 {{radio.label}}
@@ -367,7 +369,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.unifiedChanges.dcpRestrictivedeclarationrequired}}
-                @changed={{fn (mut this.unifiedChanges.dcpRestrictivedeclarationrequired) radio.code}}
+                @changed={{fn this.updateAttr radio.code}}
                 data-test-dcprestrictivedeclarationrequired={{radio.label}}
               >
                 {{radio.label}}
@@ -479,7 +481,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.unifiedChanges.dcpIsinclusionaryhousingdesignatedarea}}
-                @changed={{fn (mut this.unifiedChanges.dcpIsinclusionaryhousingdesignatedarea) radio.code}}
+                @changed={{fn this.updateAttr radio.code}}
                 data-test-dcpisinclusionaryhousingdesignatedarea={{radio.label}}
               >
                 {{radio.label}}
@@ -512,7 +514,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.unifiedChanges.dcpDiscressionaryfundingforffordablehousing}}
-                @changed={{fn (mut this.unifiedChanges.dcpDiscressionaryfundingforffordablehousing) radio.code}}
+                @changed={{fn this.updateAttr radio.code}}
                 data-test-dcpdiscressionaryfundingforffordablehousing={{radio.label}}
               >
                 {{radio.label}}
@@ -532,8 +534,8 @@
                 }}
                   <RadioButton
                     @value={{radio.code}}
-                    @groupValue={{this.unifiedChanges.dcpHousingunittypeCity}}
-                    @changed={{fn (mut this.unifiedChanges.dcpHousingunittypeCity) radio.code}}
+                    @groupValue={{this.unifiedChanges.dcpHousingunittype}}
+                    @changed={{fn this.updateAttr radio.code}}
                     data-test-dcphousingunittype={{radio.label}}
                   >
                     {{radio.label}}

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -231,22 +231,21 @@
               >
                 {{radio.label}}
               </RadioButton>
-
-              {{#if this.unifiedChanges.dcpProjectareaindustrialbusinesszone}}
-                <label>
-                  Name of Industrial Business Zone
-                  <Input
-                    @type="text"
-                    @value={{this.unifiedChanges.dcpProjectareaindutrialzonename}}
-                    maxlength="200"
-                    data-test-dcpprojectareaindustrialbusinesszonename
-                  />
-                  <ValidationMessage
-                    @changesetError={{this.submittableChanges.error.dcpProjectareaindutrialzonename}}
-                  />
-                </label>
-              {{/if}}
             {{/each}}
+            {{#if this.unifiedChanges.dcpProjectareaindustrialbusinesszone}}
+              <label>
+                Name of Industrial Business Zone
+                <Input
+                  @type="text"
+                  @value={{this.unifiedChanges.dcpProjectareaindutrialzonename}}
+                  maxlength="200"
+                  data-test-dcpprojectareaindustrialbusinesszonename
+                />
+                <ValidationMessage
+                  @changesetError={{this.submittableChanges.error.dcpProjectareaindutrialzonename}}
+                />
+              </label>
+            {{/if}}
           </fieldset>
 
           <fieldset class="medium-margin-bottom">

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -1,4 +1,7 @@
-{{log this.submittableChanges.error}}
+{{!-- template-lint-disable no-log --}}
+{{#each-in this.submittableChanges.error as |key value|}}
+  {{log key value.validation value.value}}
+{{/each-in}}
 
 <div class="grid-x grid-margin-x">
 
@@ -25,7 +28,7 @@
           <strong>Project Name</strong>
           <Input
             @type="text"
-            @value={{this.unifiedChanges.dcpRevisedprojectname}} data-test-dcprevisedprojectname
+            @value={{this.saveableChanges.dcpRevisedprojectname}} data-test-dcprevisedprojectname
           />
         </label>
       </section>
@@ -56,7 +59,7 @@
           <label>
             <strong>Description of geography</strong>
             <Textarea
-              @value={{this.unifiedChanges.dcpDescriptionofprojectareageography}}
+              @value={{this.saveableChanges.dcpDescriptionofprojectareageography}}
               maxlength="2000"
               rows="5"
             />
@@ -106,8 +109,7 @@
             }}
               <RadioButton
                 @value={{radio.code}}
-                @groupValue={{this.unifiedChanges.dcpProposedprojectorportionconstruction}}
-                @changed={{fn this.updateAttr radio.code}}
+                @groupValue={{this.saveableChanges.dcpProposedprojectorportionconstruction}}
                  data-test-dcpproposedprojectorportionconstruction={{radio.label}}
               >
                 {{radio.label}}
@@ -127,20 +129,20 @@
             }}
               <RadioButton
                 @value={{radio.code}}
-                @groupValue={{this.unifiedChanges.dcpUrbanrenewalarea}}
-                @changed={{fn this.updateAttr radio.code}}
+                @groupValue={{this.saveableChanges.dcpUrbanrenewalarea}}
+                @changed={{fn this.validate}}
                  data-test-dcpurbanrenewalarea={{radio.label}}
               >
                 {{radio.label}}
               </RadioButton>
             {{/each}}
   
-            {{#if (eq this.unifiedChanges.dcpUrbanrenewalarea 717170000)}}
+            {{#if (eq this.saveableChanges.dcpUrbanrenewalarea 717170000)}}
               <label>
                 What is the name of the Urban Renewal Area?
                 <Input
                   @type="text"
-                  @value={{this.unifiedChanges.dcpUrbanareaname}}
+                  @value={{this.saveableChanges.dcpUrbanareaname}}
                   maxlength="250"
                   data-test-dcpurbanrenewalareaname
                 />
@@ -166,8 +168,7 @@
               <span class="nowrap">
                 <RadioButton
                   @value={{radio.code}}
-                  @groupValue={{this.unifiedChanges.dcpLegalstreetfrontage}}
-                  @changed={{fn this.updateAttr radio.code}}
+                  @groupValue={{this.saveableChanges.dcpLegalstreetfrontage}}
                   data-test-dcplegalstreetfrontage={{radio.label}}
                 >
                   {{radio.label}}
@@ -193,20 +194,20 @@
             }}
               <RadioButton
                 @value={{radio.code}}
-                @groupValue={{this.unifiedChanges.dcpLanduseactiontype2}}
-                @changed={{fn this.updateAttr radio.code}}
+                @groupValue={{this.saveableChanges.dcpLanduseactiontype2}}
+                @changed={{fn this.validate}}
                 data-test-dcplanduseactiontype2={{radio.label}}
               >
                 {{radio.label}}
               </RadioButton>
             {{/each}}
 
-            {{#if (eq this.unifiedChanges.dcpLanduseactiontype2 717170000)}}
+            {{#if (eq this.saveableChanges.dcpLanduseactiontype2 717170000)}}
               <label>
                 Indicate which SEQRA or CEQR category each action fulfills
                 <Input
                   @type="text"
-                  @value={{this.unifiedChanges.dcpPleaseexplaintypeiienvreview}}
+                  @value={{this.saveableChanges.dcpPleaseexplaintypeiienvreview}}
                   maxlength="200"
                   data-test-dcppleaseexplaintypeiienvreview
                 />
@@ -227,19 +228,19 @@
             }}
               <RadioButton
                 @value={{radio.code}}
-                @groupValue={{this.unifiedChanges.dcpProjectareaindustrialbusinesszone}}
-                @changed={{fn this.updateAttr radio.code}}
+                @groupValue={{this.saveableChanges.dcpProjectareaindustrialbusinesszone}}
+                @changed={{fn this.validate}}
                 data-test-dcpprojectareaindustrialbusinesszone={{radio.label}}
               >
                 {{radio.label}}
               </RadioButton>
             {{/each}}
-            {{#if this.unifiedChanges.dcpProjectareaindustrialbusinesszone}}
+            {{#if this.saveableChanges.dcpProjectareaindustrialbusinesszone}}
               <label>
                 Name of Industrial Business Zone
                 <Input
                   @type="text"
-                  @value={{this.unifiedChanges.dcpProjectareaindutrialzonename}}
+                  @value={{this.saveableChanges.dcpProjectareaindutrialzonename}}
                   maxlength="200"
                   data-test-dcpprojectareaindustrialbusinesszonename
                 />
@@ -260,20 +261,20 @@
             }}
               <RadioButton
                 @value={{radio.code}}
-                @groupValue={{this.unifiedChanges.dcpIsprojectarealandmark}}
-                @changed={{fn this.updateAttr radio.code}}
+                @groupValue={{this.saveableChanges.dcpIsprojectarealandmark}}
                 data-test-dcpisprojectarealandmark={{radio.label}}
               >
                 {{radio.label}}
               </RadioButton>
             {{/each}}
 
-            {{#if this.unifiedChanges.dcpIsprojectarealandmark}}
+            {{#if this.saveableChanges.dcpIsprojectarealandmark}}
               <label>
                 Name of Landmark or Historic District
                 <Input
                   @type="text"
-                  @value={{this.unifiedChanges.dcpProjectarealandmarkname}}
+                  @value={{this.saveableChanges.dcpProjectarealandmarkname}}
+                  @changed={{fn this.validate}}
                   maxlength="250"
                   data-test-dcpisprojectarealandmarkname
                 />
@@ -294,8 +295,7 @@
             }}
               <RadioButton
                 @value={{radio.code}}
-                @groupValue={{this.unifiedChanges.dcpProjectareacoastalzonelocatedin}}
-                @changed={{fn this.updateAttr radio.code}}
+                @groupValue={{this.saveableChanges.dcpProjectareacoastalzonelocatedin}}
                 data-test-dcpprojectareacoastalzonelocatedin={{radio.label}}
               >
                 {{radio.label}}
@@ -314,8 +314,7 @@
             }}
               <RadioButton
                 @value={{radio.code}}
-                @groupValue={{this.unifiedChanges.dcpProjectareaischancefloodplain}}
-                @changed={{fn this.updateAttr radio.code}}
+                @groupValue={{this.saveableChanges.dcpProjectareaischancefloodplain}}
                 data-test-dcpprojectareaischancefloodplain={{radio.label}}
               >
                 {{radio.label}}
@@ -333,20 +332,20 @@
             }}
               <RadioButton
                 @value={{radio.code}}
-                @groupValue={{this.unifiedChanges.dcpRestrictivedeclaration}}
-                @changed={{fn this.updateAttr radio.code}}
+                @groupValue={{this.saveableChanges.dcpRestrictivedeclaration}}
+                @changed={{fn this.validate}}
                 data-test-dcprestrictivedeclaration={{radio.label}}
               >
                 {{radio.label}}
               </RadioButton>
             {{/each}}
 
-            {{#if this.unifiedChanges.dcpRestrictivedeclaration}}
+            {{#if this.saveableChanges.dcpRestrictivedeclaration}}
               <label>
                 <strong>City Register File Number</strong>
                 <Input
                   @type="text"
-                  @value={{this.unifiedChanges.dcpCityregisterfilenumber}}
+                  @value={{this.saveableChanges.dcpCityregisterfilenumber}}
                   maxlength="25"
                   data-test-dcpcityregisterfilenumber
                 />
@@ -368,8 +367,7 @@
             }}
               <RadioButton
                 @value={{radio.code}}
-                @groupValue={{this.unifiedChanges.dcpRestrictivedeclarationrequired}}
-                @changed={{fn this.updateAttr radio.code}}
+                @groupValue={{this.saveableChanges.dcpRestrictivedeclarationrequired}}
                 data-test-dcprestrictivedeclarationrequired={{radio.label}}
               >
                 {{radio.label}}
@@ -392,7 +390,7 @@
             <strong>In what year do you expect the development to complete?</strong>
             <Input
               @type="text"
-              @value={{this.unifiedChanges.dcpEstimatedcompletiondate}}
+              @value={{this.saveableChanges.dcpEstimatedcompletiondate}}
               maxlength="4"
               data-test-dcpestimatedcompletiondate
             />
@@ -410,60 +408,60 @@
               <li>
                 <Input
                   @type="checkbox"
-                  @checked={{this.unifiedChanges.dcpProposeddevelopmentsitenewconstruction}}
+                  @checked={{this.saveableChanges.dcpProposeddevelopmentsitenewconstruction}}
                   id="dcpproposeddevelopmentsitenewconstruction"
                 /><label for="dcpproposeddevelopmentsitenewconstruction">Newly constructed buildings</label>
               </li>
               <li>
                 <Input
                   @type="checkbox"
-                  @checked={{this.unifiedChanges.dcpProposeddevelopmentsitedemolition}}
+                  @checked={{this.saveableChanges.dcpProposeddevelopmentsitedemolition}}
                   id="dcpproposeddevelopmentsitedemolition"
                 /><label for="dcpproposeddevelopmentsitedemolition">Demolition</label>
               </li>
               <li>
                 <Input
                   @type="checkbox"
-                  @checked={{this.unifiedChanges.dcpProposeddevelopmentsiteinfoalteration}}
+                  @checked={{this.saveableChanges.dcpProposeddevelopmentsiteinfoalteration}}
                   id="dcpproposeddevelopmentsiteinfoalteration"
                 /><label for="dcpproposeddevelopmentsiteinfoalteration">Alteration</label>
               </li>
               <li>
                 <Input
                   @type="checkbox"
-                  @checked={{this.unifiedChanges.dcpProposeddevelopmentsiteinfoaddition}}
+                  @checked={{this.saveableChanges.dcpProposeddevelopmentsiteinfoaddition}}
                   id="dcpproposeddevelopmentsiteinfoaddition"
                 /><label for="dcpproposeddevelopmentsiteinfoaddition">Addition</label>
               </li>
               <li>
                 <Input
                   @type="checkbox"
-                  @checked={{this.unifiedChanges.dcpProposeddevelopmentsitechnageofuse}}
+                  @checked={{this.saveableChanges.dcpProposeddevelopmentsitechnageofuse}}
                   id="dcpproposeddevelopmentsitechnageofuse"
                 /><label for="dcpproposeddevelopmentsitechnageofuse">Change of use</label>
               </li>
               <li>
                 <Input
                   @type="checkbox"
-                  @checked={{this.unifiedChanges.dcpProposeddevelopmentsiteenlargement}}
+                  @checked={{this.saveableChanges.dcpProposeddevelopmentsiteenlargement}}
                   id="dcpproposeddevelopmentsiteenlargement"
                 /><label for="dcpproposeddevelopmentsiteenlargement">Enlargement</label>
               </li>
               <li>
                 <Input
                   @type="checkbox"
-                  @checked={{this.unifiedChanges.dcpProposeddevelopmentsiteinfoother}}
+                  @checked={{this.saveableChanges.dcpProposeddevelopmentsiteinfoother}}
                   id="dcpproposeddevelopmentsiteinfoother"
                   data-test-dcpproposeddevelopmentsiteinfoother
                 /><label for="dcpproposeddevelopmentsiteinfoother">Other&hellip;</label>
               </li>
             </ul>
-            {{#if this.unifiedChanges.dcpProposeddevelopmentsiteinfoother}}
+            {{#if this.saveableChanges.dcpProposeddevelopmentsiteinfoother}}
               <label>
                 Explain:
                 <Input
                   @type="text"
-                  @value={{this.unifiedChanges.dcpProposeddevelopmentsiteotherexplanation}}
+                  @value={{this.saveableChanges.dcpProposeddevelopmentsiteotherexplanation}}
                   data-test-dcpproposeddevelopmentsiteotherexplanation
                 />
               </label>
@@ -480,8 +478,8 @@
             }}
               <RadioButton
                 @value={{radio.code}}
-                @groupValue={{this.unifiedChanges.dcpIsinclusionaryhousingdesignatedarea}}
-                @changed={{fn this.updateAttr radio.code}}
+                @groupValue={{this.saveableChanges.dcpIsinclusionaryhousingdesignatedarea}}
+                @changed={{fn this.validate}}
                 data-test-dcpisinclusionaryhousingdesignatedarea={{radio.label}}
               >
                 {{radio.label}}
@@ -491,12 +489,12 @@
             <p class="help-text">
               Refer to <a  href="https://zr.planning.nyc.gov/appendix-f-inclusionary-housing-designated-areas-and-mandatory-inclusionary-housing-areas">Appendix F</a> of the Zoning Resolution for full list of all inclusionary housing areas which are areas that incentivize or require affordable housing in certain areas.
             </p>
-            {{#if this.unifiedChanges.dcpIsinclusionaryhousingdesignatedarea}}
+            {{#if this.saveableChanges.dcpIsinclusionaryhousingdesignatedarea}}
               <label>
                 Name of Inclusionary Housing Designated Area/Mandatory Inclusionary Housing Area
                 <Input
                   @type="text"
-                  @value={{this.unifiedChanges.dcpInclusionaryhousingdesignatedareaname}}
+                  @value={{this.saveableChanges.dcpInclusionaryhousingdesignatedareaname}}
                   data-test-dcpinclusionaryhousingdesignatedareaname
                 />
               </label>
@@ -513,15 +511,15 @@
             }}
               <RadioButton
                 @value={{radio.code}}
-                @groupValue={{this.unifiedChanges.dcpDiscressionaryfundingforffordablehousing}}
-                @changed={{fn this.updateAttr radio.code}}
+                @groupValue={{this.saveableChanges.dcpDiscressionaryfundingforffordablehousing}}
+                @changed={{fn this.validate}}
                 data-test-dcpdiscressionaryfundingforffordablehousing={{radio.label}}
               >
                 {{radio.label}}
               </RadioButton>
             {{/each}}
 
-            {{#if (eq this.unifiedChanges.dcpDiscressionaryfundingforffordablehousing 717170000)}}
+            {{#if (eq this.saveableChanges.dcpDiscressionaryfundingforffordablehousing 717170000)}}
               <fieldset class="medium-margin-bottom">
                 <legend>
                   Funding source
@@ -534,8 +532,7 @@
                 }}
                   <RadioButton
                     @value={{radio.code}}
-                    @groupValue={{this.unifiedChanges.dcpHousingunittype}}
-                    @changed={{fn this.updateAttr radio.code}}
+                    @groupValue={{this.saveableChanges.dcpHousingunittype}}
                     data-test-dcphousingunittype={{radio.label}}
                   >
                     {{radio.label}}
@@ -555,7 +552,7 @@
           <label>
             <strong>Description of the proposed development being facilitated by the land use actions</strong>
             <Textarea
-              @value={{this.unifiedChanges.dcpProjectdescriptionproposeddevelopment}}
+              @value={{this.saveableChanges.dcpProjectdescriptionproposeddevelopment}}
               rows="5"
               maxlength="3000"
               data-test-dcpprojectdescriptionproposeddevelopment
@@ -568,7 +565,7 @@
           <label>
             <strong>Why is this application being proposed? What is the legal, environmental, or land use background?</strong>
             <Textarea
-              @value={{this.unifiedChanges.dcpProjectdescriptionbackground}}
+              @value={{this.saveableChanges.dcpProjectdescriptionbackground}}
               rows="5"
               maxlength="2000"
               data-test-dcpprojectdescriptionbackground
@@ -581,7 +578,7 @@
           <label>
             <strong>What is the land use rationale for all the proposed actions?</strong>
             <Textarea
-              @value={{this.unifiedChanges.dcpProjectdescriptionproposedactions}}
+              @value={{this.saveableChanges.dcpProjectdescriptionproposedactions}}
               rows="5"
               maxlength="2000"
               data-test-dcpprojectdescriptionproposedactions
@@ -594,7 +591,7 @@
           <label>
             <strong>Description of existing land uses and structures in the proposed Project Area and Development Site</strong>
             <Textarea
-              @value={{this.unifiedChanges.dcpProjectdescriptionproposedarea}}
+              @value={{this.saveableChanges.dcpProjectdescriptionproposedarea}}
               rows="5"
               maxlength="3000"
               data-test-dcpprojectdescriptionproposedarea
@@ -607,7 +604,7 @@
           <label>
             <strong>Description of land uses and built context in surrounding area (within 1000 ft)</strong>
             <Textarea
-              @value={{this.unifiedChanges.dcpProjectdescriptionsurroundingarea}}
+              @value={{this.saveableChanges.dcpProjectdescriptionsurroundingarea}}
               rows="5"
               maxlength="3000"
               data-test-dcpprojectdescriptionsurroundingarea
@@ -620,7 +617,7 @@
           <label>
             <strong>Description of proposed CEQR scope</strong>
             <Textarea
-              @value={{this.unifiedChanges.dcpProjectattachmentsotherinformation}}
+              @value={{this.saveableChanges.dcpProjectattachmentsotherinformation}}
               rows="5"
               maxlength="3000"
               data-test-dcpprojectattachmentsotherinformation

--- a/client/app/components/packages/pas-form/edit.js
+++ b/client/app/components/packages/pas-form/edit.js
@@ -29,7 +29,7 @@ export default class PasFormComponent extends Component {
     // helpers, but emit upstream setter changes to both
     // changesets.
     // REDO: This proxy is a little slow. we should find
-    // an alternative
+    // an alternative It's also confusing.
     this.unifiedChanges = new Proxy(this.saveableChanges, {
       get(saveableChanges, prop) {
         return saveableChanges[prop];
@@ -47,8 +47,7 @@ export default class PasFormComponent extends Component {
 
     // validate initial model state because this does not
     // happen when creating a new changset
-    this.saveableChanges.validate();
-    this.submittableChanges.validate();
+    this.validate();
   }
 
   @service router;
@@ -95,6 +94,16 @@ export default class PasFormComponent extends Component {
   }
 
   @tracked modalIsOpen = false;
+
+  @action
+  async updateAttr(target, value) {
+    target = value;
+  }
+
+  @action
+  async validate() {
+    await this.unifiedChanges.validate();
+  }
 
   @action
   toggleModal() {

--- a/client/app/components/project-geography.hbs
+++ b/client/app/components/project-geography.hbs
@@ -25,59 +25,44 @@
       <legend data-test-development-site-question="{{bbl.dcpBblnumber}}-{{bbl.dcpDevelopmentsite}}">
         Is this BBL part of the development site?
       </legend>
-      <Input
-        @type="radio"
-        name={{concat idx '-bbl-dev-site'}}
-        id={{concat idx '-bbl-dev-site-yes'}}
-        @value={{eq bbl.dcpDevelopmentsite true}}
-        checked={{eq bbl.dcpDevelopmentsite true}}
-        {{on "click" (fn this.updateAttr bbl "dcpDevelopmentsite" true)}}
-        data-test-bbl-development-site-yes="{{bbl.dcpBblnumber}}"
-      />
-      <label for="{{concat idx '-bbl-dev-site-yes'}}">
+      <RadioButton
+        @value={{true}}
+        @groupValue={{bbl.dcpDevelopmentsite}}
+        @changed={{fn (mut bbl.dcpDevelopmentsite) true}}
+          data-test-bbl-development-site-yes={{bbl.dcpBblnumber}}
+      >
         Yes
-      </label>
-      <Input
-        @type="radio"
-        name={{concat idx '-bbl-dev-site'}}
-        id={{concat idx '-bbl-dev-site-no'}}
-        @value={{eq bbl.dcpDevelopmentsite false}}
-        checked={{eq bbl.dcpDevelopmentsite false}}
-        {{on "click" (fn this.updateAttr bbl "dcpDevelopmentsite" false)}}
-        data-test-bbl-development-site-no="{{bbl.dcpBblnumber}}"
-      />
-      <label for="{{concat idx '-bbl-dev-site-no'}}">
+      </RadioButton>
+      <RadioButton
+        @value={{false}}
+        @groupValue={{bbl.dcpDevelopmentsite}}
+        @changed={{fn (mut bbl.dcpDevelopmentsite) false}}
+          data-test-bbl-development-site-no={{bbl.dcpBblnumber}}
+      >
         No
-      </label>
+      </RadioButton>
+
     </fieldset>
     <fieldset>
       <legend data-test-partial-lot-question="{{bbl.dcpBblnumber}}-{{bbl.dcpPartiallot}}">
         Is this a partial lot?
       </legend>
-      <Input
-        type="radio"
-        name="bbl-partial-lot-yes"
-        id="bbl-partial-lot-yes"
-        @value={{eq bbl.dcpPartiallot true}}
-        checked={{eq bbl.dcpPartiallot true}}
-        {{on "click" (fn this.updateAttr bbl "dcpPartiallot" true)}}
-        data-test-bbl-partial-lot-yes="{{bbl.dcpBblnumber}}"
-      />
-      <label for="bbl-partial-lot-yes">
+      <RadioButton
+        @value={{true}}
+        @groupValue={{bbl.dcpPartiallot}}
+        @changed={{fn (mut bbl.dcpPartiallot) true}}
+          data-test-bbl-partial-lot-yes={{bbl.dcpBblnumber}}
+      >
         Yes
-      </label>
-      <Input
-        @type="radio"
-        name="bbl-partial-lot-no"
-        id="bbl-partial-lot-no"
-        @value={{eq bbl.dcpPartiallot false}}
-        checked={{eq bbl.dcpPartiallot false}}
-        {{on "click" (fn this.updateAttr bbl "dcpPartiallot" false)}}
-        data-test-bbl-partial-lot-no="{{bbl.dcpBblnumber}}"
-      />
-      <label for="bbl-partial-lot-no">
+      </RadioButton>
+      <RadioButton
+        @value={{false}}
+        @groupValue={{bbl.dcpPartiallot}}
+        @changed={{fn (mut bbl.dcpPartiallot) false}}
+          data-test-bbl-partial-lot-no={{bbl.dcpBblnumber}}
+      >
         No
-      </label>
+      </RadioButton>
     </fieldset>
 
     <button

--- a/client/app/components/project-geography.hbs
+++ b/client/app/components/project-geography.hbs
@@ -7,7 +7,7 @@
   <small class="dark-gray">{{search.result.label}} <br> {{bbl-breakup search.result.bbl}}</small>
 </LabsSearch>
 
-{{#each @bbls as |bbl idx|}}
+{{#each @bbls as |bbl|}}
   <fieldset class="fieldset relative">
     <legend data-test-bbl-title="{{bbl.dcpBblnumber}}">
       <a

--- a/client/app/components/project-geography.js
+++ b/client/app/components/project-geography.js
@@ -41,10 +41,4 @@ export default class ProjectGeographyComponent extends Component {
     bblObjectToBeRemoved.destroyRecord();
     this.args.bbls.removeObject(bblObjectToBeRemoved);
   }
-
-  // Update attributes when user selects radio buttons
-  @action
-  updateAttr(currentObject, attr, newVal) {
-    currentObject[attr] = newVal;
-  }
 }

--- a/client/app/router.js
+++ b/client/app/router.js
@@ -13,7 +13,7 @@ Router.map(function() { // eslint-disable-line
   this.route('login');
   this.route('logout');
 
-  this.route('packages', function() {
+  this.route('packages', function () {
     this.route('edit', { path: ':id/edit' });
     this.route('show', { path: ':id' });
   });

--- a/client/app/routes/packages.js
+++ b/client/app/routes/packages.js
@@ -1,0 +1,6 @@
+import Route from '@ember/routing/route';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+
+export default class PackagesRoute extends Route.extend(AuthenticatedRouteMixin) {
+  authenticationRoute = '/';
+}

--- a/client/app/routes/projects.js
+++ b/client/app/routes/projects.js
@@ -1,9 +1,12 @@
 import Route from '@ember/routing/route';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
 // model of this route is all projects
 // will have associated controller, which will handle business logic of sorting project
 // objects into appropriate buckets
-export default class ProjectsRoute extends Route {
+export default class ProjectsRoute extends Route.extend(AuthenticatedRouteMixin) {
+  authenticationRoute = '/';
+
   // where we define the model of this part of the application
   model(params) {
     return this.store.query('project', { include: 'packages.pasForm', ...params });

--- a/client/app/validations/submittable-pas-form.js
+++ b/client/app/validations/submittable-pas-form.js
@@ -13,42 +13,42 @@ export default {
       withValue: 717170000,
     }),
   ],
-  dcp_pleaseexplaintypeiienvreview: [
+  dcpPleaseexplaintypeiienvreview: [
     validatePresenceIf({
       presence: true,
       on: 'dcpLanduseactiontype2',
       withValue: 717170000,
     }),
   ],
-  dcp_projectareaindutrialzonename: [
+  dcpProjectareaindutrialzonename: [
     validatePresenceIf({
       presence: true,
       on: 'dcpProjectareaindustrialbusinesszone',
       withValue: true,
     }),
   ],
-  dcp_projectarealandmarkname: [
+  dcpProjectarealandmarkname: [
     validatePresenceIf({
       presence: true,
       on: 'dcpIsprojectarealandmark',
       withValue: true,
     }),
   ],
-  dcp_proposeddevelopmentsiteotherexplanation: [
+  dcpProposeddevelopmentsiteotherexplanation: [
     validatePresenceIf({
       presence: true,
       on: 'dcpProposeddevelopmentsiteinfoother',
       withValue: true,
     }),
   ],
-  dcp_inclusionaryhousingdesignatedareaname: [
+  dcpInclusionaryhousingdesignatedareaname: [
     validatePresenceIf({
       presence: true,
       on: 'dcpIsinclusionaryhousingdesignatedarea',
       withValue: true,
     }),
   ],
-  dcp_housingunittype: [
+  dcpHousingunittype: [
     validatePresenceIf({
       presence: true,
       on: 'dcpDiscressionaryfundingforffordablehousing',

--- a/client/app/validators/required-if-selected.js
+++ b/client/app/validators/required-if-selected.js
@@ -7,7 +7,8 @@ export default function validatePresenceIf(options) {
 
   return (...args) => {
     const [,,, changes, content] = args;
-    const hasMatchingWith = (changes[on] || content[on]) === withValue;
+    const target = Object.prototype.hasOwnProperty.call(changes, on) ? changes[on] : content[on];
+    const hasMatchingWith = target === withValue;
 
     if (hasMatchingWith) {
       return validatePresence(options)(...args);

--- a/client/tests/acceptance/project-card-shows-correct-data-test.js
+++ b/client/tests/acceptance/project-card-shows-correct-data-test.js
@@ -2,10 +2,17 @@ import { module, test } from 'qunit';
 import { visit, findAll } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { authenticateSession } from 'ember-simple-auth/test-support';
 
 module('Acceptance | project card shows correct data', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+
+  hooks.beforeEach(() => {
+    authenticateSession({
+      emailaddress1: 'me@me.com',
+    });
+  });
 
   test('Shows correct project status', async function(assert) {
     // 4 default applicant projects that with Active statuscode

--- a/client/tests/acceptance/user-can-click-package-edit-test.js
+++ b/client/tests/acceptance/user-can-click-package-edit-test.js
@@ -2,10 +2,17 @@ import { module, test } from 'qunit';
 import { visit, click, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { authenticateSession } from 'ember-simple-auth/test-support';
 
 module('Acceptance | user can interact with packages', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+
+  hooks.beforeEach(() => {
+    authenticateSession({
+      emailaddress1: 'me@me.com',
+    });
+  });
 
   test('User can visit edit package route', async function(assert) {
     this.server.create('project', 1, 'applicant');

--- a/client/tests/acceptance/user-can-click-package-show-test.js
+++ b/client/tests/acceptance/user-can-click-package-show-test.js
@@ -2,10 +2,17 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { authenticateSession } from 'ember-simple-auth/test-support';
 
 module('Acceptance | user can interact with packages', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+
+  hooks.beforeEach(() => {
+    authenticateSession({
+      emailaddress1: 'me@me.com',
+    });
+  });
 
   test('User can visit view-only (show) package route', async function(assert) {
     const ourProject = this.server.create('project');

--- a/client/tests/acceptance/user-sees-projects-of-all-types-test.js
+++ b/client/tests/acceptance/user-sees-projects-of-all-types-test.js
@@ -2,10 +2,17 @@ import { module, test } from 'qunit';
 import { visit, find, findAll } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { authenticateSession } from 'ember-simple-auth/test-support';
 
 module('Acceptance | user sees projects of all types', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+
+  hooks.beforeEach(() => {
+    authenticateSession({
+      emailaddress1: 'me@me.com',
+    });
+  });
 
   test('Shows correct # of projects by type', async function(assert) {
     this.server.createList('project', 4, 'applicant');

--- a/client/tests/unit/validators/required-if-selected-test.js
+++ b/client/tests/unit/validators/required-if-selected-test.js
@@ -42,3 +42,40 @@ test('it validates when withValue is not present', function (assert) {
 
   assert.equal(result, true);
 });
+
+test('it validates when withValue is falsey', function (assert) {
+  const args = [
+    'someKey',
+    '',
+    undefined,
+    {},
+    { dependentKey: true },
+  ];
+
+  const result = validateRequiredIfSelected({
+    presence: true,
+    on: 'dependentKey',
+    withValue: false,
+    message: 'someKey must be filled in.',
+  })(...args);
+
+  assert.equal(result, true);
+});
+
+test('it validates when key not in content but in changes', function (assert) {
+  const args = [
+    'someKey',
+    '',
+    undefined,
+    { dependentKey: true },
+    {},
+  ];
+
+  const result = validateRequiredIfSelected({
+    presence: true,
+    on: 'dependentKey',
+    withValue: false,
+  })(...args);
+
+  assert.equal(result, true);
+});


### PR DESCRIPTION
Depends on #206 

Refactors the approach to multiple changes with a much simpler approach that doesn't rely on proxies, instead uses events from e-changeset. Makes conditional validations much stabler.

Refactors several template logic to simplify.

Fixes a small bug in project geographies form in which the radio groups weren't configured correctly and so changes in unrelated radio buttons would change

Authenticates routes so that an invalidated cookie will redirect users.