### PR TITLE
175 Display spinners during save or submit

### DIFF
--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -698,11 +698,15 @@
             type="button"
             class="button expanded large"
             disabled={{not this.isSaveable}}
-            {{on "click" this.save}}
+            {{on "click" (perform this.save)}}
             data-test-save-button
           >
             {{!-- TODO: Make this button work with the action passed in @save--}}
-            Save
+            {{#if this.save.isRunning}}
+              <FaIcon @icon="spinner" @spin="true" size="5x" class="light-gray" />
+            {{else}}
+              Save
+            {{/if}}
           </button>
           <button
             type="button"
@@ -711,8 +715,11 @@
             {{on "click" this.toggleModal}}
             data-test-submit-button
           >
-            {{!-- TODO: Disable this button if model dirty/invaild --}}
-            Submit
+            {{#if this.submit.isRunning}}
+              <FaIcon @icon="spinner" @spin="true" size="5x" class="light-gray" />
+            {{else}}
+              Submit
+            {{/if}}
           </button>
         </p>
         {{#if this.modalIsOpen}}
@@ -727,6 +734,7 @@
                   <button
                     type="button"
                     class="button large secondary no-margin"
+                    disabled={{this.submit.isRunning}}
                     {{on "click" this.toggleModal}}
                   >
                     Continue Editing
@@ -735,11 +743,16 @@
                 <div class="cell large-6 text-right">
                   <button
                     type="button"
-                    class="button large no-margin"
-                    {{on "click" (fn this.submit)}}
+                    class="button expanded large no-margin"
+                    disabled={{this.submit.isRunning}}
+                    {{on "click" (perform this.submit)}}
                     data-test-confirm-submit-button
                   >
-                    Submit
+                    {{#if this.submit.isRunning}}
+                      <FaIcon @icon="spinner" @spin="true" size="5x" class="light-gray" />
+                    {{else}}
+                      Submit
+                    {{/if}}
                   </button>
                 </div>
               </div>

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -130,7 +130,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpUrbanrenewalarea}}
-                @changed={{fn this.validate}}
+                @changed={{this.validate}}
                  data-test-dcpurbanrenewalarea={{radio.label}}
               >
                 {{radio.label}}
@@ -195,7 +195,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpLanduseactiontype2}}
-                @changed={{fn this.validate}}
+                @changed={{this.validate}}
                 data-test-dcplanduseactiontype2={{radio.label}}
               >
                 {{radio.label}}
@@ -229,7 +229,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpProjectareaindustrialbusinesszone}}
-                @changed={{fn this.validate}}
+                @changed={{this.validate}}
                 data-test-dcpprojectareaindustrialbusinesszone={{radio.label}}
               >
                 {{radio.label}}
@@ -274,7 +274,7 @@
                 <Input
                   @type="text"
                   @value={{this.saveableChanges.dcpProjectarealandmarkname}}
-                  @changed={{fn this.validate}}
+                  @changed={{this.validate}}
                   maxlength="250"
                   data-test-dcpisprojectarealandmarkname
                 />
@@ -333,7 +333,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpRestrictivedeclaration}}
-                @changed={{fn this.validate}}
+                @changed={{this.validate}}
                 data-test-dcprestrictivedeclaration={{radio.label}}
               >
                 {{radio.label}}
@@ -479,7 +479,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpIsinclusionaryhousingdesignatedarea}}
-                @changed={{fn this.validate}}
+                @changed={{this.validate}}
                 data-test-dcpisinclusionaryhousingdesignatedarea={{radio.label}}
               >
                 {{radio.label}}
@@ -512,7 +512,7 @@
               <RadioButton
                 @value={{radio.code}}
                 @groupValue={{this.saveableChanges.dcpDiscressionaryfundingforffordablehousing}}
-                @changed={{fn this.validate}}
+                @changed={{this.validate}}
                 data-test-dcpdiscressionaryfundingforffordablehousing={{radio.label}}
               >
                 {{radio.label}}

--- a/client/app/components/packages/pas-form/edit.js
+++ b/client/app/components/packages/pas-form/edit.js
@@ -3,6 +3,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { Changeset } from 'ember-changeset';
 import lookupValidator from 'ember-changeset-validations';
