### PR TITLE
171, 211, 164: improved instructions and hyperlinks

### DIFF
--- a/client/app/components/land-use-action.hbs
+++ b/client/app/components/land-use-action.hbs
@@ -14,6 +14,9 @@
     </PowerSelect>
   </label>
 </div>
+{{#if this.landUseActionSelections}}
+  <h5>Land Use Actions Included in This Project</h5>
+{{/if}}
 {{#each this.landUseActionSelections as |landUseAction|}}
   <fieldset class="fieldset relative">
     <legend>

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -58,6 +58,9 @@
 
           <label>
             <strong>Description of geography</strong>
+            <p class="help-text">
+              Fill in if the project area and/or development site is irregular, especially large, or does not consist of tax lots.
+            </p>
             <Textarea
               @value={{this.saveableChanges.dcpDescriptionofprojectareageography}}
               maxlength="2000"
@@ -119,7 +122,7 @@
 
           <fieldset class="medium-margin-bottom">
             <legend>
-              <strong>Is the proposed Project Area located in a current or former <a href="https://www1.nyc.gov/site/hpd/services-and-information/urban-renewal.page">Urban Renewal Area</a>?</strong>
+              <strong>Is the proposed Project Area located in a current or former <a href="https://www1.nyc.gov/site/hpd/services-and-information/urban-renewal.page" target="_blank" rel="noopener noreferrer">Urban Renewal Area &nbsp;<FaIcon @icon="external-link-alt" @prefix="fas" @fixedWidth={{true}}/></a>?</strong>
             </legend>
 
             {{#each (array
@@ -156,7 +159,7 @@
 
           <fieldset class="medium-margin-bottom">
             <legend>
-              <strong>What is the <a href="https://streets.planning.nyc.gov/about">Legal Street Frontage Status in the Project Area</a>?</strong>
+              <strong>What is the <a href="https://streets.planning.nyc.gov/about" target="_blank" rel="noopener noreferrer">Legal Street Frontage Status in the Project Area &nbsp;<FaIcon @icon="external-link-alt" @prefix="fas" @fixedWidth={{true}}/></a>?</strong>
             </legend>
             {{#each (array
                 (hash code=717170000 label='Mapped and Build')
@@ -181,8 +184,10 @@
             <legend>
               <strong>Do all land use actions meet&nbsp;
                 <a
-                  href="https://govt.westlaw.com/nycrr/Document/I4ec3a767cd1711dda432a117e6e0f345?viewType=FullText&originationContext=documenttoc&transitionType=CategoryPageItem&contextData=(sc.Default)">
-                  SEQRA or CEQR criteria&nbsp;
+                  href="https://govt.westlaw.com/nycrr/Document/I4ec3a767cd1711dda432a117e6e0f345?viewType=FullText&originationContext=documenttoc&transitionType=CategoryPageItem&contextData=(sc.Default)"
+                  target="_blank"
+                  rel="noopener noreferrer">
+                  SEQRA or CEQR criteria&nbsp;<FaIcon @icon="external-link-alt" @prefix="fas" @fixedWidth={{true}}/>
                 </a>
                 for Type II status?
               </strong>
@@ -220,7 +225,7 @@
 
           <fieldset class="medium-margin-bottom">
             <legend>
-              <strong>Is the proposed Project Area in an <a href="https://zola.planning.nyc.gov/">Industrial Business Zone</a>?</strong>
+              <strong>Is the proposed Project Area in an <a href="https://zola.planning.nyc.gov/" target="_blank" rel="noopener noreferrer">Industrial Business Zone&nbsp;<FaIcon @icon="external-link-alt" @prefix="fas" @fixedWidth={{true}}/></a>?</strong>
             </legend>
             {{#each (array
               (hash code=true label='Yes')
@@ -253,7 +258,7 @@
 
           <fieldset class="medium-margin-bottom">
             <legend>
-              <strong>Is the proposed Project Area within or adjacent to a designated (City or State) <a href="https://zola.planning.nyc.gov/">Landmark or Historic District</a>?</strong>
+              <strong>Is the proposed Project Area within or adjacent to a designated (City or State) <a href="https://zola.planning.nyc.gov/"  target="_blank" rel="noopener noreferrer">Landmark or Historic District&nbsp;<FaIcon @icon="external-link-alt" @prefix="fas" @fixedWidth={{true}}/></a>?</strong>
             </legend>
             {{#each (array
               (hash code=true label='Yes')
@@ -287,7 +292,7 @@
 
           <fieldset class="medium-margin-bottom">
             <legend>
-              <strong>Is the proposed Project Area located within the <a href="https://dcp.maps.arcgis.com/apps/View/index.html?appid=90e3a9f927c2471483631a20e8a41d8d">NYC Coastal Zone</a>?</strong>
+              <strong>Is the proposed Project Area located within the <a href="https://dcp.maps.arcgis.com/apps/View/index.html?appid=90e3a9f927c2471483631a20e8a41d8d"  target="_blank" rel="noopener noreferrer">NYC Coastal Zone&nbsp;<FaIcon @icon="external-link-alt" @prefix="fas" @fixedWidth={{true}}/></a>?</strong>
             </legend>
             {{#each (array
               (hash code=true label='Yes')
@@ -305,7 +310,7 @@
 
           <fieldset class="medium-margin-bottom">
             <legend>
-              <strong>Is the Project Area located within the <a href="https://dcp.maps.arcgis.com/apps/webappviewer/index.html?id=1c37d271fba14163bbb520517153d6d5">1% annual chance floodplain</a>?</strong>
+              <strong>Is the Project Area located within the <a href="https://dcp.maps.arcgis.com/apps/webappviewer/index.html?id=1c37d271fba14163bbb520517153d6d5"  target="_blank" rel="noopener noreferrer">1% annual chance floodplain&nbsp;<FaIcon @icon="external-link-alt" @prefix="fas" @fixedWidth={{true}}/></a>?</strong>
             </legend>
             {{#each (array
               (hash code=717170000 label='Yes')
@@ -324,7 +329,7 @@
 
           <fieldset class="medium-margin-bottom">
             <legend>
-              <strong>Is a <a href="https://a836-acris.nyc.gov/CP/">legal instrument</a> associated with a previous CPC or CPC Chair action recorded against the project site?</strong>
+              <strong>Is a <a href="https://a836-acris.nyc.gov/CP/"  target="_blank" rel="noopener noreferrer">legal instrument&nbsp;<FaIcon @icon="external-link-alt" @prefix="fas" @fixedWidth={{true}}/></a> associated with a previous CPC or CPC Chair action recorded against the project site?</strong>
             </legend>
             {{#each (array
               (hash code=true label='Yes')
@@ -342,7 +347,10 @@
 
             {{#if this.saveableChanges.dcpRestrictivedeclaration}}
               <label>
-                <strong>City Register File Number</strong>
+                <strong>City Register file number or other identifier</strong>
+                <p class="help-text">
+                  Feel free to attach a copy of the legal instrument in the Attachments section.
+                </p>
                 <Input
                   @type="text"
                   @value={{this.saveableChanges.dcpCityregisterfilenumber}}
@@ -470,8 +478,11 @@
 
           <fieldset class="medium-margin-bottom">
             <legend>
-              <strong>Is the Development Site in an <a href="https://zola.planning.nyc.gov/">Inclusionary Housing Designated Area/Mandatory Inclusionary Housing Area</a>?</strong>
+              <strong>Is the Development Site in an <a href="https://zola.planning.nyc.gov/"  target="_blank" rel="noopener noreferrer">Inclusionary Housing Designated Area/Mandatory Inclusionary Housing Area&nbsp;<FaIcon @icon="external-link-alt" @prefix="fas" @fixedWidth={{true}}/></a>?</strong>
             </legend>
+            <p class="help-text">
+              Refer to <a href="https://zr.planning.nyc.gov/appendix-f-inclusionary-housing-designated-areas-and-mandatory-inclusionary-housing-areas" target="_blank" rel="noopener noreferrer">Appendix F&nbsp;<FaIcon @icon="external-link-alt" @prefix="fas" @fixedWidth={{true}}/></a> of the Zoning Resolution for full list of all inclusionary housing areas which are areas that incentivize or require affordable housing in certain areas.
+            </p>
             {{#each (array
               (hash code=true label='Yes')
               (hash code=false label='No')) as |radio|
@@ -486,9 +497,6 @@
               </RadioButton>
             {{/each}}
 
-            <p class="help-text">
-              Refer to <a  href="https://zr.planning.nyc.gov/appendix-f-inclusionary-housing-designated-areas-and-mandatory-inclusionary-housing-areas">Appendix F</a> of the Zoning Resolution for full list of all inclusionary housing areas which are areas that incentivize or require affordable housing in certain areas.
-            </p>
             {{#if this.saveableChanges.dcpIsinclusionaryhousingdesignatedarea}}
               <label>
                 Name of Inclusionary Housing Designated Area/Mandatory Inclusionary Housing Area
@@ -548,6 +556,9 @@
             <span id="project-description" class="section-anchor"></span>
             Project Description
           </h3>
+          <p class="help-text">
+            For complex proposals, feel free to upload a draft document (in the Attachments section) explaining this information instead of filling out the form inputs.
+          </p>
 
           <label>
             <strong>Description of the proposed development being facilitated by the land use actions</strong>
@@ -616,6 +627,9 @@
 
           <label>
             <strong>Description of proposed CEQR scope</strong>
+            <p class="help-text">
+              Include to expedite CEQR guidance: If proposed actions are not approved, what is the applicant’s as-of-right development (CEQR “no-action”) proposal? What would be expected to occur on non-applicant-controlled sites because of the Proposed Actions (CEQR “with-action”)?
+            </p>
             <Textarea
               @value={{this.saveableChanges.dcpProjectattachmentsotherinformation}}
               rows="5"
@@ -626,9 +640,6 @@
               @changesetError={{this.submittableChanges.error.dcpProjectattachmentsotherinformation}}
             />
           </label>
-          <p class="help-text">
-            Include to expedite CEQR guidance: If proposed actions are not approved, what is the applicant’s as-of-right development (CEQR “no-action”) proposal? What would be expected to occur on non-applicant-controlled sites because of the Proposed Actions (CEQR “with-action”)?
-          </p>
         </section>
 
         <section class="form-section">
@@ -646,22 +657,22 @@
               <h5>Required for all projects:</h5>
               <ul class="text-small">
                 <li class="small-margin-bottom">
-                  <a href="http://gis.nyc.gov/taxmap/map.htm">Tax Map(s)</a> — if project area has more than one tax block submit a separate map for each tax block
+                  <a href="http://gis.nyc.gov/taxmap/map.htm" target="_blank" rel="noopener noreferrer">Tax Map(s)&nbsp;<FaIcon @icon="external-link-alt" @prefix="fas" @fixedWidth={{true}}/></a> — if project area has more than one tax block submit a separate map for each tax block
                 </li>
                 <li class="small-margin-bottom">
-                  <a href="https://www1.nyc.gov/site/planning/zoning/index- map.page">Official Zoning Map</a> — circle the project area
+                  <a href="https://www1.nyc.gov/site/planning/zoning/index- map.page" target="_blank" rel="noopener noreferrer">Official Zoning Map&nbsp;<FaIcon @icon="external-link-alt" @prefix="fas" @fixedWidth={{true}}/></a> — circle the project area
                 </li>
                 <li class="small-margin-bottom">
-                  <a href="https://applicantmaps.planning.nyc.gov/">Land Use Map</a>
+                  <a href="https://applicantmaps.planning.nyc.gov/" target="_blank" rel="noopener noreferrer">Land Use Map&nbsp;<FaIcon @icon="external-link-alt" @prefix="fas" @fixedWidth={{true}}/></a>
                 </li>
                 <li class="small-margin-bottom">
-                  Site Plan — include building heights, unit counts and square footage calculations (GSF & ZSF) for proposed project (certain exceptions apply, consult the Lead Planner)
+                  Illustrative Site Plan or Drawings — include any project details relevant to activities or findings (certain exceptions apply, consult the Lead Planner)
                 </li>
                 <li class="small-margin-bottom">
                   Photographs
                 </li>
                 <li class="small-margin-bottom">
-                  Signature Form
+                  <a href="https://www1.nyc.gov/assets/planning/download/pdf/applicants/applicant-portal/dcp-signature-form.pdf" target="_blank" rel="noopener noreferrer">Signature Form &nbsp;<FaIcon @icon="external-link-alt" @prefix="fas" @fixedWidth={{true}}/></a>
                 </li>
               </ul>
             </div>
@@ -669,12 +680,12 @@
               <h5>For projects in the NYC Coastal Zone: </h5>
               <ul class="text-small">
                 <li class="small-margin-bottom">
-                  Map of <a href="https://dcp.maps.arcgis.com/apps/View/index.html?app id=90e3a9f927c2471483631a20e8a41d8d">project location within the NYC coastal zone</a> including Special Area Designations
+                  Map of <a href="https://dcp.maps.arcgis.com/apps/View/index.html?app id=90e3a9f927c2471483631a20e8a41d8d" target="_blank" rel="noopener noreferrer">project location within the NYC coastal zone &nbsp;<FaIcon @icon="external-link-alt" @prefix="fas" @fixedWidth={{true}}/></a> including Special Area Designations
                 </li>
               </ul>
 
               <h5>
-                For <a href="https://streets.planning.nyc.gov/about">City Map changes</a>:
+                For <a href="https://streets.planning.nyc.gov/about" target="_blank" rel="noopener noreferrer">City Map changes &nbsp;<FaIcon @icon="external-link-alt" @prefix="fas" @fixedWidth={{true}}/></a>:
               </h5>
               <ul class="text-small">
                 <li class="small-margin-bottom">Most recent Borough President’s final Section Map or most recent approved and filed Alteration Map for the project area</li>

--- a/client/app/components/project-geography.hbs
+++ b/client/app/components/project-geography.hbs
@@ -1,4 +1,9 @@
 <h5>Add a tax lot by searching a BBL or an address</h5>
+
+<p class="help-text">
+  NYC Planning's <a href="https://lotselector.planning.nyc.gov/" target="_blank" rel="noopener noreferrer">Tax Lot Selector &nbsp;<FaIcon @icon="external-link-alt" @prefix="fas" @fixedWidth={{true}}/></a> is a helpful tool for identifying and selecting tax lot BBL numbers within a project area. If your project is very large, you can download the BBLs from the Tax Lot Selector app using the "Paperless Filing" option and upload that file to this form as an attachment.
+</p>
+
 <LabsSearch
   @searchPlaceholder='Look up BBL (ex 1001440001)'
   data-test-input="bbl-search"
@@ -6,6 +11,11 @@
 >
   <small class="dark-gray">{{search.result.label}} <br> {{bbl-breakup search.result.bbl}}</small>
 </LabsSearch>
+
+{{#if @bbls}}
+  <br>
+  <h5>Tax Lots Included in This Project</h5>
+{{/if}}
 
 {{#each @bbls as |bbl|}}
   <fieldset class="fieldset relative">
@@ -45,7 +55,7 @@
     </fieldset>
     <fieldset>
       <legend data-test-partial-lot-question="{{bbl.dcpBblnumber}}-{{bbl.dcpPartiallot}}">
-        Is this a partial lot?
+        Is only a portion of this lot included in the project area?
       </legend>
       <RadioButton
         @value={{true}}


### PR DESCRIPTION
- Addresses #171 by clarifying geography instructions + adding some additional instruction improvements requested by Aline after the applicant demo (eg: telling people to use tax lot selector if they have a large project or don't have an address)
- Addresses #211 by adding a link to the signature form
- Addresses #164 by making hyperlinks open in a new tab and adding fontawesome symbol
