### PR TITLE
RadioButton refactor

### DIFF
--- a/client/app/components/packages/applicant-fieldset.hbs
+++ b/client/app/components/packages/applicant-fieldset.hbs
@@ -11,14 +11,16 @@
       <RadioButton
         @value={{717170000}}
         @groupValue={{@applicant.dcpType}}
-          data-test-applicant-type-radio-individual
+        @radioId={{concat 'individual-' @index}}
+        data-test-applicant-type-radio-individual
       >
         Individual
       </RadioButton>
       <RadioButton
         @value={{717170001}}
         @groupValue={{@applicant.dcpType}}
-          data-test-applicant-type-radio-organization
+        @radioId={{concat 'organization-' @index}}
+        data-test-applicant-type-radio-organization
       >
         Organization
       </RadioButton>

--- a/client/app/components/packages/applicant-fieldset.hbs
+++ b/client/app/components/packages/applicant-fieldset.hbs
@@ -11,7 +11,6 @@
       <RadioButton
         @value={{717170000}}
         @groupValue={{@applicant.dcpType}}
-        @radioId={{concat 'individual-' @index}}
         data-test-applicant-type-radio-individual
       >
         Individual
@@ -19,7 +18,6 @@
       <RadioButton
         @value={{717170001}}
         @groupValue={{@applicant.dcpType}}
-        @radioId={{concat 'organization-' @index}}
         data-test-applicant-type-radio-organization
       >
         Organization

--- a/client/app/components/packages/applicant-team-editor.hbs
+++ b/client/app/components/packages/applicant-team-editor.hbs
@@ -4,7 +4,6 @@
       @elementId={{concat 'applicant-fieldset-' index}}
       @applicant={{applicant}}
       @removeApplicant={{fn this.removeApplicant}}
-      @index={{index}}
       data-test-applicant-fieldset={{index}}
       data-test-applicant-type={{applicant.friendlyEntityName}}
     />

--- a/client/app/components/packages/applicant-team-editor.hbs
+++ b/client/app/components/packages/applicant-team-editor.hbs
@@ -4,6 +4,7 @@
       @elementId={{concat 'applicant-fieldset-' index}}
       @applicant={{applicant}}
       @removeApplicant={{fn this.removeApplicant}}
+      @index={{index}}
       data-test-applicant-fieldset={{index}}
       data-test-applicant-type={{applicant.friendlyEntityName}}
     />

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -11,19 +11,19 @@
         submitting the PAS, a prospective applicant acknowledges that they intend to file a land use application with NYC
         Planning. Submission allows staff to be assigned from appropriate divisions and project tracking to commence.
       </p>
-    
+
       <p>
         NYC Planning understands that some projects may not be fully formed at the submission of the PAS. Give as much
         detailed information as possible. Failure to provide detailed, relevant information will result in the PAS being
         rejected.
       </p>
-    
+
       <section class="form-section">
         <h3 class="section-header">
           <span id="project-info" class="section-anchor"></span>
           Project Information
         </h3>
-    
+
         <label>
           <strong>Project Name</strong>
           <Input
@@ -32,7 +32,7 @@
           />
         </label>
       </section>
-    
+
       <section class="form-section">
         <h3 class="section-header">
           <span id="applicant-team" class="section-anchor"></span>
@@ -110,7 +110,8 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpProposedprojectorportionconstruction}}
-                 data-test-dcpproposedprojectorportionconstruction={{radio.label}}
+                @radioId={{concat 'dcpproposedprojectorportionconstruction' radio.code}}
+                data-test-dcpproposedprojectorportionconstruction={{radio.label}}
               >
                 {{radio.label}}
               </RadioButton>
@@ -130,13 +131,14 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpUrbanrenewalarea}}
+                @radioId={{concat 'dcpurbanrenewalarea' radio.code}}
                 @changed={{fn this.validate}}
                  data-test-dcpurbanrenewalarea={{radio.label}}
               >
                 {{radio.label}}
               </RadioButton>
             {{/each}}
-  
+
             {{#if (eq this.saveableChanges.dcpUrbanrenewalarea 717170000)}}
               <label>
                 What is the name of the Urban Renewal Area?
@@ -169,6 +171,7 @@
                 <RadioButton
                   @value={{radio.code}}
                   @groupValue={{this.saveableChanges.dcpLegalstreetfrontage}}
+                  @radioId={{concat 'dcplegalstreetfrontage' radio.code}}
                   data-test-dcplegalstreetfrontage={{radio.label}}
                 >
                   {{radio.label}}
@@ -195,6 +198,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpLanduseactiontype2}}
+                @radioId={{concat 'dcplanduseactiontype2' radio.code}}
                 @changed={{fn this.validate}}
                 data-test-dcplanduseactiontype2={{radio.label}}
               >
