### PR TITLE
214:  conditional organization applicant input

### DIFF
--- a/client/app/components/packages/applicant-fieldset.hbs
+++ b/client/app/components/packages/applicant-fieldset.hbs
@@ -26,13 +26,12 @@
   {{/if}}
 
   {{!-- and if the applicant is on behalf of an organization, we need to know which organization --}}
-  {{#if (eq @applicant.dcpType "Organization")}}
-    <label>
+  {{#if (eq @applicant.dcpType 717170001)}}
+    <label data-test-applicant-organization>
       Organization
       <Input
         type="text"
         @value={{@applicant.dcpOrganization}}
-        data-test-applicant-organization
       />
     </label>
     <hr/>

--- a/client/tests/integration/components/packages/applicant-team-editor-test.js
+++ b/client/tests/integration/components/packages/applicant-team-editor-test.js
@@ -97,6 +97,9 @@ module('Integration | Component | packages/applicant-team-editor', function(hook
     // switch from Individual to Organization applicant type
     await click('[data-test-applicant-type-radio-organization]');
 
+    // organization input should appear after user toggles to "Organization"
+    assert.dom('[data-test-applicant-organization]').hasText('Organization');
+
     // should be reflected in the applicants array!
     assert.equal(this.applicants[0].dcpType, 717170001);
   });


### PR DESCRIPTION
This commit addresses #214, where the conditional organization input was no longer showing up.

The dcpType value changed from text (“Individual” or “Organization”) to coded values.

This commit uses the appropriate coded value to render the organization input.  It also adds a meaningful test, which would have caught when this broke previously.