### PR TITLE
View files

### DIFF
--- a/client/app/components/packages/attachments.hbs
+++ b/client/app/components/packages/attachments.hbs
@@ -15,7 +15,9 @@
           <div class="grid-x">
             <div class="cell small-8">
               <a
-                href="#"
+                href={{concat (get-env-variable 'host') '/documents' file.serverRelativeUrl}}
+                target="_blank"
+                rel="noopener noreferrer"
                 data-test-document-name={{idx}}
               >
                 {{file.name}}

--- a/client/app/helpers/get-env-variable.js
+++ b/client/app/helpers/get-env-variable.js
@@ -1,0 +1,10 @@
+import { helper } from '@ember/component/helper';
+import { get } from '@ember/object';
+import ENV from '../config/environment';
+
+export default helper(([path], hash) => {
+  // allow override for testing
+  const targetEnv = hash.environment || ENV;
+
+  return get(targetEnv, path);
+});

--- a/client/tests/integration/helpers/get-env-variable-test.js
+++ b/client/tests/integration/helpers/get-env-variable-test.js
@@ -1,0 +1,18 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | get-env-variable', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // Replace this with your real tests.
+  test('it renders', async function(assert) {
+    this.set('inputValue', 'key');
+    this.environment = { key: 'value' };
+
+    await render(hbs`{{get-env-variable inputValue environment=environment}}`);
+
+    assert.equal(this.element.textContent.trim(), 'value');
+  });
+});

--- a/server/src/crm/crm.service.ts
+++ b/server/src/crm/crm.service.ts
@@ -456,6 +456,25 @@ export class CrmService {
     })
   }
 
+  async getSharepointFile(serverRelativeUrl): Promise<any> {
+    const { access_token } = await this.generateSharePointAccessToken();
+    const SHAREPOINT_CRM_SITE = this.config.get('SHAREPOINT_CRM_SITE');
+
+    // see https://docs.microsoft.com/en-us/previous-versions/office/sharepoint-server/dn775742(v=office.15)
+    const url = `https://nyco365.sharepoint.com/sites/${SHAREPOINT_CRM_SITE}/_api/web/GetFileByServerRelativeUrl('/${serverRelativeUrl}')/$value?binaryStringResponseBody=true`;
+
+    const options = {
+      url,
+      headers: {
+        'Authorization': `Bearer ${access_token}`,
+      },
+    };
+
+    // this returns a pipeable stream
+    return Request.get(options)
+      .on('error', (e) => console.log(e));
+  }
+
   async deleteSharepointFile(serverRelativeUrl): Promise<any> {
     const { access_token } = await this.generateSharePointAccessToken();
     const SHAREPOINT_CRM_SITE = this.config.get('SHAREPOINT_CRM_SITE');

--- a/server/src/document/document.controller.ts
+++ b/server/src/document/document.controller.ts
@@ -9,6 +9,9 @@ import {
   Delete,
   Query,
   HttpCode,
+  Param,
+  Get,
+  Res,
 } from '@nestjs/common';
 import { ConfigService } from '../config/config.service';
 import { CrmService } from '../crm/crm.service';
@@ -67,5 +70,16 @@ export class DocumentController {
   @HttpCode(204)
   async destroy(@Query('serverRelativeUrl') serverRelativeUrl) {
     return this.crmService.deleteSharepointFile(serverRelativeUrl);
+  }
+
+  // "path" refers to the "relative server path", the path
+  // to the file itself on the sharepoint host. for example,
+  // /sites/dcpuat2/.../filename.png
+  @Get('/*')
+  async read(@Param() path, @Res() res) {
+    const pathSegment = path[0];
+    const stream = await this.crmService.getSharepointFile(pathSegment);
+
+    stream.pipe(res);
   }
 }


### PR DESCRIPTION
This PR provides handling for the get method on the /documents resource, which takes a sharepoint relative server URL, retrieves the file, and pipes it to the user.

This is not a shareable URL and may be too memory intensive but probably isn't an issue unless we expect hundreds of simultaneous downloads.

This also adds some helpers that generate deep links to CRM entities from models