@@ -229,6 +233,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpProjectareaindustrialbusinesszone}}
+                @radioId={{concat 'dcpprojectareaindustrialbusinesszone' radio.code}}
                 @changed={{fn this.validate}}
                 data-test-dcpprojectareaindustrialbusinesszone={{radio.label}}
               >
@@ -262,6 +267,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpIsprojectarealandmark}}
+                @radioId={{concat 'dcpisprojectarealandmark' radio.code}}
                 data-test-dcpisprojectarealandmark={{radio.label}}
               >
                 {{radio.label}}
@@ -296,6 +302,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpProjectareacoastalzonelocatedin}}
+                @radioId={{concat 'dcpprojectareacoastalzonelocatedin' radio.code}}
                 data-test-dcpprojectareacoastalzonelocatedin={{radio.label}}
               >
                 {{radio.label}}
@@ -315,6 +322,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpProjectareaischancefloodplain}}
+                @radioId={{concat 'dcpprojectareaischancefloodplain' radio.code}}
                 data-test-dcpprojectareaischancefloodplain={{radio.label}}
               >
                 {{radio.label}}
@@ -333,6 +341,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpRestrictivedeclaration}}
+                @radioId={{concat 'dcprestrictivedeclaration' radio.code}}
                 @changed={{fn this.validate}}
                 data-test-dcprestrictivedeclaration={{radio.label}}
               >
@@ -368,6 +377,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpRestrictivedeclarationrequired}}
+                @radioId={{concat 'dcprestrictivedeclarationrequired' radio.code}}
                 data-test-dcprestrictivedeclarationrequired={{radio.label}}
               >
                 {{radio.label}}
@@ -479,6 +489,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpIsinclusionaryhousingdesignatedarea}}
+                @radioId={{concat 'dcpisinclusionaryhousingdesignatedarea' radio.code}}
                 @changed={{fn this.validate}}
                 data-test-dcpisinclusionaryhousingdesignatedarea={{radio.label}}
               >
@@ -512,6 +523,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpDiscressionaryfundingforffordablehousing}}
+                @radioId={{concat 'dcpdiscressionaryfundingforffordablehousing' radio.code}}
                 @changed={{fn this.validate}}
                 data-test-dcpdiscressionaryfundingforffordablehousing={{radio.label}}
               >
@@ -533,6 +545,7 @@
                   <RadioButton
                     @value={{radio.code}}
                     @groupValue={{this.saveableChanges.dcpHousingunittype}}
+                    @radioId={{concat 'dcphousingunittype' radio.code}}
                     data-test-dcphousingunittype={{radio.label}}
                   >
                     {{radio.label}}

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -110,7 +110,6 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpProposedprojectorportionconstruction}}
-                @radioId={{concat 'dcpproposedprojectorportionconstruction' radio.code}}
                 data-test-dcpproposedprojectorportionconstruction={{radio.label}}
               >
                 {{radio.label}}
@@ -131,7 +130,6 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpUrbanrenewalarea}}
-                @radioId={{concat 'dcpurbanrenewalarea' radio.code}}
                 @changed={{fn this.validate}}
                  data-test-dcpurbanrenewalarea={{radio.label}}
               >
@@ -171,7 +169,6 @@
                 <RadioButton
                   @value={{radio.code}}
                   @groupValue={{this.saveableChanges.dcpLegalstreetfrontage}}
-                  @radioId={{concat 'dcplegalstreetfrontage' radio.code}}
                   data-test-dcplegalstreetfrontage={{radio.label}}
                 >
                   {{radio.label}}
@@ -198,7 +195,6 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpLanduseactiontype2}}
-                @radioId={{concat 'dcplanduseactiontype2' radio.code}}
                 @changed={{fn this.validate}}
                 data-test-dcplanduseactiontype2={{radio.label}}
               >
@@ -233,7 +229,6 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpProjectareaindustrialbusinesszone}}
-                @radioId={{concat 'dcpprojectareaindustrialbusinesszone' radio.code}}
                 @changed={{fn this.validate}}
                 data-test-dcpprojectareaindustrialbusinesszone={{radio.label}}
               >
