### PR TITLE
183 Patch applicant geographic state

### DIFF
--- a/client/app/components/packages/applicant-fieldset.hbs
+++ b/client/app/components/packages/applicant-fieldset.hbs
@@ -74,7 +74,20 @@
       <label>City <Input type="text" @value={{@applicant.dcpCity}}/></label>
     </div>
     <div class="cell auto medium-2">
-      <label>State <Input type="text" @value={{@applicant.dcpState}}/></label>
+      <label data-test-applicant-state-dropdown>
+        State
+        <PowerSelect
+          supportsDataTestProperties={{true}}
+          @selected={{get this.stateLabelLookup @applicant.dcpState}}
+          @placeholder="state"
+          @searchEnabled={{true}}
+          @searchField="label"
+          @options={{this.stateOptions}}
+          @onchange={{fn this.updateAttrWithOption @applicant 'dcpState'}}
+        as |state|>
+          {{state.label}}
+        </PowerSelect>
+      </label>
     </div>
     <div class="cell auto medium-4">
       <label>ZIP <Input type="text" @value={{@applicant.dcpZipcode}}/></label>

--- a/client/app/components/packages/applicant-fieldset.js
+++ b/client/app/components/packages/applicant-fieldset.js
@@ -14,7 +14,8 @@ export default class ApplicantFieldset extends Component {
       (accumulator, option) => ({
         [option.code]: option,
         ...accumulator,
-      }), { });
+      }), { },
+    );
   }
 
   // TODO: Refactor this to engage with Changeset, when changesets are

