### PR TITLE
240:  Route applicants to the correct CRM entity/table

### DIFF
--- a/client/mirage/factories/applicant.js
+++ b/client/mirage/factories/applicant.js
@@ -22,7 +22,7 @@ export default Factory.extend({
   }),
 
   applicantTeamMember: trait({
-    targetEntity: 'dcp_applicantrepinformation',
+    targetEntity: 'dcp_applicantrepresentativeinformation',
     dcpType: null,
     dcpOrganization: 'Vandelay Industries',
   }),

--- a/client/mirage/factories/applicant.js
+++ b/client/mirage/factories/applicant.js
@@ -22,7 +22,7 @@ export default Factory.extend({
   }),
 
   applicantTeamMember: trait({
-    targetEntity: 'dcp_applicantrepresentativeinformation',
+    targetEntity: 'dcp_applicantrepinformation',
     dcpType: null,
     dcpOrganization: 'Vandelay Industries',
   }),

--- a/server/src/packages/packages.controller.ts
+++ b/server/src/packages/packages.controller.ts
@@ -48,7 +48,8 @@ export const PACKAGE_ATTRS = [
     applicants: {
       ref: 'dcp_applicantinformationid',
       attributes: [
-        ...APPLICANT_ATTRIBUTES
+        ...APPLICANT_ATTRIBUTES,
+        'target_entity', // custom attribute to handle the two applicant crm entities
       ],
     },
     bbls: {

--- a/server/src/packages/packages.controller.ts
+++ b/server/src/packages/packages.controller.ts
@@ -73,7 +73,22 @@ export const PACKAGE_ATTRS = [
         ...projectPackage,
         'pas-form': {
           ...pasForm,
-          applicants: pasForm.dcp_dcp_applicantinformation_dcp_pasform,
+          applicants: [
+            ...pasForm.dcp_dcp_applicantinformation_dcp_pasform,
+            ...pasForm.dcp_dcp_applicantrepinformation_dcp_pasform.map((applicant) => {
+              // map this array to handle the slight differences in schemas between these two entities
+              // that we treat as one applicants array on the frontend
+
+              // define target_entity for the frontend (defaults to dcp_applicantinformation)
+              applicant['target_entity'] = 'dcp_applicantrepresentativeinformation'
+
+              return {
+              ...applicant,
+              // FIXME: this is ensuring the Ember Data relationships work (with a unique ref)
+              // but this is hacky because dcp_applicantinformationid doesn't exist on this entity
+              dcp_applicantinformationid: `representative-${applicant.dcp_applicantrepresentativeinformationid}`
+            }}),
+          ],
           bbls: pasForm.dcp_dcp_projectbbl_dcp_pasform,
         },
       }

--- a/server/src/packages/packages.service.ts
+++ b/server/src/packages/packages.service.ts
@@ -46,6 +46,7 @@ export class PackagesService {
         dcp_pasformid eq ${_dcp_pasform_value}
       &$expand=
         dcp_dcp_applicantinformation_dcp_pasform,
+        dcp_dcp_applicanrepresentativetinformation_dcp_pasform,
         dcp_package,
         dcp_dcp_projectbbl_dcp_pasform($filter=statecode eq 0)
     `);

--- a/server/src/packages/packages.service.ts
+++ b/server/src/packages/packages.service.ts
@@ -46,7 +46,7 @@ export class PackagesService {
         dcp_pasformid eq ${_dcp_pasform_value}
       &$expand=
         dcp_dcp_applicantinformation_dcp_pasform,
-        dcp_dcp_applicanrepresentativetinformation_dcp_pasform,
+        dcp_dcp_applicantrepinformation_dcp_pasform,
         dcp_package,
         dcp_dcp_projectbbl_dcp_pasform($filter=statecode eq 0)
     `);

--- a/server/src/packages/pas-form/applicants/applicants.controller.ts
+++ b/server/src/packages/pas-form/applicants/applicants.controller.ts
@@ -15,11 +15,11 @@ import { JsonApiSerializeInterceptor } from '../../../json-api-serialize.interce
 import { AuthenticateGuard } from '../../../authenticate.guard';
 import { JsonApiDeserializePipe } from '../../../json-api-deserialize.pipe';
 
-// CRM has two entities that encompass the applicant team, 
+// CRM has two entities that encompass the applicant team,
 // dcp_applicantinformation and dcp_applicantrepinformation
 // TODO: This controller exposes these two entites as one "applicant" resource
 // and handles routes applicant resources from and to the appropriate CRM entity
-// the frontend provides (and needs) a custom property "targetEntity"
+// the frontend uses a custom attribute, "targetEntity",
 // to track the ultimate CRM entity destination (and source when getting existing)
 
 export const APPLICANT_REPRESENTATIVE_ATTRIBUTES = [
@@ -38,7 +38,6 @@ export const APPLICANT_ATTRIBUTES = [
   ...APPLICANT_REPRESENTATIVE_ATTRIBUTES,
   'dcp_type',
 ];
-
 
 @UseInterceptors(
   new JsonApiSerializeInterceptor('applicants', {
@@ -67,31 +66,44 @@ export class ApplicantsController {
   @Post('/')
   create(@Body() body) {
     const { target_entity } = body;
-  
+
     let allowedAttrs;
 
     // determine the appropraite attributes based on the entity type
     if (target_entity === 'dcp_applicantinformation') {
       allowedAttrs = pick(body, APPLICANT_ATTRIBUTES);
-    } else if (target_entity === 'dcp_applicantrepinformation') {
-      allowedAttrs = pick(body, APPLICANT_REPRESENTATIVE_ATTRIBUTES);
-    }
-
-    if (body.pas_form) {
-      let applicantBody = {
-        ...allowedAttrs,
+      if (body.pas_form) {
+        return this.crmService.create('dcp_applicantinformations', {
+          ...allowedAttrs,
+          // Dy365 syntax for associating a newly-created record
+          // with an existing record.
+          // see: https://docs.microsoft.com/en-us/powerapps/developer/common-data-service/webapi/create-entity-web-api#associate-entity-records-on-create
+          'dcp_dcp_applicantinformation_dcp_pasform@odata.bind': [
+            `/dcp_pasforms(${body.pas_form})`,
+          ],
+        });
+      } else {
+        return this.crmService.create(`dcp_applicantinformations`, allowedAttrs);
       }
-      const objKey = `dcp_${target_entity}_dcp_pasform@odata.bind` 
-      // Dy365 syntax for associating a newly-created record
-      // with an existing record.
-      // see: https://docs.microsoft.com/en-us/powerapps/developer/common-data-service/webapi/create-entity-web-api#associate-entity-records-on-create
-      applicantBody[objKey] = [`/dcp_pasforms(${body.pas_form})`]
-
-      console.log(applicantBody);
-      
-      return this.crmService.create(`${target_entity}s`, applicantBody);
-    } else {
-      return this.crmService.create(`${target_entity}s`, allowedAttrs);
+    } else if (target_entity === 'dcp_applicantrepresentativeinformation') {
+      allowedAttrs = pick(body, APPLICANT_REPRESENTATIVE_ATTRIBUTES);
+      if (body.pas_form) {
+        return this.crmService.create(
+          'dcp_applicantrepresentativeinformations',
+          {
+            ...allowedAttrs,
+            // Dy365 syntax for associating a newly-created record
+            // with an existing record.
+            // see: https://docs.microsoft.com/en-us/powerapps/developer/common-data-service/webapi/create-entity-web-api#associate-entity-records-on-create
+            'dcp_dcp_applicantrepinformation_dcp_pasform@odata.bind': [`/dcp_pasforms(${body.pas_form})`],
+          },
+        );
+      } else {
+        return this.crmService.create(
+          `dcp_applicantrepinformations`,
+          allowedAttrs,
+        );
+      }
     }
   }
 
@@ -104,5 +116,3 @@ export class ApplicantsController {
     };
   }
 }
-
-

--- a/server/src/packages/pas-form/applicants/applicants.controller.ts
+++ b/server/src/packages/pas-form/applicants/applicants.controller.ts
@@ -36,7 +36,6 @@ export const APPLICANT_REPRESENTATIVE_ATTRIBUTES = [
   'dcp_state',
   'dcp_zipcode',
   'dcp_phone',
-  'target_entity',
 ];
 
 export const APPLICANT_ATTRIBUTES = [
@@ -63,8 +62,7 @@ export class ApplicantsController {
     let allowedAttrs;
 
     if (target_entity === 'dcp_applicantinformation') {
-      // we can't send target_entity to CRM because it doesn't exist there
-      allowedAttrs = pick(body, APPLICANT_ATTRIBUTES.filter(attribute => attribute !== 'target_entity'));
+      allowedAttrs = pick(body, APPLICANT_ATTRIBUTES);
 
       await this.crmService.update(
         'dcp_applicantinformations',
@@ -72,7 +70,7 @@ export class ApplicantsController {
         allowedAttrs,
       );
     } else if (target_entity === 'dcp_applicantrepresentativeinformation') {
-      allowedAttrs = pick(body, APPLICANT_REPRESENTATIVE_ATTRIBUTES.filter(attribute => attribute !== 'target_entity'));
+      allowedAttrs = pick(body, APPLICANT_REPRESENTATIVE_ATTRIBUTES);
 
       // strip the hacky prepended "representative-" to use the exact CRM id
       const representativeId = id.replace('representative-', '');
@@ -97,9 +95,9 @@ export class ApplicantsController {
 
     let allowedAttrs;
 
-    // determine the appropraite attributes based on the entity type
+    // determine the appropriate attributes based on the entity type
     if (target_entity === 'dcp_applicantinformation') {
-      allowedAttrs = pick(body, APPLICANT_ATTRIBUTES.filter(attribute => attribute !== 'target_entity'));
+      allowedAttrs = pick(body, APPLICANT_ATTRIBUTES);
 
       if (body.pas_form) {
         return this.crmService.create('dcp_applicantinformations', {
@@ -118,7 +116,7 @@ export class ApplicantsController {
         );
       }
     } else if (target_entity === 'dcp_applicantrepresentativeinformation') {
-      allowedAttrs = pick(body, APPLICANT_REPRESENTATIVE_ATTRIBUTES.filter(attribute => attribute !== 'target_entity'));
+      allowedAttrs = pick(body, APPLICANT_REPRESENTATIVE_ATTRIBUTES);
 
       if (body.pas_form) {
         return this.crmService.create(
@@ -153,7 +151,7 @@ export class ApplicantsController {
 
       await this.crmService.delete('dcp_applicantrepresentativeinformations', representativeId);
     } else {
-      // anything that doesn't have representative in the ID is an applicant information entity
+      // anything that doesn't have "representative" in the ID is an applicant information entity
       await this.crmService.delete('dcp_applicantinformations', id);
     }
 

--- a/server/src/packages/pas-form/applicants/applicants.controller.ts
+++ b/server/src/packages/pas-form/applicants/applicants.controller.ts
@@ -1,9 +1,26 @@
-import { Controller, Patch, Body, Param, Post, UseInterceptors, UseGuards, UsePipes, Delete } from '@nestjs/common';
+import {
+  Controller,
+  Patch,
+  Body,
+  Param,
+  Post,
+  UseInterceptors,
+  UseGuards,
+  UsePipes,
+  Delete,
+} from '@nestjs/common';
 import { pick } from 'underscore';
 import { CrmService } from '../../../crm/crm.service';
 import { JsonApiSerializeInterceptor } from '../../../json-api-serialize.interceptor';
 import { AuthenticateGuard } from '../../../authenticate.guard';
 import { JsonApiDeserializePipe } from '../../../json-api-deserialize.pipe';
+
+// CRM has two entities that encompass the applicant team, 
+// dcp_applicantinformation and dcp_applicantrepresentativeinformation
+// TODO: This controller exposes these two entites as one "applicant" resource
+// and handles routes applicant resources from and to the appropriate CRM entity
+// the frontend provides (and needs) a custom property "targetEntity"
+// to track the ultimate CRM entity destination (and source when getting existing)
 
 export const APPLICANT_ATTRIBUTES = [
   'dcp_firstname',
@@ -15,15 +32,16 @@ export const APPLICANT_ATTRIBUTES = [
   'dcp_state',
   'dcp_zipcode',
   'dcp_phone',
-  'dcp_type',
+  'dcp_type', // only on dcp_applicantinformation entity, not applicantrepresentative
+  'targetEntity', // custom attribute to route to/from correct crm entity
 ];
 
-@UseInterceptors(new JsonApiSerializeInterceptor('applicants', {
-  id: 'dcp_applicantinformationid',
-  attributes: [
-    ...APPLICANT_ATTRIBUTES,
-  ],
-}))
+@UseInterceptors(
+  new JsonApiSerializeInterceptor('applicants', {
+    id: 'dcp_applicantinformationid',
+    attributes: [...APPLICANT_ATTRIBUTES],
+  }),
+)
 @UseGuards(AuthenticateGuard)
 @UsePipes(JsonApiDeserializePipe)
 @Controller('applicants')
@@ -39,7 +57,7 @@ export class ApplicantsController {
     return {
       dcp_applicantinformationid: id,
       ...body,
-    }
+    };
   }
 
   @Post('/')
@@ -53,7 +71,9 @@ export class ApplicantsController {
         // Dy365 syntax for associating a newly-created record
         // with an existing record.
         // see: https://docs.microsoft.com/en-us/powerapps/developer/common-data-service/webapi/create-entity-web-api#associate-entity-records-on-create
-        'dcp_dcp_applicantinformation_dcp_pasform@odata.bind': [`/dcp_pasforms(${body.pas_form})`],
+        'dcp_dcp_applicantinformation_dcp_pasform@odata.bind': [
+          `/dcp_pasforms(${body.pas_form})`,
+        ],
       });
     } else {
       return this.crmService.create('dcp_applicantinformations', allowedAttrs);


### PR DESCRIPTION
This PR addresses #238 and addresses #240, by adding conditional logic to our api server for handling applicants.  

Previously all applicants being added in applicant portal would go to the `Applicant Information` grid in CRM, and would not bring in existing `Applicant Representative Information` records.  

This fixes by:
- Including the representative entity in the packages controller (for getting existing applicant representatives)
- Gives the frontend an attribute `target_entity` so the app knows what kind of applicant to render
- Conditionally Posts/Patches/Deletes the appropriate CRM entity through conditional logic in the applicant controller.