### PR TITLE
197: validate land use action fields for save and submit

### DIFF
--- a/client/app/components/action-form-input.hbs
+++ b/client/app/components/action-form-input.hbs
@@ -1,7 +1,7 @@
 <Input
   class="action-form-input"
   type={{@fieldType}}
-  maxlength="200"
+  maxlength={{@length}}
   @min="1"
   placeholder=""
   autocomplete="off"

--- a/client/app/components/land-use-action.hbs
+++ b/client/app/components/land-use-action.hbs
@@ -29,50 +29,114 @@
           <div class="shrink cell">
             <label for="middle-label" class="middle">How many {{landUseAction.name}} actions?</label>
           </div>
-          <div class="auto cell">
-            <ActionFormInput @pasForm={{@pasForm}} @fieldType="number" @landUseActionField={{landUseAction.countField}}/>
-          </div>
+        </div>
+        <div class="auto cell">
+          <ActionFormInput 
+            @pasForm={{@pasForm}}
+            @fieldType="number"
+            @length="10"
+            @landUseActionField={{landUseAction.countField}}
+          />
+          <ValidationMessage
+            @changesetError={{get @submittableChanges.error landUseAction.countField}}
+          />
         </div>
         <label class="action-form-label">
           Where in the Zoning Resolution can this action be found?
-          <ActionFormInput @pasForm={{@pasForm}} @fieldType="text" @landUseActionField={{landUseAction.attr1}}/>
-          <span class="help-text">Provide all known Zoning Resolution section numbers or indicate if unsure at this time. Ex. ZR Sec. 74-711 and 74-715</span>
+          <ActionFormInput 
+            @pasForm={{@pasForm}}
+            @fieldType="text"
+            @length="250"
+            @landUseActionField={{landUseAction.attr1}}
+          />
+          <ValidationMessage
+            @changesetError={{get @submittableChanges.error landUseAction.attr1}}
+          />
+          <span class="help-text">Provide the Zoning Resolution section number. Ex. ZR Sec. 74-711</span>
         </label>
         <label class="action-form-label">
           Which sections of the Zoning Resolution does this modify?
