### PR TITLE
Save-button component

### DIFF
--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -693,14 +693,14 @@
     <div class="cell large-4">
 
       <div class="sticky-sidebar">
-        <Packages::save-button
+        <Packages::SaveButton
           @clickEvent={{perform this.save}}
           @isEnabled={{this.isSaveable}}
           @isRunning={{this.save.isRunning}}
           @isSaved={{and (not this.isSaveable) (not this.save.isRunning)}}
           data-test-save-button
         />
-        <Packages::save-button
+        <Packages::SaveButton
           @clickEvent={{this.toggleModal}}
           @isEnabled={{this.isSubmittable}}
           @isRunning={{this.submit.isRunning}}
@@ -727,7 +727,7 @@
                   </button>
                 </div>
                 <div class="cell large-6 text-right">
-                  <Packages::save-button
+                  <Packages::SaveButton
                     @clickEvent={{perform this.submit}}
                     @isEnabled={{not this.submit.isRunning}}
                     @isRunning={{this.submit.isRunning}}

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -693,35 +693,21 @@
     <div class="cell large-4">
 
       <div class="sticky-sidebar">
-        <p>
-          <button
-            type="button"
-            class="button expanded large"
-            disabled={{not this.isSaveable}}
-            {{on "click" (perform this.save)}}
-            data-test-save-button
-          >
-            {{!-- TODO: Make this button work with the action passed in @save--}}
-            {{#if this.save.isRunning}}
-              <FaIcon @icon="spinner" @spin="true" size="5x" class="light-gray" />
-            {{else}}
-              Save
-            {{/if}}
-          </button>
-          <button
-            type="button"
-            class="button expanded large secondary"
-            disabled={{not this.isSubmittable}}
-            {{on "click" this.toggleModal}}
-            data-test-submit-button
-          >
-            {{#if this.submit.isRunning}}
-              <FaIcon @icon="spinner" @spin="true" size="5x" class="light-gray" />
-            {{else}}
-              Submit
-            {{/if}}
-          </button>
-        </p>
+        <Packages::save-button
+          @clickEvent={{perform this.save}}
+          @isEnabled={{this.isSaveable}}
+          @isRunning={{this.save.isRunning}}
+          @isSaved={{and (not this.isSaveable) (not this.save.isRunning)}}
+          data-test-save-button
+        />
+        <Packages::save-button
+          @clickEvent={{this.toggleModal}}
+          @isEnabled={{this.isSubmittable}}
+          @isRunning={{this.submit.isRunning}}
+          @isSubmit={{true}}
+          class="secondary"
+          data-test-submit-button
+        />
         {{#if this.modalIsOpen}}
           <EmberWormhole @to="reveal-modal-container">
             <RevealModal @toggle={{this.toggleModal}}>
@@ -741,19 +727,14 @@
                   </button>
                 </div>
                 <div class="cell large-6 text-right">
-                  <button
-                    type="button"
-                    class="button expanded large no-margin"
-                    disabled={{this.submit.isRunning}}
-                    {{on "click" (perform this.submit)}}
+                  <Packages::save-button
+                    @clickEvent={{perform this.submit}}
+                    @isEnabled={{not this.submit.isRunning}}
+                    @isRunning={{this.submit.isRunning}}
+                    @isSubmit={{true}}
+                    class="no-margin"
                     data-test-confirm-submit-button
-                  >
-                    {{#if this.submit.isRunning}}
-                      <FaIcon @icon="spinner" @spin="true" size="5x" class="light-gray" />
-                    {{else}}
-                      Submit
-                    {{/if}}
-                  </button>
+                  />
                 </div>
               </div>
             </RevealModal>

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -694,14 +694,14 @@
 
       <div class="sticky-sidebar">
         <Packages::SaveButton
-          @clickEvent={{perform this.save}}
+          @onClick={{perform this.save}}
           @isEnabled={{this.isSaveable}}
           @isRunning={{this.save.isRunning}}
           @isSaved={{and (not this.isSaveable) (not this.save.isRunning)}}
           data-test-save-button
         />
         <Packages::SaveButton
-          @clickEvent={{this.toggleModal}}
+          @onClick={{this.toggleModal}}
           @isEnabled={{this.isSubmittable}}
           @isRunning={{this.submit.isRunning}}
           @isSubmit={{true}}
@@ -728,7 +728,7 @@
                 </div>
                 <div class="cell large-6 text-right">
                   <Packages::SaveButton
-                    @clickEvent={{perform this.submit}}
+                    @onClick={{perform this.submit}}
                     @isEnabled={{not this.submit.isRunning}}
                     @isRunning={{this.submit.isRunning}}
                     @isSubmit={{true}}

--- a/client/app/components/packages/save-button.hbs
+++ b/client/app/components/packages/save-button.hbs
@@ -2,7 +2,7 @@
   type="button"
   class="button expanded large {{if @isSaved 'button--saved'}}"
   disabled={{not @isEnabled}}
-  {{on "click" @clickEvent}}
+  {{on "click" @onClick}}
   ...attributes
 >
   {{#if @isRunning}}

--- a/client/app/components/packages/save-button.hbs
+++ b/client/app/components/packages/save-button.hbs
@@ -1,0 +1,17 @@
+<button
+  type="button"
+  class="button expanded large {{if @isSaved 'button--saved'}}"
+  disabled={{not @isEnabled}}
+  {{on "click" @clickEvent}}
+  ...attributes
+>
+  {{#if @isRunning}}
+    <FaIcon @icon="spinner" @spin={{true}} @pulse={{true}} class="small-margin-right" />
+    {{if @isSubmit 'Submitting' 'Saving'}}
+  {{else if @isSaved}}
+    <FaIcon @icon="check" class="small-margin-right" />
+    {{if @isSubmit 'Submitted' 'Saved'}}
+  {{else}}
+    {{if @isSubmit 'Submit' 'Save'}}
+  {{/if}}
+</button>

--- a/client/app/styles/app.scss
+++ b/client/app/styles/app.scss
@@ -76,3 +76,8 @@ $sticky-sidebar-offset: 6rem + rem-calc(20);
   padding: 0.4em;
   padding-right: 0;
 }
+
+.button.button--saved {
+  opacity: 1 !important;
+  background-color: $green-muted !important;
+}


### PR DESCRIPTION
This PR adds a `<Packages::save-button />` component for the save and submit buttons, which now visually indicate to the user that the save action was successful. 

![image](https://user-images.githubusercontent.com/409279/81875318-03aeda80-954e-11ea-87a9-27ef0f0fc800.png)
