### PR TITLE
245 revise land use action component

### DIFF
--- a/client/app/components/action-form-input.hbs
+++ b/client/app/components/action-form-input.hbs
@@ -2,6 +2,7 @@
   class="action-form-input"
   type={{@fieldType}}
   maxlength="200"
+  @min="1"
   placeholder=""
   autocomplete="off"
   @value={{mut (get @pasForm @landUseActionField)}}

--- a/client/app/components/land-use-action.hbs
+++ b/client/app/components/land-use-action.hbs
@@ -8,18 +8,17 @@
       @placeholder="-- select an action --"
       @searchEnabled={{false}}
       @options={{this.availableActions}}
-      @onchange={{fn (mut this.selectedAction)}}
-      @onclose={{fn this.addSelectedAction}}
+      @onchange={{fn this.addSelectedAction}}
       as |landUseAction|
     >
       {{landUseAction.name}}
     </PowerSelect>
   </label>
 </div>
-{{#if this.selectedActions}}
+{{#if this.sortedSelectedActions}}
   <h5>Land Use Actions Included in This Project</h5>
 {{/if}}
-{{#each this.selectedActions as |landUseAction|}}
+{{#each this.sortedSelectedActions as |landUseAction|}}
   <fieldset class="fieldset relative">
     <legend>
       <strong data-test-action-name="{{landUseAction.name}}">{{landUseAction.name}}</strong>

--- a/client/app/components/land-use-action.hbs
+++ b/client/app/components/land-use-action.hbs
@@ -7,28 +7,32 @@
       supportsDataTestProperties={{true}}
       @placeholder="-- select an action --"
       @searchEnabled={{false}}
-      @options={{this.sortedAvailableLandUseActionOptions}}
-      @onchange={{fn (mut this.selectedLandUseAction)}}
-      @onclose={{fn this.addNewLandUseActionSelection}}
+      @options={{this.availableActions}}
+      @onchange={{fn (mut this.selectedAction)}}
+      @onclose={{fn this.addSelectedAction}}
       as |landUseAction|
     >
       {{landUseAction.name}}
     </PowerSelect>
   </label>
 </div>
-{{#if this.landUseActionSelections}}
+{{#if this.selectedActions}}
   <h5>Land Use Actions Included in This Project</h5>
 {{/if}}
-{{#each this.landUseActionSelections as |landUseAction|}}
+{{#each this.selectedActions as |landUseAction|}}
   <fieldset class="fieldset relative">
     <legend>
-      <strong>{{landUseAction.name}}</strong>
+      <strong data-test-action-name="{{landUseAction.name}}">{{landUseAction.name}}</strong>
     </legend>
-    <label class="action-form-label">
-    How many {{landUseAction.name}} actions?
-      <ActionFormInput @pasForm={{@pasForm}} @fieldType="number" @landUseActionField={{landUseAction.countField}}/>
-    </label>
     {{#if (or (eq landUseAction.name "Zoning Special Permit") (eq landUseAction.name "Zoning Certification") (eq landUseAction.name "Zoning Authorization"))}}
+      <div class="grid-x grid-margin-x">
+        <div class="shrink cell">
+          <label for="middle-label" class="middle">How many {{landUseAction.name}} actions?</label>
+        </div>
+        <div class="auto cell">
+          <ActionFormInput @pasForm={{@pasForm}} @fieldType="number" @landUseActionField={{landUseAction.countField}}/>
+        </div>
+      </div>
       <label class="action-form-label">
         Where in the Zoning Resolution can this action be found?
         <ActionFormInput @pasForm={{@pasForm}} @fieldType="text" @landUseActionField={{landUseAction.attr1}}/>

--- a/client/mirage/factories/pas-form.js
+++ b/client/mirage/factories/pas-form.js
@@ -6,9 +6,9 @@ export default Factory.extend({
     dcpPfzoningcertification: 21,
     dcpZoningpursuantto: 'some value',
     dcpZoningtomodify: 'some other val',
-    dcpPfzoningtextamendment: 2,
+    dcpPfzoningtextamendment: 1,
     dcpAffectedzrnumber: '',
     dcpZoningresolutiontitle: '',
-    dcpPfchangeincitymap: 4,
+    dcpPfchangeincitymap: 1,
   }),
 });

--- a/client/tests/integration/components/land-use-action-test.js
+++ b/client/tests/integration/components/land-use-action-test.js
@@ -13,7 +13,7 @@ module('Integration | Component | land-use-action', function(hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
-  test('User can edit an existing action, add a new action, and answer extra questions', async function(assert) {
+  test('User can add new actions and answer extra questions', async function(assert) {
     const projectPackage = this.server.create('package', 1, 'applicant', 'withLandUseActions');
 
     this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form' });
@@ -24,43 +24,43 @@ module('Integration | Component | land-use-action', function(hooks) {
       </LandUseAction>
     `);
 
-    // Check that we can edit "Change in CityMap"
-    assert.dom(this.element).includesText('How many Change in CityMap actions?');
+    assert.equal(this.package.pasForm.dcpPfzoningspecialpermit, undefined);
 
-    assert.equal(this.package.pasForm.dcpPfchangeincitymap, 4);
-
-    await fillIn('[data-test-input="dcpPfchangeincitymap"]', 2);
-
-    assert.equal(this.package.pasForm.dcpPfchangeincitymap, 2);
-
-    // Check that we can add "Zoning Special Permit" and answer extra questions
     await selectChoose('[data-test-land-use-action-picker]', 'Zoning Special Permit');
+    await selectChoose('[data-test-land-use-action-picker]', 'Zoning Authorization');
 
-    assert.dom(this.element).includesText('How many Zoning Special Permit actions?');
-    assert.dom(this.element).includesText('Where in the Zoning Resolution can this action be found?');
-    assert.dom(this.element).includesText('Which sections of the Zoning Resolution does this modify?');
+    // Check that we can add "Zoning Special Permit" and "Zoning Authorization"
+    assert.dom('[data-test-action-name="Zoning Special Permit"]').exists({ count: 1 });
+    assert.dom('[data-test-action-name="Zoning Authorization"]').exists({ count: 1 });
 
-    assert.ok(!this.package.pasForm.dcpPfzoningspecialpermit);
-    assert.ok(!this.package.pasForm.dcpZoningspecialpermitpursuantto);
-    assert.ok(!this.package.pasForm.dcpZoningspecialpermittomodify);
+    // Check that count field is set to 1 and that extra questions are not yet filled
+    assert.equal(this.package.pasForm.dcpPfzoningspecialpermit, 1);
+    assert.equal(this.package.pasForm.dcpZoningspecialpermitpursuantto, undefined);
+    assert.equal(this.package.pasForm.dcpZoningspecialpermittomodify, undefined);
+    assert.equal(this.package.pasForm.dcpPfzoningauthorization, 1);
+    assert.equal(this.package.pasForm.dcpZoningauthorizationpursuantto, undefined);
+    assert.equal(this.package.pasForm.dcpZoningauthorizationtomodify, undefined);
 
+    // fill in count field for Zoning Special Permit
     await fillIn('[data-test-input="dcpPfzoningspecialpermit"]', 6);
-
     assert.equal(this.package.pasForm.dcpPfzoningspecialpermit, 6);
     // make sure that changing one count field input did not affect the other
-    assert.equal(this.package.pasForm.dcpPfchangeincitymap, 2);
+    assert.equal(this.package.pasForm.dcpPfzoningauthorization, 1);
+    // fill in count field for Zoning Authorization
+    await fillIn('[data-test-input="dcpPfzoningauthorization"]', 4);
+    assert.equal(this.package.pasForm.dcpPfzoningauthorization, 4);
+    // make sure that changing one count field input did not affect the other
+    assert.equal(this.package.pasForm.dcpPfzoningspecialpermit, 6);
 
+    // check that user can fill in extra questions
     await fillIn('[data-test-input="dcpZoningspecialpermitpursuantto"]', 'Section 5B');
-
     assert.equal(this.package.pasForm.dcpZoningspecialpermitpursuantto, 'Section 5B');
-
     await fillIn('[data-test-input="dcpZoningspecialpermittomodify"]', 'Permit 7A');
-
     assert.equal(this.package.pasForm.dcpZoningspecialpermittomodify, 'Permit 7A');
   });
 
-  test('User can delete an action', async function(assert) {
-    const projectPackage = this.server.create('package');
+  test('User can delete actions', async function(assert) {
+    const projectPackage = this.server.create('package', 1, 'applicant', 'withLandUseActions');
 
     this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form' });
 
@@ -70,7 +70,13 @@ module('Integration | Component | land-use-action', function(hooks) {
       </LandUseAction>
     `);
 
-    // Check that user can delete "Zoning Special Permit"
+    // Check that user can delete action loaded from db, "Change in CityMap"
+    assert.equal(this.package.pasForm.dcpPfchangeincitymap, 1);
+    await click('[data-test-delete-button="Change in CityMap"]');
+    assert.equal(this.package.pasForm.dcpPfchangeincitymap, 0);
+    assert.dom('[data-test-action-name="Change in CityMap"]').doesNotExist();
+
+    // Check that user can delete "Zoning Special Permit" after adding
     await selectChoose('[data-test-land-use-action-picker]', 'Zoning Special Permit');
 
     await fillIn('[data-test-input="dcpPfzoningspecialpermit"]', 6);
@@ -87,6 +93,7 @@ module('Integration | Component | land-use-action', function(hooks) {
 
     await click('[data-test-delete-button="Zoning Special Permit"]');
 
+    assert.dom('[data-test-action-name="Zoning Special Permit"]').doesNotExist();
     assert.equal(this.package.pasForm.dcpPfzoningspecialpermit, 0);
     assert.equal(this.package.pasForm.dcpZoningspecialpermitpursuantto, '');
     assert.equal(this.package.pasForm.dcpZoningspecialpermittomodify, '');
@@ -103,13 +110,15 @@ module('Integration | Component | land-use-action', function(hooks) {
       </LandUseAction>
     `);
 
+    assert.dom('[data-test-action-name="Change in CityMap"]').exists({ count: 1 });
+    assert.dom('[data-test-action-name="Zoning Certification"]').exists({ count: 1 });
+    assert.dom('[data-test-action-name="Zoning Text Amendment"]').exists({ count: 1 });
+
     assert.dom('[data-test-input="dcpPfzoningcertification"]').hasValue('21');
     assert.dom('[data-test-input="dcpZoningpursuantto"]').hasValue('some value');
     assert.dom('[data-test-input="dcpZoningtomodify"]').hasValue('some other val');
-    assert.dom('[data-test-input="dcpPfzoningtextamendment"]').hasValue('2');
     assert.dom('[data-test-input="dcpAffectedzrnumber"]').hasNoValue();
     assert.dom('[data-test-input="dcpZoningresolutiontitle"]').hasNoValue();
-    assert.dom('[data-test-input="dcpPfchangeincitymap"]').hasValue('4');
   });
 
   test('Issue #235 Bug: Updating action inputs does not cause actions to show up twice', async function(assert) {

--- a/client/tests/integration/components/land-use-action-test.js
+++ b/client/tests/integration/components/land-use-action-test.js
@@ -153,4 +153,32 @@ module('Integration | Component | land-use-action', function(hooks) {
     // check that setting field on the model did NOT add another instance of the action to the UI
     assert.dom('[data-test-input="dcpPfzoningspecialpermit"]').exists({ count: 1 });
   });
+
+  test('selected actions are sorted properly', async function(assert) {
+    const projectPackage = this.server.create('package', 1, 'applicant', 'withLandUseActions');
+
+    this.package = await this.owner.lookup('service:store').findRecord('package', projectPackage.id, { include: 'pas-form' });
+
+    // Template block usage:
+    await render(hbs`
+      <LandUseAction @pasForm={{this.package.pasForm}}>
+      </LandUseAction>
+    `);
+
+    // selectedActions should be sorted:
+    // (1) all new (added by user) actions should be on top, sorted by most recently added on top
+    // (2) all actions from db should be on bottom, sorted alphabetically
+
+    assert.dom('[data-test-action-name="Change in CityMap"]').exists({ count: 1 });
+    assert.dom('[data-test-action-name="Zoning Certification"]').exists({ count: 1 });
+    assert.dom('[data-test-action-name="Zoning Text Amendment"]').exists({ count: 1 });
+
+    // if added in this order, should be sorted: (1) Renewal (2) Acquisition (3) Landfill
+    await selectChoose('[data-test-land-use-action-picker]', 'Landfill');
+    await selectChoose('[data-test-land-use-action-picker]', 'Acquisition of Real Property');
+    await selectChoose('[data-test-land-use-action-picker]', 'Renewal');
+
+    // check that order is: (1) Renewal (2) Acquisition (3) Landfill (4) CityMap (5) Zoning Cert (6) Zoning Text Amendment
+    assert.dom(this.element).hasText('Add a Proposed Action: -- select an action -- Land Use Actions Included in This Project Renewal Previous ULURP Numbers: ex. 200307ZRK Delete Action Acquisition of Real Property Delete Action Landfill Delete Action Change in CityMap Delete Action Zoning Certification How many Zoning Certification actions? Where in the Zoning Resolution can this action be found? Provide the Zoning Resolution section number. Ex. ZR Sec. 74-711 Which sections of the Zoning Resolution does this modify? Provide the Zoning Resolution section number(s). Ex. ZR Sec. 42-10 and 43-17 Delete Action Zoning Text Amendment Affected ZR Section Number: Provide the Zoning Resolution section number. Ex. ZR Sec. 74-711 Affected ZR Section Title: Provide the Zoning Resolution section Title. Ex. EXAMPLE Delete Action');
+  });
 });


### PR DESCRIPTION
**Feature Update:**
- Only "Zoning Authorization", "Zoning Certification", and "Zoning Special Permit" now have a count field input. When an action is added from the dropdown, its count field is automatically set to 1. Addresses #245 

**Refactor:**
- Create a new array `actionsAddedByUser` that acts as a reference array for distinguishing new actions that the user has selected from the dropdown.
- Redefine `selectedActions` by filtering by actions that have values set on the model OR exist in `actionsAddedByUser` array. By avoiding combining two different arrays (one "new" and one "existing"), and instead just filtering ONE array we can simplify this computed property and avoid double counting actions that might meet both criteria.

**Sorting:**
- Add sorting logic. Actions should be sorted by: (1) if they're from the db they should be on the bottom of the list and sorted alphabetically. (2) if they have been added by the user from the dropdown they should be sorted on top with most recently added first. Addresses #254 