@@ -267,7 +262,6 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpIsprojectarealandmark}}
-                @radioId={{concat 'dcpisprojectarealandmark' radio.code}}
                 data-test-dcpisprojectarealandmark={{radio.label}}
               >
                 {{radio.label}}
@@ -302,7 +296,6 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpProjectareacoastalzonelocatedin}}
-                @radioId={{concat 'dcpprojectareacoastalzonelocatedin' radio.code}}
                 data-test-dcpprojectareacoastalzonelocatedin={{radio.label}}
               >
                 {{radio.label}}
@@ -322,7 +315,6 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpProjectareaischancefloodplain}}
-                @radioId={{concat 'dcpprojectareaischancefloodplain' radio.code}}
                 data-test-dcpprojectareaischancefloodplain={{radio.label}}
               >
                 {{radio.label}}
@@ -341,7 +333,6 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpRestrictivedeclaration}}
-                @radioId={{concat 'dcprestrictivedeclaration' radio.code}}
                 @changed={{fn this.validate}}
                 data-test-dcprestrictivedeclaration={{radio.label}}
               >
@@ -377,7 +368,6 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpRestrictivedeclarationrequired}}
-                @radioId={{concat 'dcprestrictivedeclarationrequired' radio.code}}
                 data-test-dcprestrictivedeclarationrequired={{radio.label}}
               >
                 {{radio.label}}
@@ -489,7 +479,6 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpIsinclusionaryhousingdesignatedarea}}
-                @radioId={{concat 'dcpisinclusionaryhousingdesignatedarea' radio.code}}
                 @changed={{fn this.validate}}
                 data-test-dcpisinclusionaryhousingdesignatedarea={{radio.label}}
               >
@@ -523,7 +512,6 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpDiscressionaryfundingforffordablehousing}}
-                @radioId={{concat 'dcpdiscressionaryfundingforffordablehousing' radio.code}}
                 @changed={{fn this.validate}}
                 data-test-dcpdiscressionaryfundingforffordablehousing={{radio.label}}
               >
@@ -545,7 +533,6 @@
                   <RadioButton
                     @value={{radio.code}}
                     @groupValue={{this.saveableChanges.dcpHousingunittype}}
-                    @radioId={{concat 'dcphousingunittype' radio.code}}
                     data-test-dcphousingunittype={{radio.label}}
                   >
                     {{radio.label}}

--- a/client/app/components/project-geography.hbs
+++ b/client/app/components/project-geography.hbs
@@ -28,7 +28,6 @@
       <RadioButton
         @value={{true}}
         @groupValue={{bbl.dcpDevelopmentsite}}
-        @radioId={{concat 'bbl-development-site-yes-' bbl.dcpBblnumber}}
         @changed={{fn (mut bbl.dcpDevelopmentsite) true}}
         data-test-bbl-development-site-yes={{bbl.dcpBblnumber}}
       >
@@ -37,7 +36,6 @@
       <RadioButton
         @value={{false}}
         @groupValue={{bbl.dcpDevelopmentsite}}
-        @radioId={{concat 'bbl-development-site-no-' bbl.dcpBblnumber}}
         @changed={{fn (mut bbl.dcpDevelopmentsite) false}}
         data-test-bbl-development-site-no={{bbl.dcpBblnumber}}
       >
@@ -52,7 +50,6 @@
       <RadioButton
         @value={{true}}
         @groupValue={{bbl.dcpPartiallot}}
-        @radioId={{concat 'bbl-partial-lot-yes-' bbl.dcpBblnumber}}
         @changed={{fn (mut bbl.dcpPartiallot) true}}
         data-test-bbl-partial-lot-yes={{bbl.dcpBblnumber}}
       >
@@ -61,7 +58,6 @@
       <RadioButton
         @value={{false}}
         @groupValue={{bbl.dcpPartiallot}}
-        @radioId={{concat 'bbl-partial-lot-no-' bbl.dcpBblnumber}}
         @changed={{fn (mut bbl.dcpPartiallot) false}}
         data-test-bbl-partial-lot-no={{bbl.dcpBblnumber}}
       >

--- a/client/app/components/project-geography.hbs
+++ b/client/app/components/project-geography.hbs
@@ -28,16 +28,18 @@
       <RadioButton
         @value={{true}}
         @groupValue={{bbl.dcpDevelopmentsite}}
