### PR TITLE
168: add styling, functionality, and tests for pas-form visual error handling

### DIFF
--- a/client/app/components/packages/pas-form-error.hbs
+++ b/client/app/components/packages/pas-form-error.hbs
@@ -9,7 +9,7 @@
         There was a problem saving your information.
     </h5>
       {{#each @pasForm.adapterError.errors as |error|}}
-        <p class="font-mono text-red-dark bg-red-white small-padding text-small" data-test-error-message>{{error.message}}</p>
+        <p class="font-mono text-red-dark bg-red-white small-padding text-small" data-test-error-message>{{error.details}}</p>
       {{/each}}
       <p class="text-red-dark text-small">
         Please try again. If the problem persists, please contact City Planning at <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or <a href="tel:212-720-3300" class="nowrap">212-720-3300</a>.

--- a/client/app/components/packages/pas-form-error.hbs
+++ b/client/app/components/packages/pas-form-error.hbs
@@ -1,0 +1,18 @@
+{{#if @pasForm.adapterError}}
+  <div class="callout alert" data-test-error-saving>
+    <h5 class="text-red-dark">
+      <FaIcon
+      @icon="exclamation-circle"
+      @size="2x"
+      class="text-red float-left medium-margin-right tiny-margin-top"
+      />
+        There was a problem saving your information.
+    </h5>
+      {{#each @pasForm.adapterError.errors as |error|}}
+        <p class="font-mono text-red-dark bg-red-white small-padding text-small" data-test-error-message>{{error.message}}</p>
+      {{/each}}
+      <p class="text-red-dark text-small">
+        Please try again. If the problem persists, please contact City Planning at <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or <a href="tel:212-720-3300" class="nowrap">212-720-3300</a>.
+      </p>
+  </div>
+{{/if}}

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -711,6 +711,8 @@
           @isSaved={{and (not this.isSaveable) (not this.save.isRunning)}}
           data-test-save-button
         />
+        {{!-- Error Handling --}}
+        <Packages::PasFormError @pasForm={{this.pasForm}}/>
         <Packages::SaveButton
           @onClick={{this.toggleModal}}
           @isEnabled={{this.isSubmittable}}
@@ -730,7 +732,7 @@
                 <div class="cell large-6">
                   <button
                     type="button"
-                    class="button large secondary no-margin"
+                    class="button large secondary"
                     disabled={{this.submit.isRunning}}
                     {{on "click" this.toggleModal}}
                   >
@@ -748,9 +750,12 @@
                   />
                 </div>
               </div>
+              {{!-- Error Handling --}}
+              <Packages::PasFormError @pasForm={{this.pasForm}}/>
             </RevealModal>
           </EmberWormhole>
         {{/if}}
+
         <nav>
           <ul class="no-bullet text-weight-bold">
             <li class="medium-margin-bottom">

--- a/client/app/components/packages/pas-form/edit.js
+++ b/client/app/components/packages/pas-form/edit.js
@@ -78,18 +78,30 @@ export default class PasFormComponent extends Component {
   }
 
   @task(function* () {
-    yield this.saveableChanges.execute();
-    yield this.saveableChanges.rollback();
+    try {
+      // in case there are errors on saving/patching,
+      // this should occur BEFORE the changeset executions & rollbacks
+      yield this.args.onSave();
 
-    yield this.args.onSave();
+      yield this.saveableChanges.execute();
+      yield this.saveableChanges.rollback();
+    } catch (adapterError) {
+      console.log('Save error:', adapterError);
+    }
   })
   save;
 
   @task(function* () {
-    yield this.submittableChanges.execute();
-    yield this.submittableChanges.rollback();
+    try {
+      // in case there are errors on saving/patching,
+      // this should occur BEFORE the changeset executions & rollbacks
+      yield this.args.onSubmit();
 
-    yield this.args.onSubmit();
+      yield this.submittableChanges.execute();
+      yield this.submittableChanges.rollback();
+    } catch (adapterError) {
+      console.log('Submit error:', adapterError);
+    }
   })
   submit;
 

--- a/client/tests/acceptance/error-message-appears-when-save-fails-test.js
+++ b/client/tests/acceptance/error-message-appears-when-save-fails-test.js
@@ -27,7 +27,7 @@ module('Acceptance | error message appears when save fails', function(hooks) {
       pasForm: this.server.create('pas-form'),
     });
 
-    this.server.patch('/pas-forms/:id', { errors: [{ message: 'server problem' }] }, 500); // force mirage to error
+    this.server.patch('/pas-forms/:id', { errors: [{ detail: 'server problem' }] }, 500); // force mirage to error
 
     await visit('/packages/1/edit');
 
@@ -64,7 +64,7 @@ module('Acceptance | error message appears when save fails', function(hooks) {
       }),
     });
 
-    this.server.patch('/pas-forms/:id', { errors: [{ message: 'server problem' }] }, 500); // force mirage to error
+    this.server.patch('/pas-forms/:id', { errors: [{ detail: 'server problem' }] }, 500); // force mirage to error
 
     await visit('/packages/1/edit');
 
@@ -72,7 +72,6 @@ module('Acceptance | error message appears when save fails', function(hooks) {
 
     await click('[data-test-submit-button]');
     await click('[data-test-confirm-submit-button]');
-    await settled(); // async make sure submit action finishes
 
     await waitFor('[data-test-error-message]');
 

--- a/client/tests/acceptance/error-message-appears-when-save-fails-test.js
+++ b/client/tests/acceptance/error-message-appears-when-save-fails-test.js
@@ -1,0 +1,84 @@
+import { module, test } from 'qunit';
+import {
+  visit,
+  click,
+  settled,
+  fillIn,
+  currentURL,
+  waitFor,
+} from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+
+module('Acceptance | error message appears when save fails', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(() => {
+    authenticateSession({
+      emailaddress1: 'me@me.com',
+    });
+  });
+
+  test('error message appears when error occurs on save', async function(assert) {
+    this.server.create('package', {
+      project: this.server.create('project'),
+      pasForm: this.server.create('pas-form'),
+    });
+
+    this.server.patch('/pas-forms/:id', { errors: [{ message: 'server problem' }] }, 500); // force mirage to error
+
+    await visit('/packages/1/edit');
+
+    assert.dom('[data-test-error-message]').doesNotExist();
+
+    await fillIn('[data-test-dcprevisedprojectname]', 'Some Cool New Project Name');
+
+    // save it
+    await click('[data-test-save-button]');
+    await settled(); // async make sure save action finishes before assertion
+
+    await waitFor('[data-test-error-message]');
+
+    assert.dom('[data-test-error-message]').exists();
+
+    // check that model was not saved
+    assert.equal(this.server.db.pasForms[0].dcpRevisedprojectname, undefined);
+  });
+
+  test('error message appears when error occurs on submit', async function(assert) {
+    // all required fields are filled for submitting
+    this.server.create('package', {
+      project: this.server.create('project'),
+      pasForm: this.server.create('pas-form', {
+        dcpRevisedprojectname: 'project name',
+        applicants: [
+          this.server.create('applicant', {
+            dcpFirstname: 'first name',
+            dcpLastname: 'last name',
+            dcpEmail: 'email',
+            dcpType: '717170000',
+          }),
+        ],
+      }),
+    });
+
+    this.server.patch('/pas-forms/:id', { errors: [{ message: 'server problem' }] }, 500); // force mirage to error
+
+    await visit('/packages/1/edit');
+
+    assert.dom('[data-test-error-message]').doesNotExist();
+
+    await click('[data-test-submit-button]');
+    await click('[data-test-confirm-submit-button]');
+    await settled(); // async make sure submit action finishes
+
+    await waitFor('[data-test-error-message]');
+
+    assert.dom('[data-test-error-message]').exists();
+
+    // make sure route did not transition
+    assert.equal(currentURL(), '/packages/1/edit');
+  });
+});

--- a/client/tests/integration/components/packages/pas-form-error-test.js
+++ b/client/tests/integration/components/packages/pas-form-error-test.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Integration | Component | pas-form-error', function(hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  test('it renders', async function(assert) {
+    await render(hbs`<Packages::PasFormError />`);
+
+    assert.equal(this.element.textContent.trim(), '');
+  });
+});


### PR DESCRIPTION
Error handling on save and submit buttons of pas-form. 

Might run into conflicts with loading spinner branch, will resolve when that's merged

Addresses #168 