### PR TITLE
187 Enable Save when files marked for upload or deletion. Upload+delete files on Save. 

### DIFF
--- a/client/app/components/packages/attachments.hbs
+++ b/client/app/components/packages/attachments.hbs
@@ -115,6 +115,7 @@
           @name={{@package.id}}
           @accept='*/*'
           @multiple={{true}}
+          @onfileadd={{this.trackFileForUpload}}
           class="button secondary expanded"
         >
           <FaIcon @icon="upload" @prefix="fas" />

--- a/client/app/components/packages/attachments.js
+++ b/client/app/components/packages/attachments.js
@@ -2,9 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
 /**
-  * This component creates a new File Manager specifically for
-  * the passed in package. The File Manager is among one of many
-  * on the the application File Manager service.
+  * This component wires a fileManager to the attachments UI.
   * @param      {Package Model}  package
   */
 export default class PackagesAttachmentsComponent extends Component {
@@ -20,6 +18,16 @@ export default class PackagesAttachmentsComponent extends Component {
   @action
   unmarkFileForDeletion(file) {
     this.fileManager.unMarkFileForDeletion(file);
+  }
+
+  // This action doesn't perform any file selection.
+  // That part is automatically handled by the
+  // ember-file-upload addon.
+  // Here we manually increment the number of files to
+  // upload to update the fileManager isDirty state.
+  @action
+  trackFileForUpload() {
+    this.fileManager.trackFileForUpload();
   }
 
   @action

--- a/client/app/components/packages/pas-form/edit.js
+++ b/client/app/components/packages/pas-form/edit.js
@@ -57,8 +57,16 @@ export default class PasFormComponent extends Component {
       isBblsDirty,
       isApplicantsDirty,
     } = this.pasForm;
+    const {
+      isDirty: isAttachmentsDirty,
+    } = this.package.fileManager;
 
-    return !this.isUpdatingDb && ((isPasFormDirty && isPasFormValid) || isBblsDirty || isApplicantsDirty);
+    return !this.isUpdatingDb && ((isPasFormDirty
+      && isPasFormValid)
+      || isBblsDirty
+      || isApplicantsDirty
+      || isAttachmentsDirty
+    );
   }
 
   get isSubmittable() {

--- a/client/app/controllers/packages/edit.js
+++ b/client/app/controllers/packages/edit.js
@@ -5,6 +5,7 @@ export default class PackagesEditController extends Controller {
   @action
   async savePackage() {
     await this.model.saveDescendants();
+    await this.model.fileManager.save();
   }
 
   @action

--- a/client/tests/acceptance/user-can-click-package-edit-test.js
+++ b/client/tests/acceptance/user-can-click-package-edit-test.js
@@ -9,6 +9,7 @@ import {
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import { selectFiles } from 'ember-file-upload/test-support';
 
 module('Acceptance | user can click package edit', function(hooks) {
   setupApplicationTest(hooks);
@@ -48,5 +49,73 @@ module('Acceptance | user can click package edit', function(hooks) {
     await waitFor('[data-test-show-dcprevisedprojectname]');
 
     assert.equal(currentURL(), '/packages/1');
+  });
+
+  test('Save button is enabled when file marked for deletion', async function (assert) {
+    // TODO: Refactor factories so there doesn't need to be duplicate package
+    const project = this.server.create('project', 'applicant');
+    this.server.create('package', 'applicant', 'withExistingDocuments', {
+      project,
+    });
+
+    await visit('/packages/2/edit');
+
+    // ! We remove the pregenerated applicant here to disable the "save" button.
+    // Clicking "Save" to disable the Save button causes a race condition:
+    // The automated clicks act so fast that the file is marked for deletion
+    // BEFORE the full Save operation completes,
+    // causing the file marked for deletion to be immediately cleared.
+    // TODO: Perhaps rework frontend using a Task group to prevent
+    // this race condition.
+    await click('[data-test-remove-applicant-button]');
+
+    assert.dom('[data-test-save-button]').isDisabled();
+
+    await click('[data-test-delete-file-button="0"]');
+
+    assert.dom('[data-test-save-button]').isEnabled();
+  });
+
+  test('Save button is enabled when file marked for upload', async function (assert) {
+    const project = this.server.create('project', 'applicant');
+    this.server.create('package', 'applicant', 'withExistingDocuments', {
+      project,
+    });
+
+    await visit('/packages/2/edit');
+
+    // See note in previous test about why this click to remove applicant
+    // is performed.
+    await click('[data-test-remove-applicant-button]');
+
+    assert.dom('[data-test-save-button]').isDisabled();
+
+    const file = new File(['foo'], 'Zoning Application.pdf', { type: 'text/plain' });
+
+    await selectFiles('#FileUploader2 > input', file);
+
+    assert.dom('[data-test-save-button]').isEnabled();
+  });
+
+  test('Files marked for upload and deletion are cleared on Save', async function (assert) {
+    const project = this.server.create('project', 'applicant');
+    this.server.create('package', 'applicant', 'withExistingDocuments', {
+      project,
+    });
+
+    await visit('/packages/2/edit');
+
+    const file = new File(['foo'], 'Zoning Application.pdf', { type: 'text/plain' });
+    await selectFiles('#FileUploader2 > input', file);
+
+    await click('[data-test-delete-file-button="0"]');
+
+    await assert.dom('[data-test-document-to-be-deleted-name]').exists();
+    await assert.dom('[data-test-document-to-be-uploaded-name]').exists();
+
+    await click('[data-test-save-button]');
+
+    await assert.dom('[data-test-document-to-be-deleted-name]').doesNotExist();
+    await assert.dom('[data-test-document-to-be-uploaded-name]').doesNotExist();
   });
 });


### PR DESCRIPTION
This PR ...
1) Enable the Save button when files marked for upload or deletion
2) Calls fileManager.save() when the PAS Form Save button is clicked. 
fileManager.save() will execute file upload and deletion for files appropriately marked. 