--- a/client/app/components/packages/applicant-fieldset.js
+++ b/client/app/components/packages/applicant-fieldset.js
@@ -1,7 +1,29 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { STATE_OPTION_SET } from '../../models/applicant';
 
 export default class ApplicantFieldset extends Component {
+  get stateOptions() {
+    return Object.values(STATE_OPTION_SET);
+  }
+
+  // TODO: Use a global helper instead after writing
+  // unified optionset handling
+  get stateLabelLookup() {
+    return this.stateOptions.reduce(
+      (accumulator, option) => ({
+        [option.code]: option,
+        ...accumulator,
+      }), { });
+  }
+
+  // TODO: Refactor this to engage with Changeset, when changesets are
+  // introduced for applicant, BBls.
+  @action
+  updateAttrWithOption(currentObject, attr, { code: optionCode }) {
+    this.updateAttr(currentObject, attr, optionCode);
+  }
+
   // syncs radio input toggle to Ember model
   @action
   updateAttr(currentObject, attr, newVal) {

--- a/client/app/models/applicant.js
+++ b/client/app/models/applicant.js
@@ -1,5 +1,244 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
+export const STATE_OPTION_SET = {
+  AK: {
+    code: 717170000,
+    label: 'AK',
+  },
+  AL: {
+    code: 717170001,
+    label: 'AL',
+  },
+  AR: {
+    code: 717170002,
+    label: 'AR',
+  },
+  AS: {
+    code: 717170053,
+    label: 'AS',
+  },
+  AZ: {
+    code: 717170003,
+    label: 'AZ',
+  },
+  CA: {
+    code: 717170004,
+    label: 'CA',
+  },
+  CO: {
+    code: 717170005,
+    label: 'CO',
+  },
+  CT: {
+    code: 717170006,
+    label: 'CT',
+  },
+  DC: {
+    code: 717170007,
+    label: 'DC',
+  },
+  DE: {
+    code: 717170008,
+    label: 'DE',
+  },
+  FL: {
+    code: 717170009,
+    label: 'FL',
+  },
+  FM: {
+    code: 717170056,
+    label: 'FM',
+  },
+  GA: {
+    code: 717170010,
+    label: 'GA',
+  },
+  GU: {
+    code: 717170054,
+    label: 'GU',
+  },
+  HI: {
+    code: 717170011,
+    label: 'HI',
+  },
+  IA: {
+    code: 717170012,
+    label: 'IA',
+  },
+  ID: {
+    code: 717170013,
+    label: 'ID',
+  },
+  IL: {
+    code: 717170014,
+    label: 'IL',
+  },
+  IN: {
+    code: 717170015,
+    label: 'IN',
+  },
+  KS: {
+    code: 717170016,
+    label: 'KS',
+  },
+  KY: {
+    code: 717170017,
+    label: 'KY',
+  },
+  LA: {
+    code: 717170018,
+    label: 'LA',
+  },
+  MA: {
+    code: 717170019,
+    label: 'MA',
+  },
+  MD: {
+    code: 717170020,
+    label: 'MD',
+  },
+  ME: {
+    code: 717170021,
+    label: 'ME',
+  },
+  MH: {
+    code: 717170055,
+    label: 'MH',
+  },
+  MI: {
+    code: 717170022,
+    label: 'MI',
+  },
+  MN: {
+    code: 717170023,
+    label: 'MN',
+  },
+  MO: {
+    code: 717170024,
+    label: 'MO',
+  },
+  MP: {
+    code: 717170057,
+    label: 'MP',
+  },
+  MS: {
+    code: 717170025,
+    label: 'MS',
+  },
+  MT: {
+    code: 717170026,
+    label: 'MT',
+  },
+  NC: {
+    code: 717170027,
+    label: 'NC',
+  },
+  ND: {
+    code: 717170028,
+    label: 'ND',
+  },
+  NE: {
+    code: 717170029,
+    label: 'NE',
+  },
+  NH: {
+    code: 717170030,
+    label: 'NH',
+  },
+  NJ: {
+    code: 717170031,
+    label: 'NJ',
+  },
+  NM: {
+    code: 717170032,
+    label: 'NM',
+  },
+  NV: {
+    code: 717170033,
+    label: 'NV',
+  },
+  NY: {
+    code: 717170034,
+    label: 'NY',
+  },
+  OH: {
+    code: 717170035,
+    label: 'OH',
+  },
+  OK: {
+    code: 717170036,
+    label: 'OK',
+  },
+  OR: {
+    code: 717170037,
+    label: 'OR',
+  },
+  PA: {
+    code: 717170038,
+    label: 'PA',
+  },
+  PR: {
+    code: 717170039,
+    label: 'PR',
+  },
+  PW: {
+    code: 717170058,
+    label: 'PW',
+  },
+  RI: {
+    code: 717170040,
+    label: 'RI',
+  },
+  SC: {
+    code: 717170041,
+    label: 'SC',
+  },
+  SD: {
+    code: 717170042,
+    label: 'SD',
+  },
+  TN: {
+    code: 717170043,
+    label: 'TN',
+  },
+  TX: {
+    code: 717170044,
+    label: 'TX',
+  },
+  UT: {
+    code: 717170045,
+    label: 'UT',
+  },
+  VA: {
+    code: 717170046,
+    label: 'VA',
+  },
+  VI: {
+    code: 717170047,
+    label: 'VI',
+  },
+  VT: {
+    code: 717170048,
+    label: 'VT',
+  },
+  WA: {
+    code: 717170049,
+    label: 'WA',
+  },
+  WI: {
+    code: 717170050,
+    label: 'WI',
+  },
+  WV: {
+    code: 717170051,
+    label: 'WV',
+  },
+  WY: {
+    label: 'WY',
+    code: 717170052,
+  },
+};
+
 export default class ApplicantModel extends Model {
   @belongsTo('pas-form')
   pasForm;

--- a/client/tests/integration/components/packages/applicant-team-editor-test.js
+++ b/client/tests/integration/components/packages/applicant-team-editor-test.js
@@ -3,6 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { selectChoose } from 'ember-power-select/test-support';
 
 
 module('Integration | Component | packages/applicant-team-editor', function(hooks) {
@@ -102,5 +103,23 @@ module('Integration | Component | packages/applicant-team-editor', function(hook
 
     // should be reflected in the applicants array!
     assert.equal(this.applicants[0].dcpType, 717170001);
+  });
+
+  test('user can select a state for an applicant team member', async function(assert) {
+    this.server.create('applicant', 'individualApplicant');
+
+    this.applicants = [
+      await this.owner.lookup('service:store').findRecord('applicant', 1),
+    ];
+
+    await render(hbs`
+      <Packages::ApplicantTeamEditor 
+        @applicants={{this.applicants}}
+      />
+    `);
+
+    await selectChoose('[data-test-applicant-state-dropdown]', 'OR');
+
+    assert.equal(this.applicants[0].dcpState, 717170037);
   });
 });


### PR DESCRIPTION
Since the applicant dcpState field is an option set, we
introduce a dropdown for that field so for users can search and
select for a specific state. In the frontend business logic,
we translate the selected state into its respective option set
code and assign the code to the applicant.dcpState field.

Addresses #183 and #210