-          <ActionFormInput @pasForm={{@pasForm}} @fieldType="text" @landUseActionField={{landUseAction.attr2}}/>
-          <span class="help-text">Provide all known Zoning Resolution section numbers or indicate if unsure at this time. Ex. ZR Sec. 42-10 and 43-17</span>
+          <ActionFormInput
+            @pasForm={{@pasForm}}
+            @fieldType="text"
+            @length="250"
+            @landUseActionField={{landUseAction.attr2}}
+          />
+          <ValidationMessage
+            @changesetError={{get @submittableChanges.error landUseAction.attr2}}
+          />
+          <span class="help-text">Provide the Zoning Resolution section number(s). Ex. ZR Sec. 42-10 and 43-17</span>
         </label>
       {{/if}}
       {{#if (eq landUseAction.name "Zoning Map Amendment")}}
         <label class="action-form-label">
           Existing Zoning Districts:
-          <ActionFormInput @pasForm={{@pasForm}} @fieldType="text" @landUseActionField={{landUseAction.attr1}}/>
-          <span class="help-text">Provide all known zoning districts. Ex. R7-1/C2-4</span>
+          <ActionFormInput
+            @pasForm={{@pasForm}}
+            @fieldType="text"
+            @length="250"
+            @landUseActionField={{landUseAction.attr1}}
+          />
+          <ValidationMessage
+            @changesetError={{get @submittableChanges.error landUseAction.attr1}}
+          />
+          <span class="help-text">ex. R7-1/C2-4</span>
         </label>
         <label>
           Proposed Zoning Districts:
-          <ActionFormInput @pasForm={{@pasForm}} @fieldType="text" @landUseActionField={{landUseAction.attr2}}/>
-          <span class="help-text">Provide all known zoning districts. Ex. C4-5X</span>
+          <ActionFormInput
+            @pasForm={{@pasForm}}
+            @fieldType="text"
+            @length="250"
+            @landUseActionField={{landUseAction.attr2}}
+          />
+          <ValidationMessage
+            @changesetError={{get @submittableChanges.error landUseAction.attr2}}
+          />
+          <span class="help-text">ex. C4-5X</span>
         </label>
       {{/if}}
       {{#if (eq landUseAction.name "Zoning Text Amendment")}}
         <label class="action-form-label">
           Affected ZR Section Number:
-          <ActionFormInput @pasForm={{@pasForm}} @fieldType="text" @landUseActionField={{landUseAction.attr1}}/>
+          <ActionFormInput
+            @pasForm={{@pasForm}}
+            @fieldType="text"
+            @length="250"
+            @landUseActionField={{landUseAction.attr1}}
+          />
+          <ValidationMessage
+            @changesetError={{get @submittableChanges.error landUseAction.attr1}}
+          />
           <span class="help-text">Provide the Zoning Resolution section number. Ex. ZR Sec. 74-711</span>
         </label>
         <label class="action-form-label">
           Affected ZR Section Title:
-          <ActionFormInput @pasForm={{@pasForm}} @fieldType="text" @landUseActionField={{landUseAction.attr2}}/>
-          <span class="help-text">Provide the Zoning Resolution section Title. Ex. "Landmark preservation in all districts"</span>
+          <ActionFormInput
+            @pasForm={{@pasForm}}
+            @fieldType="text"
+            @length="250"
+            @landUseActionField={{landUseAction.attr2}}
+          />
+          <ValidationMessage
+            @changesetError={{get @submittableChanges.error landUseAction.attr2}}
+          />
+          <span class="help-text">Provide the Zoning Resolution section Title. Ex. EXAMPLE</span>
         </label>
       {{/if}}
       {{#if (or (eq landUseAction.name "Modification") (eq landUseAction.name "Renewal"))}}
         <label class="action-form-label">
           Previous ULURP Numbers:
-          <ActionFormInput @pasForm={{@pasForm}} @fieldType="text" @landUseActionField={{landUseAction.attr1}}/>
-          <span class="help-text">Ex. 200307ZRK</span>
+          <ActionFormInput
+            @pasForm={{@pasForm}}
+            @fieldType="text"
+            @length="100"
+            @landUseActionField={{landUseAction.attr1}}
+          />
+          <ValidationMessage
+            @changesetError={{get @submittableChanges.error landUseAction.attr1}}
+          />
+          <span class="help-text">ex. 200307ZRK</span>
         </label>
       {{/if}}
     {{else}}

--- a/client/app/components/land-use-action.js
+++ b/client/app/components/land-use-action.js
@@ -3,7 +3,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 // lookup to match action titles to their associated attributes
-export const allLandUseActionOptions = [
+export const All_LAND_USE_ACTION_OPTIONS = [
   {
     name: 'Acquisition of Real Property', countField: 'dcpPfacquisitionofrealproperty', attr1: '', attr2: '',
   },
@@ -69,7 +69,11 @@ export default class LandUseActionComponent extends Component {
   get selectedActions() {
     const { pasForm } = this.args;
     const newActions = this.actionsAddedByUser;
-    return allLandUseActionOptions.filter((option) => pasForm[option.countField] || pasForm[option.attr1] || pasForm[option.attr2] || newActions.includes(option));
+    return All_LAND_USE_ACTION_OPTIONS
+      .filter((option) => pasForm[option.countField]
+      || pasForm[option.attr1]
+      || pasForm[option.attr2]
+      || newActions.includes(option));
   }
 
   // sorting: actions from db all on bottom in alphabetical order
@@ -105,7 +109,8 @@ export default class LandUseActionComponent extends Component {
 
   // actions that appear in dropdown sorted alphabetically
   get availableActions() {
-    return allLandUseActionOptions.filter((option) => !this.selectedActions.includes(option))
+    return All_LAND_USE_ACTION_OPTIONS
+      .filter((option) => !this.selectedActions.includes(option))
       .sort((a, b) => ((a.name > b.name) ? 1 : -1));
   }
 
@@ -121,7 +126,7 @@ export default class LandUseActionComponent extends Component {
 
     this.actionsAddedByUser.removeObject(actionToRemove);
     // reset all model attributes
-    pasForm[actionToRemove.countField] = 0;
+    pasForm[actionToRemove.countField] = null;
     pasForm[actionToRemove.attr1] = '';
     pasForm[actionToRemove.attr2] = '';
   }

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -105,9 +105,9 @@
           <p class="text-small">
             Note: This is preliminary information and may change following discussion with NYC Planning.
           </p>
-
           <LandUseAction
             @pasForm={{saveable-form.saveableChanges}}
+            @submittableChanges={{saveable-form.submittableChanges}}
           />
         </section>
 

--- a/client/app/components/validation-message.hbs
+++ b/client/app/components/validation-message.hbs
@@ -1,6 +1,7 @@
 {{#if @changesetError}}
   <span
     class="text-red"
+    data-test-validation-message="{{@changesetError.validation.firstObject}}"
     ...attributes
   >
     {{@changesetError.validation}}

--- a/client/app/validations/saveable-pas-form.js
+++ b/client/app/validations/saveable-pas-form.js
@@ -115,4 +115,109 @@ export default {
       message: 'Text is too long (max 2000 characters)',
     }),
   ],
+
+  dcpZoningauthorizationpursuantto: [
+    validateLength({
+      max: 250,
+      message: 'Text is too long (max 250 characters)',
+    }),
+  ],
+
+  dcpZoningauthorizationtomodify: [
+    validateLength({
+      max: 250,
+      message: 'Text is too long (max 250 characters)',
+    }),
+  ],
+
+  dcpZoningtomodify: [
+    validateLength({
+      max: 250,
+      message: 'Text is too long (max 250 characters)',
+    }),
+  ],
+
+  dcpZoningpursuantto: [
+    validateLength({
+      max: 250,
+      message: 'Text is too long (max 250 characters)',
+    }),
+  ],
+
+  dcpExistingmapamend: [
+    validateLength({
+      max: 250,
+      message: 'Text is too long (max 250 characters)',
+    }),
+  ],
+
+  dcpProposedmapamend: [
+    validateLength({
+      max: 250,
+      message: 'Text is too long (max 250 characters)',
+    }),
+  ],
+
+  dcpZoningspecialpermitpursuantto: [
+    validateLength({
+      max: 250,
+      message: 'Text is too long (max 250 characters)',
+    }),
+  ],
+
+  dcpZoningspecialpermittomodify: [
+    validateLength({
+      max: 250,
+      message: 'Text is too long (max 250 characters)',
+    }),
+  ],
+
+  dcpAffectedzrnumber: [
+    validateLength({
+      max: 250,
+      message: 'Text is too long (max 250 characters)',
+    }),
+  ],
+
+  dcpZoningresolutiontitle: [
+    validateLength({
+      max: 250,
+      message: 'Text is too long (max 250 characters)',
+    }),
+  ],
+
+  dcpPreviousulurpnumbers1: [
+    validateLength({
+      max: 100,
+      message: 'Text is too long (max 250 characters)',
+    }),
+  ],
+
+  dcpPreviousulurpnumbers2: [
+    validateLength({
+      max: 100,
+      message: 'Text is too long (max 250 characters)',
+    }),
+  ],
+
+  dcpPfzoningauthorization: [
+    validateLength({
+      max: 10,
+      message: 'Text is too long (max 10 characters)',
+    }),
+  ],
+
+  dcpPfzoningcertification: [
+    validateLength({
+      max: 10,
+      message: 'Text is too long (max 10 characters)',
+    }),
+  ],
+
+  dcpPzoningspecialpermit: [
+    validateLength({
+      max: 10,
+      message: 'Text is too long (max 10 characters)',
+    }),
+  ],
 };

--- a/client/app/validations/submittable-pas-form.js
+++ b/client/app/validations/submittable-pas-form.js
@@ -1,5 +1,6 @@
 import SaveablePasForm from './saveable-pas-form';
 import validatePresenceIf from '../validators/required-if-selected';
+import validateNumberIf from '../validators/validate-number-if';
 
 export default {
   ...SaveablePasForm,
@@ -60,6 +61,126 @@ export default {
       on: 'dcpDiscressionaryfundingforffordablehousing',
       withValue: 717170000,
       message: 'This field is required',
+    }),
+  ],
+  dcpZoningauthorizationpursuantto: [
+    validatePresenceIf({
+      presence: true,
+      on: 'dcpPfzoningauthorization',
+      withValue: (target) => target !== null && target !== undefined,
+      message: 'This field is required',
+    }),
+  ],
+  dcpZoningauthorizationtomodify: [
+    validatePresenceIf({
+      presence: true,
+      on: 'dcpPfzoningauthorization',
+      withValue: (target) => target !== null && target !== undefined,
+      message: 'This field is required',
+    }),
+  ],
+  dcpZoningtomodify: [
+    validatePresenceIf({
+      presence: true,
+      on: 'dcpPfzoningcertification',
+      withValue: (target) => target !== null && target !== undefined,
+      message: 'This field is required',
+    }),
+  ],
+  dcpZoningpursuantto: [
+    validatePresenceIf({
+      presence: true,
+      on: 'dcpPfzoningcertification',
+      withValue: (target) => target !== null && target !== undefined,
+      message: 'This field is required',
+    }),
+  ],
+  dcpExistingmapamend: [
+    validatePresenceIf({
+      presence: true,
+      on: 'dcpPfzoningmapamendment',
+      withValue: 1,
+      message: 'This field is required',
+    }),
+  ],
+  dcpProposedmapamend: [
+    validatePresenceIf({
+      presence: true,
+      on: 'dcpPfzoningmapamendment',
+      withValue: 1,
+      message: 'This field is required',
+    }),
+  ],
+  dcpZoningspecialpermitpursuantto: [
+    validatePresenceIf({
+      presence: true,
+      on: 'dcpPfzoningspecialpermit',
+      withValue: (target) => target !== null && target !== undefined,
+      message: 'This field is required',
+    }),
+  ],
+  dcpZoningspecialpermittomodify: [
+    validatePresenceIf({
+      presence: true,
+      on: 'dcpPfzoningspecialpermit',
+      withValue: (target) => target !== null && target !== undefined,
+      message: 'This field is required',
+    }),
+  ],
+  dcpAffectedzrnumber: [
+    validatePresenceIf({
+      presence: true,
+      on: 'dcpPfzoningtextamendment',
+      withValue: 1,
+      message: 'This field is required',
+    }),
+  ],
+  dcpZoningresolutiontitle: [
+    validatePresenceIf({
+      presence: true,
+      on: 'dcpPfzoningtextamendment',
+      withValue: 1,
+      message: 'This field is required',
+    }),
+  ],
+  dcpPreviousulurpnumbers1: [
+    validatePresenceIf({
+      presence: true,
+      on: 'dcpPfmodification',
+      withValue: 1,
+      message: 'This field is required',
+    }),
+  ],
+  dcpPreviousulurpnumbers2: [
+    validatePresenceIf({
+      presence: true,
+      on: 'dcpPfrenewal',
+      withValue: 1,
+      message: 'This field is required',
+    }),
+  ],
+  dcpPfzoningauthorization: [
+    validateNumberIf({
+      on: 'dcpPfzoningauthorization',
+      withValue: (target) => target !== null && target !== undefined,
+      gte: 1,
+      message: 'Number of actions must be greater than 0.',
+    }),
+  ],
+  dcpPfzoningcertification: [
+    validateNumberIf({
+      on: 'dcpPfzoningcertification',
+      withValue: (target) => target !== null && target !== undefined,
+      gte: 1,
+      message: 'Number of actions must be greater than 0.',
+    }),
+  ],
+  dcpPfzoningspecialpermit: [
+    validateNumberIf({
+      on: 'dcpPfzoningspecialpermit',
+      withValue: (target) => target !== null && target !== undefined,
+      gte: 1,
+      message: 'Number of actions must be greater than 0.',
     }),
   ],
 };

--- a/client/app/validators/validate-number-if.js
+++ b/client/app/validators/validate-number-if.js
@@ -1,23 +1,18 @@
 import {
-  validatePresence,
+  validateNumber,
 } from 'ember-changeset-validations/validators';
 
-export default function validatePresenceIf(options) {
+export default function validateNumberIf(options) {
   const { withValue, on } = options;
 
   return (...args) => {
     const [,,, changes, content] = args;
     const target = Object.prototype.hasOwnProperty.call(changes, on) ? changes[on] : content[on];
-    let hasMatchingWith;
 
-    if (typeof withValue === 'function') {
-      hasMatchingWith = withValue(target);
-    } else {
-      hasMatchingWith = target === withValue;
-    }
+    const hasMatchingWith = withValue(target);
 
     if (hasMatchingWith) {
-      return validatePresence(options)(...args);
+      return validateNumber(options)(...args);
     }
 
     return true;

--- a/client/tests/acceptance/land-use-action-fields-validate-test.js
+++ b/client/tests/acceptance/land-use-action-fields-validate-test.js
@@ -1,0 +1,76 @@
+import { module, test } from 'qunit';
+import {
+  visit,
+  fillIn,
+} from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import { selectChoose } from 'ember-power-select/test-support';
+
+module('Acceptance | land use action fields validate', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(() => {
+    authenticateSession({
+      emailaddress1: 'me@me.com',
+    });
+  });
+
+  test('validation message appears for count field when user types incorrect value', async function(assert) {
+    this.server.create('package', {
+      project: this.server.create('project'),
+      pasForm: this.server.create('pas-form'),
+    });
+
+    await visit('/packages/1/edit');
+
+    await selectChoose('[data-test-land-use-action-picker]', 'Zoning Authorization');
+
+    assert.dom('[data-test-validation-message="Number of actions must be greater than 0."]').doesNotExist();
+
+    await fillIn('[data-test-input="dcpPfzoningauthorization"]', '-1');
+
+    assert.dom('[data-test-validation-message="Number of actions must be greater than 0."]').exists();
+
+    await fillIn('[data-test-input="dcpPfzoningauthorization"]', '0');
+
+    assert.dom('[data-test-validation-message="Number of actions must be greater than 0."]').exists();
+
+    await fillIn('[data-test-input="dcpPfzoningauthorization"]', '');
+
+    assert.dom('[data-test-validation-message="Number of actions must be greater than 0."]').exists();
+
+    await fillIn('[data-test-input="dcpPfzoningauthorization"]', '2');
+
+    assert.dom('[data-test-validation-message="Number of actions must be greater than 0."]').doesNotExist();
+  });
+
+  test('validation message appears for extra questions when user types incorrect value', async function(assert) {
+    this.server.create('package', {
+      project: this.server.create('project'),
+      pasForm: this.server.create('pas-form'),
+    });
+
+    await visit('/packages/1/edit');
+
+    assert.dom('[data-test-validation-message="This field is required."]').doesNotExist();
+
+    // Zoning Authorization
+    await selectChoose('[data-test-land-use-action-picker]', 'Zoning Authorization');
+    assert.dom('[data-test-validation-message="This field is required"]').exists({ count: 2 });
+    await fillIn('[data-test-input="dcpPfzoningauthorization"]', '');
+    assert.dom('[data-test-validation-message="This field is required"]').exists({ count: 2 });
+    await fillIn('[data-test-input="dcpZoningauthorizationpursuantto"]', 'Section 5');
+    assert.dom('[data-test-validation-message="This field is required"]').exists({ count: 1 });
+    await fillIn('[data-test-input="dcpZoningauthorizationtomodify"]', 'Section B');
+    assert.dom('[data-test-validation-message="This field is required"]').doesNotExist();
+
+    // Renewal
+    await selectChoose('[data-test-land-use-action-picker]', 'Renewal');
+    assert.dom('[data-test-validation-message="This field is required"]').exists({ count: 1 });
+    await fillIn('[data-test-input="dcpPreviousulurpnumbers2"]', '7777777');
+    assert.dom('[data-test-validation-message="This field is required"]').doesNotExist();
+  });
+});

--- a/client/tests/integration/components/land-use-action-test.js
+++ b/client/tests/integration/components/land-use-action-test.js
@@ -73,7 +73,7 @@ module('Integration | Component | land-use-action', function(hooks) {
     // Check that user can delete action loaded from db, "Change in CityMap"
     assert.equal(this.package.pasForm.dcpPfchangeincitymap, 1);
     await click('[data-test-delete-button="Change in CityMap"]');
-    assert.equal(this.package.pasForm.dcpPfchangeincitymap, 0);
+    assert.equal(this.package.pasForm.dcpPfchangeincitymap, null);
     assert.dom('[data-test-action-name="Change in CityMap"]').doesNotExist();
 
     // Check that user can delete "Zoning Special Permit" after adding
@@ -94,7 +94,7 @@ module('Integration | Component | land-use-action', function(hooks) {
     await click('[data-test-delete-button="Zoning Special Permit"]');
 
     assert.dom('[data-test-action-name="Zoning Special Permit"]').doesNotExist();
-    assert.equal(this.package.pasForm.dcpPfzoningspecialpermit, 0);
+    assert.equal(this.package.pasForm.dcpPfzoningspecialpermit, null);
     assert.equal(this.package.pasForm.dcpZoningspecialpermitpursuantto, '');
     assert.equal(this.package.pasForm.dcpZoningspecialpermittomodify, '');
   });
@@ -179,6 +179,6 @@ module('Integration | Component | land-use-action', function(hooks) {
     await selectChoose('[data-test-land-use-action-picker]', 'Renewal');
 
     // check that order is: (1) Renewal (2) Acquisition (3) Landfill (4) CityMap (5) Zoning Cert (6) Zoning Text Amendment
-    assert.dom(this.element).hasText('Add a Proposed Action: -- select an action -- Land Use Actions Included in This Project Renewal Previous ULURP Numbers: Ex. 200307ZRK Delete Action Acquisition of Real Property No additional information required for this action Delete Action Landfill No additional information required for this action Delete Action Change in CityMap No additional information required for this action Delete Action Zoning Certification How many Zoning Certification actions? Where in the Zoning Resolution can this action be found? Provide all known Zoning Resolution section numbers or indicate if unsure at this time. Ex. ZR Sec. 74-711 and 74-715 Which sections of the Zoning Resolution does this modify? Provide all known Zoning Resolution section numbers or indicate if unsure at this time. Ex. ZR Sec. 42-10 and 43-17 Delete Action Zoning Text Amendment Affected ZR Section Number: Provide the Zoning Resolution section number. Ex. ZR Sec. 74-711 Affected ZR Section Title: Provide the Zoning Resolution section Title. Ex. "Landmark preservation in all districts" Delete Action');
+    assert.dom(this.element).hasText('Add a Proposed Action: -- select an action -- Land Use Actions Included in This Project Renewal Previous ULURP Numbers: ex. 200307ZRK Delete Action Acquisition of Real Property No additional information required for this action Delete Action Landfill No additional information required for this action Delete Action Change in CityMap No additional information required for this action Delete Action Zoning Certification How many Zoning Certification actions? Where in the Zoning Resolution can this action be found? Provide the Zoning Resolution section number. Ex. ZR Sec. 74-711 Which sections of the Zoning Resolution does this modify? Provide the Zoning Resolution section number(s). Ex. ZR Sec. 42-10 and 43-17 Delete Action Zoning Text Amendment Affected ZR Section Number: Provide the Zoning Resolution section number. Ex. ZR Sec. 74-711 Affected ZR Section Title: Provide the Zoning Resolution section Title. Ex. EXAMPLE Delete Action');
   });
 });


### PR DESCRIPTION
Validate land use action fields for `save`:
- length of fields for land use actions

Validate land use action fields for `submit`:
- Zoning Special Permit, Zoning Certification, and Zoning Authorization count field should be greater than or equal to 1 (creation of a new `validateNumberIf` function for Zoning Authorization, Zoning Certification, and Zoning Special Permit)
- if count field for action exists, assure extra questions are answered
- update `validatePresenceIf` to allow for `!==`. This was necessary for checking whether one of the three zoning fields above were not `null` or `undefined` (if a user has selected one of these options from the dropdown menu, the count field will NOT be null or undefined, but a number or an empty string. We don't want validation to happen if a user has not selected the action from the dropdown menu)

Addresses #197, #251, #257, #275 

Will need to rebase/update once changes in #295 are merged in