+        @radioId={{concat 'bbl-development-site-yes-' bbl.dcpBblnumber}}
         @changed={{fn (mut bbl.dcpDevelopmentsite) true}}
-          data-test-bbl-development-site-yes={{bbl.dcpBblnumber}}
+        data-test-bbl-development-site-yes={{bbl.dcpBblnumber}}
       >
         Yes
       </RadioButton>
       <RadioButton
         @value={{false}}
         @groupValue={{bbl.dcpDevelopmentsite}}
+        @radioId={{concat 'bbl-development-site-no-' bbl.dcpBblnumber}}
         @changed={{fn (mut bbl.dcpDevelopmentsite) false}}
-          data-test-bbl-development-site-no={{bbl.dcpBblnumber}}
+        data-test-bbl-development-site-no={{bbl.dcpBblnumber}}
       >
         No
       </RadioButton>
@@ -50,16 +52,18 @@
       <RadioButton
         @value={{true}}
         @groupValue={{bbl.dcpPartiallot}}
+        @radioId={{concat 'bbl-partial-lot-yes-' bbl.dcpBblnumber}}
         @changed={{fn (mut bbl.dcpPartiallot) true}}
-          data-test-bbl-partial-lot-yes={{bbl.dcpBblnumber}}
+        data-test-bbl-partial-lot-yes={{bbl.dcpBblnumber}}
       >
         Yes
       </RadioButton>
       <RadioButton
         @value={{false}}
         @groupValue={{bbl.dcpPartiallot}}
+        @radioId={{concat 'bbl-partial-lot-no-' bbl.dcpBblnumber}}
         @changed={{fn (mut bbl.dcpPartiallot) false}}
-          data-test-bbl-partial-lot-no={{bbl.dcpBblnumber}}
+        data-test-bbl-partial-lot-no={{bbl.dcpBblnumber}}
       >
         No
       </RadioButton>

--- a/client/app/components/radio-button.hbs
+++ b/client/app/components/radio-button.hbs
@@ -3,40 +3,26 @@
 {{!-- Disabling lint because we do not own this source code --}}
 {{!-- template-lint-disable  --}}
 
+{{radio-button-input
+  class=radioClass
+  id=radioId
+  autofocus=autofocus
+  disabled=disabled
+  name=name
+  required=required
+  tabindex=tabindex
+  groupValue=groupValue
+  value=value
+  ariaLabelledby=ariaLabelledby
+  ariaDescribedby=ariaDescribedby
+  changed=(action "changed")
+}}
 {{#if hasBlock}}
   <label
     class="ember-radio-button {{if checked checkedClass}} {{joinedClassNames}}"
     for={{radioId}}
     ...attributes
   >
-    {{radio-button-input
-        class=radioClass
-        id=radioId
-        autofocus=autofocus
-        disabled=disabled
-        name=name
-        required=required
-        tabindex=tabindex
-        groupValue=groupValue
-        value=value
-        ariaLabelledby=ariaLabelledby
-        ariaDescribedby=ariaDescribedby
-        changed=(action "changed")}}
-
     {{yield}}
   </label>
-{{else}}
-  {{radio-button-input
-      class=radioClass
-      id=radioId
-      autofocus=autofocus
-      disabled=disabled
-      name=name
-      required=required
-      tabindex=tabindex
-      groupValue=groupValue
-      value=value
-      ariaLabelledby=ariaLabelledby
-      ariaDescribedby=ariaDescribedby
-      changed=(action "changed")}}
 {{/if}}

--- a/client/app/components/radio-button.js
+++ b/client/app/components/radio-button.js
@@ -1,3 +1,6 @@
 import RadioButtonComponent from 'ember-radio-button/components/radio-button';
+import { guidFor } from '@ember/object/internals';
 
-export default RadioButtonComponent;
+export default class GroupIdentifier extends RadioButtonComponent {
+  radioId = `radio-${guidFor(this)}`;
+}

--- a/client/app/styles/modules/_pasform.scss
+++ b/client/app/styles/modules/_pasform.scss
@@ -14,7 +14,3 @@
 .action-form-label {
   margin: 0 0 1rem
 }
-
-.ember-radio-button {
-  display: inline-block;
-}


### PR DESCRIPTION
This PR refactors the `<RadioButton>` component to follow the style guide markup standards (labels following inputs instead of wrapping them). It also passes in the optional `@radioId` arg for the `{{radio-button-input}}` component to use — which associates the labels with their inputs. 