### PR TITLE
235: update new and existing actions arrays to assure actions are not double counted

### DIFF
--- a/client/app/components/land-use-action.hbs
+++ b/client/app/components/land-use-action.hbs
@@ -23,7 +23,7 @@
     </legend>
     <label class="action-form-label">
     How many {{landUseAction.name}} actions?
-      <ActionFormInput @pasForm={{@pasForm}} @fieldType="number" @landUseActionField={{landUseAction.field}}/>
+      <ActionFormInput @pasForm={{@pasForm}} @fieldType="number" @landUseActionField={{landUseAction.countField}}/>
     </label>
     {{#if (or (eq landUseAction.name "Zoning Special Permit") (eq landUseAction.name "Zoning Certification") (eq landUseAction.name "Zoning Authorization"))}}
       <label class="action-form-label">

--- a/client/app/components/land-use-action.js
+++ b/client/app/components/land-use-action.js
@@ -2,6 +2,64 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
+// lookup to match action titles to their associated attributes
+export const allLandUseActionOptions = [
+  {
+    name: 'Acquisition of Real Property', countField: 'dcpPfacquisitionofrealproperty', attr1: '', attr2: '',
+  },
+  {
+    name: 'Change in CityMap', countField: 'dcpPfchangeincitymap', attr1: '', attr2: '',
+  },
+  {
+    name: 'Concession', countField: 'dcpPfconcession', attr1: '', attr2: '',
+  },
+  {
+    name: 'Disposition of Real Property', countField: 'dcpPfdispositionofrealproperty', attr1: '', attr2: '',
+  },
+  {
+    name: 'Franchise', countField: 'dcpPffranchise', attr1: '', attr2: '',
+  },
+  {
+    name: 'Housing Plan & Project', countField: 'dcpPfhousingplanandproject', attr1: '', attr2: '',
+  },
+  {
+    name: 'Landfill', countField: 'dcpPflandfill', attr1: '', attr2: '',
+  },
+  {
+    name: 'Modification', countField: 'dcpPfmodification', attr1: 'dcpPreviousulurpnumbers1', attr2: '',
+  },
+  {
+    name: 'Renewal', countField: 'dcpPfrenewal', attr1: 'dcpPreviousulurpnumbers2', attr2: '',
+  },
+  {
+    name: 'Revocable Consent', countField: 'dcpPfrevocableconsent', attr1: '', attr2: '',
+  },
+  {
+    name: 'Site Selection - Public Facility', countField: 'dcpPfsiteselectionpublicfacility', attr1: '', attr2: '',
+  },
+  {
+    name: 'UDAAP', countField: 'dcpPfudaap', attr1: '', attr2: '',
+  },
+  {
+    name: 'URA', countField: 'dcpPfura', attr1: '', attr2: '',
+  },
+  {
+    name: 'Zoning Authorization', countField: 'dcpPfzoningauthorization', attr1: 'dcpZoningauthorizationpursuantto', attr2: 'dcpZoningauthorizationtomodify',
+  },
+  {
+    name: 'Zoning Certification', countField: 'dcpPfzoningcertification', attr1: 'dcpZoningpursuantto', attr2: 'dcpZoningtomodify',
+  },
+  {
+    name: 'Zoning Map Amendment', countField: 'dcpPfzoningmapamendment', attr1: 'dcpExistingmapamend', attr2: 'dcpProposedmapamend',
+  },
+  {
+    name: 'Zoning Special Permit', countField: 'dcpPfzoningspecialpermit', attr1: 'dcpZoningspecialpermitpursuantto', attr2: 'dcpZoningspecialpermittomodify',
+  },
+  {
+    name: 'Zoning Text Amendment', countField: 'dcpPfzoningtextamendment', attr1: 'dcpAffectedzrnumber', attr2: 'dcpZoningresolutiontitle',
+  },
+];
+
 export default class LandUseActionComponent extends Component {
   // local variable that records results of dropdown selection
   @tracked selectedLandUseAction = {};
@@ -9,82 +67,28 @@ export default class LandUseActionComponent extends Component {
   // actions selected by user in dropdown
   @tracked newLandUseActionSelections = [];
 
-  // lookup to match action titles to their associated attributes
-  allLandUseActionOptions = [
-    {
-      name: 'Acquisition of Real Property', field: 'dcpPfacquisitionofrealproperty', attr1: '', attr2: '',
-    },
-    {
-      name: 'Change in CityMap', field: 'dcpPfchangeincitymap', attr1: '', attr2: '',
-    },
-    {
-      name: 'Concession', field: 'dcpPfconcession', attr1: '', attr2: '',
-    },
-    {
-      name: 'Disposition of Real Property', field: 'dcpPfdispositionofrealproperty', attr1: '', attr2: '',
-    },
-    {
-      name: 'Franchise', field: 'dcpPffranchise', attr1: '', attr2: '',
-    },
-    {
-      name: 'Housing Plan & Project', field: 'dcpPfhousingplanandproject', attr1: '', attr2: '',
-    },
-    {
-      name: 'Landfill', field: 'dcpPflandfill', attr1: '', attr2: '',
-    },
-    {
-      name: 'Modification', field: 'dcpPfmodification', attr1: 'dcpPreviousulurpnumbers1', attr2: '',
-    },
-    {
-      name: 'Renewal', field: 'dcpPfrenewal', attr1: 'dcpPreviousulurpnumbers2', attr2: '',
-    },
-    {
-      name: 'Revocable Consent', field: 'dcpPfrevocableconsent', attr1: '', attr2: '',
-    },
-    {
-      name: 'Site Selection - Public Facility', field: 'dcpPfsiteselectionpublicfacility', attr1: '', attr2: '',
-    },
-    {
-      name: 'UDAAP', field: 'dcpPfudaap', attr1: '', attr2: '',
-    },
-    {
-      name: 'URA', field: 'dcpPfura', attr1: '', attr2: '',
-    },
-    {
-      name: 'Zoning Authorization', field: 'dcpPfzoningauthorization', attr1: 'dcpZoningauthorizationpursuantto', attr2: 'dcpZoningauthorizationtomodify',
-    },
-    {
-      name: 'Zoning Certification', field: 'dcpPfzoningcertification', attr1: 'dcpZoningpursuantto', attr2: 'dcpZoningtomodify',
-    },
-    {
-      name: 'Zoning Map Amendment', field: 'dcpPfzoningmapamendment', attr1: 'dcpExistingmapamend', attr2: 'dcpProposedmapamend',
-    },
-    {
-      name: 'Zoning Special Permit', field: 'dcpPfzoningspecialpermit', attr1: 'dcpZoningspecialpermitpursuantto', attr2: 'dcpZoningspecialpermittomodify',
-    },
-    {
-      name: 'Zoning Text Amendment', field: 'dcpPfzoningtextamendment', attr1: 'dcpAffectedzrnumber', attr2: 'dcpZoningresolutiontitle',
-    },
-  ];
-
   // Actions with partial or complete answers already saved
   // to the PAS Form Entity in CRM
   get existingLandUseActionSelections() {
     const { pasForm } = this.args;
-    return this.allLandUseActionOptions.filter((option) => pasForm[option.field] || pasForm[option.attr1] || pasForm[option.attr2]);
+    return allLandUseActionOptions.filter((option) => pasForm[option.countField] || pasForm[option.attr1] || pasForm[option.attr2]);
   }
 
-  // Actions selected by user in dropdown, or already
-  // existing in CRM
+  // Actions selected by user in dropdown ("new"), or already
+  // existing in CRM ("existing")
   get landUseActionSelections() {
+    const { pasForm } = this.args;
+    // Filter the "new" actions array so that the action does not exist on BOTH the "exisiting" and "new" arrays,
+    // when user enters a value in the action inputs (and therefore updates the model)
+    const filteredNewActions = this.newLandUseActionSelections.filter((action) => !pasForm[action.countField] && !pasForm[action.attr1] && !pasForm[action.attr2]);
     return [
       ...this.existingLandUseActionSelections,
-      ...this.newLandUseActionSelections,
+      ...filteredNewActions,
     ];
   }
 
   get availableLandUseActionOptions() {
-    return this.allLandUseActionOptions.filter((option) => !this.landUseActionSelections.includes(option));
+    return allLandUseActionOptions.filter((option) => !this.landUseActionSelections.includes(option));
   }
 
   get sortedAvailableLandUseActionOptions() {
@@ -92,30 +96,30 @@ export default class LandUseActionComponent extends Component {
   }
 
   // when a user selects an option from the dropdown menu,
-  // the option is removed from the landUseActionOptions
+  // the option is filtered out of the availableLandUseActionOptions
   // (and therefore removed from the dropdown).
   // The selected option is added to the newLandUseActionSelections array
   // (and therefore displays in the list of selected actions).
   @action
   addNewLandUseActionSelection() {
-    // use unshiftObject to place new action at top of list
-    const selection = this.selectedLandUseAction.field;
+    const selection = this.selectedLandUseAction.countField;
 
     if (selection) {
-      this.newLandUseActionSelections.unshiftObject(this.selectedLandUseAction);
+      this.newLandUseActionSelections.pushObject(this.selectedLandUseAction);
       this.selectedLandUseAction = {};
     }
   }
 
   // When a user deletes an action, the associated fields are reset as well.
-  // The selected action option is added back to the landUseActionOptions arrays
-  // (and therefore added back to the dropdown).
+  // Because the action is removed from landUseActionSelections, it is no
+  // longer filtered out of availableLandUseActionOptions array
+  // (and therefore exists in the dropdown).
   @action
   removeSelectedAction(actionToRemove) {
     const { pasForm } = this.args;
 
-    this.newLandUseActionSelections.removeObject(actionToRemove);
-    pasForm[actionToRemove.field] = 0;
+    this.landUseActionSelections.removeObject(actionToRemove);
+    pasForm[actionToRemove.countField] = 0;
     pasForm[actionToRemove.attr1] = '';
     pasForm[actionToRemove.attr2] = '';
   }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -5473,7 +5473,7 @@ ember-concurrency@0.9.0:
     ember-compatibility-helpers "^1.2.0"
     ember-maybe-import-regenerator "^0.1.5"
 
-"ember-concurrency@^0.8.27 || ^0.9.0 || ^0.10.0 || ^1.0.0", ember-concurrency@^1.1.0:
+"ember-concurrency@^0.8.27 || ^0.9.0 || ^0.10.0 || ^1.0.0", ember-concurrency@^1.1.0, ember-concurrency@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-1.1.7.tgz#b3f0c0478db1096503499d39e1b263c575cd52ef"
   integrity sha512-PtEJvB4wG8e5CEHRC9ILl2BxF6U/xlMOhfCji/x7FxNFB9M230Du86LAy+4/yOozZHyoARVuazABPUj02P+DmQ==


### PR DESCRIPTION
**Bug fix**:

In the landUseAction component --> previously, when a user would enter a value into one of the action inputs (and therefore the field was set on the model), the action was added to the "existing" actions array, meanwhile it still also existed on the "new" actions array, meaning it showed up twice in the UI.

This PR filters the "new" actions array so that actions that have fields set on the model will be filtered out of that array, avoiding these actions being double counted.

**This PR also:**
- updated the property names in `allLandUseActionOptions`
- moved `allLandUseActionOptions` to be an exported constant

Addresses #235 