+import { task } from 'ember-concurrency';
 import SaveablePasFormValidations from '../../../validations/saveable-pas-form';
 import SubmittablePasFormValidations from '../../../validations/submittable-pas-form';
 
@@ -57,26 +58,32 @@ export default class PasFormComponent extends Component {
       isApplicantsDirty,
     } = this.pasForm;
 
-    return (isPasFormDirty && isPasFormValid) || isBblsDirty || isApplicantsDirty;
+    return !this.isUpdatingDb && ((isPasFormDirty && isPasFormValid) || isBblsDirty || isApplicantsDirty);
   }
 
   get isSubmittable() {
-    return this.submittableChanges.isValid;
+    return !this.isUpdatingDb && this.submittableChanges.isValid;
   }
 
-  @action
-  async save() {
-    await this.saveableChanges.save();
-
-    this.args.onSave();
+  get isUpdatingDb() {
+    return this.save.isRunning || this.submit.isRunning;
   }
 
-  @action
-  async submit() {
-    await this.submittableChanges.save();
+  @task(function* () {
+    yield this.saveableChanges.execute();
+    yield this.saveableChanges.rollback();
 
-    this.args.onSubmit();
-  }
+    yield this.args.onSave();
+  })
+  save;
+
+  @task(function* () {
+    yield this.submittableChanges.execute();
+    yield this.submittableChanges.rollback();
+
+    yield this.args.onSubmit();
+  })
+  submit;
 
   @action
   validate() {
@@ -87,6 +94,8 @@ export default class PasFormComponent extends Component {
 
   @action
   toggleModal() {
-    this.modalIsOpen = !this.modalIsOpen;
+    if (!this.save.isRunning) {
+      this.modalIsOpen = !this.modalIsOpen;
+    }
   }
 }

--- a/client/app/components/packages/pas-form/show.hbs
+++ b/client/app/components/packages/pas-form/show.hbs
@@ -5,7 +5,9 @@
         Project Information
       </h3>
 
-      <p>
+      <p
+        data-test-show-dcprevisedprojectname
+      >
         <strong>
           Project Name
         </strong>

--- a/client/app/controllers/packages/edit.js
+++ b/client/app/controllers/packages/edit.js
@@ -3,13 +3,13 @@ import { action } from '@ember/object';
 
 export default class PackagesEditController extends Controller {
   @action
-  savePackage() {
-    this.model.saveDescendants();
+  async savePackage() {
+    await this.model.saveDescendants();
   }
 
   @action
-  submitPackage() {
-    this.model.submit();
+  async submitPackage() {
+    await this.model.submit();
 
     this.transitionToRoute('packages.show', this.model.id);
   }

--- a/client/package.json
+++ b/client/package.json
@@ -45,6 +45,7 @@
     "ember-cli-sass": "^10.0.1",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-uglify": "^3.0.0",
+    "ember-concurrency": "^1.1.7",
     "ember-data": "~3.17.0",
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^7.0.1",

--- a/client/tests/acceptance/user-can-click-package-edit-test.js
+++ b/client/tests/acceptance/user-can-click-package-edit-test.js
@@ -4,6 +4,7 @@ import {
   click,
   currentURL,
   settled,
+  waitFor,
 } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -34,11 +35,17 @@ module('Acceptance | user can click package edit', function(hooks) {
     await visit('/projects');
     await click('[data-test-project="edit-pas"]');
     await click('[data-test-save-button]');
+
+    await waitFor('[data-test-submit-button]:not([disabled])');
     await click('[data-test-submit-button]');
     await click('[data-test-confirm-submit-button]');
 
     // for some reason promises aren't being captured so we await for settled state
     await settled();
+
+    // use waitFor as a way to "wait" for the transition
+    // within the pas-form/edit Component submit() task
+    await waitFor('[data-test-show-dcprevisedprojectname]');
 
     assert.equal(currentURL(), '/packages/1');
   });


### PR DESCRIPTION
A spinner is displayed on respective buttons during save or submit.
This commit also syncs the button disabled state and spinner state.

It also removes a duplicate call to pasForm.save() by calling pasForm changesets' execute() -- instead of save() --  before calling package.saveDescendents(), which will call pasForm.save() anyway. 

changeset.execute() moves the Changeset changes down to the underlying model.

For next PR: 
 - disable form inputs when saving or submitting 