### PR TITLE
Make generic save button; make more generic pas-form

### DIFF
--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -720,22 +720,20 @@
 
       <div class="sticky-sidebar">
         <Packages::SaveButton
-          @onClick={{perform this.save}}
-          @isEnabled={{this.isSaveable}}
-          @isRunning={{this.save.isRunning}}
-          @isSaved={{and (not this.isSaveable) (not this.save.isRunning)}}
+          @onClick={{this.save}}
+          @isEnabled={{or @package.isDirty (and this.saveableChanges.isDirty this.saveableChanges.isValid)}}
           data-test-save-button
         />
         {{!-- Error Handling --}}
         <Packages::PasFormError @pasForm={{this.pasForm}}/>
         <Packages::SaveButton
           @onClick={{this.toggleModal}}
-          @isEnabled={{this.isSubmittable}}
-          @isRunning={{this.submit.isRunning}}
+          @isEnabled={{this.submittableChanges.isValid}}
           @isSubmit={{true}}
           class="secondary"
           data-test-submit-button
         />
+
         {{#if this.modalIsOpen}}
           <EmberWormhole @to="reveal-modal-container">
             <RevealModal @toggle={{this.toggleModal}}>
@@ -748,7 +746,7 @@
                   <button
                     type="button"
                     class="button expanded large secondary"
-                    disabled={{this.submit.isRunning}}
+                    disabled={{this.saveChangeset.isRunning}}
                     {{on "click" this.toggleModal}}
                   >
                     Continue Editing
@@ -756,9 +754,8 @@
                 </div>
                 <div class="cell large-6 small-padding-left">
                   <Packages::SaveButton
-                    @onClick={{perform this.submit}}
-                    @isEnabled={{not this.submit.isRunning}}
-                    @isRunning={{this.submit.isRunning}}
+                    @onClick={{this.submit}}
+                    @isEnabled={{this.submittableChanges.isValid}}
                     @isSubmit={{true}}
                     class="no-margin"
                     data-test-confirm-submit-button

--- a/client/app/components/packages/save-button.hbs
+++ b/client/app/components/packages/save-button.hbs
@@ -1,14 +1,14 @@
 <button
   type="button"
-  class="button expanded large {{if @isSaved 'button--saved'}}"
-  disabled={{not @isEnabled}}
-  {{on "click" @onClick}}
+  class="button expanded large {{if this.didSave 'button--saved'}}"
+  disabled={{not this.isEnabled}}
+  {{on "click" (perform this.clickTask)}}
   ...attributes
 >
-  {{#if @isRunning}}
+  {{#if this.clickTask.isRunning}}
     <FaIcon @icon="spinner" @spin={{true}} @pulse={{true}} class="small-margin-right" />
     {{if @isSubmit 'Submitting' 'Saving'}}
-  {{else if @isSaved}}
+  {{else if this.didSave}}
     <FaIcon @icon="check" class="small-margin-right" />
     {{if @isSubmit 'Submitted' 'Saved'}}
   {{else}}

--- a/client/app/components/packages/save-button.js
+++ b/client/app/components/packages/save-button.js
@@ -1,0 +1,25 @@
+import Component from '@glimmer/component';
+import { task } from 'ember-concurrency';
+
+// isSubmit, isEnabled, onClick
+// onClick can be a promise/task — it's wrapped in a task
+// see ember-concurrency docs for more on the API about clickTask
+export default class SaveButtonComponent extends Component {
+  // enabledness depends on some upstream context
+  // we want the consumer to determine enabledness
+  // used directly on the save button for enabledness
+  get isEnabled() {
+    return this.args.isEnabled && !this.clickTask.isRunning;
+  }
+
+  // depends on whether the task has run and was successful
+  get didSave() {
+    return !this.isEnabled && this.clickTask.lastSuccessful;
+  }
+
+  // triggered when the button is clicked
+  @task(function* () {
+    yield this.args.onClick();
+  })
+  clickTask;
+}

--- a/client/app/models/package.js
+++ b/client/app/models/package.js
@@ -125,4 +125,12 @@ export default class PackageModel extends Model {
 
     await this.save();
   }
+
+  get isDirty() {
+    return this.hasDirtyAttributes
+      || this.fileManager.isDirty
+      || this.pasForm.hasDirtyAttributes
+      || this.pasForm.isBblsDirty
+      || this.pasForm.isApplicantsDirty;
+  }
 }

--- a/client/tests/unit/models/project-test.js
+++ b/client/tests/unit/models/project-test.js
@@ -13,4 +13,15 @@ module('Unit | Model | project', function(hooks) {
 
     assert.ok(model);
   });
+
+  test('pasPackages works when no packages available', function(assert) {
+    const store = this.owner.lookup('service:store');
+    const model = store.createRecord('project', {
+      packages: [],
+    });
+
+    assert.equal(model.pasPackages.length, 0);
+
+    assert.ok(model);
+  });
 });


### PR DESCRIPTION
This refactors parts of the pas-form and most of the save-button to be a little more generic, know a little less about each other.

This simplifies the save-button public API surface, encapsulates some of the button-specific state that pas-form was taking care.

Validations are injectable now, moving the pas-form component to something a little more generic, but not yet.