### PR TITLE
231 Display Text Input validation messages

### DIFF
--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -30,6 +30,9 @@
             @type="text"
             @value={{this.saveableChanges.dcpRevisedprojectname}} data-test-dcprevisedprojectname
           />
+          <ValidationMessage
+            @changesetError={{this.saveableChanges.error.dcpRevisedprojectname}}
+          />
         </label>
       </section>
 
@@ -72,7 +75,6 @@
             </small>
             <Textarea
               @value={{this.saveableChanges.dcpDescriptionofprojectareageography}}
-              maxlength="2000"
               rows="5"
             />
             <ValidationMessage
@@ -155,10 +157,12 @@
                 <Input
                   @type="text"
                   @value={{this.saveableChanges.dcpUrbanareaname}}
-                  maxlength="250"
                   data-test-dcpurbanrenewalareaname
                 />
 
+                <ValidationMessage
+                  @changesetError={{this.saveableChanges.error.dcpUrbanareaname}}
+                />
                 <ValidationMessage
                   @changesetError={{this.submittableChanges.error.dcpUrbanareaname}}
                   data-test-dcpurbanrenewalareaname-validation
@@ -223,8 +227,10 @@
                 <Input
                   @type="text"
                   @value={{this.saveableChanges.dcpPleaseexplaintypeiienvreview}}
-                  maxlength="200"
                   data-test-dcppleaseexplaintypeiienvreview
+                />
+                <ValidationMessage
+                  @changesetError={{this.saveableChanges.error.dcpPleaseexplaintypeiienvreview}}
                 />
                 <ValidationMessage
                   @changesetError={{this.submittableChanges.error.dcpPleaseexplaintypeiienvreview}}
@@ -256,8 +262,10 @@
                 <Input
                   @type="text"
                   @value={{this.saveableChanges.dcpProjectareaindutrialzonename}}
-                  maxlength="200"
                   data-test-dcpprojectareaindustrialbusinesszonename
+                />
+                <ValidationMessage
+                  @changesetError={{this.saveableChanges.error.dcpProjectareaindutrialzonename}}
                 />
                 <ValidationMessage
                   @changesetError={{this.submittableChanges.error.dcpProjectareaindutrialzonename}}
@@ -290,8 +298,10 @@
                   @type="text"
                   @value={{this.saveableChanges.dcpProjectarealandmarkname}}
                   @changed={{this.validate}}
-                  maxlength="250"
                   data-test-dcpisprojectarealandmarkname
+                />
+                <ValidationMessage
+                  @changesetError={{this.saveableChanges.error.dcpProjectarealandmarkname}}
                 />
                 <ValidationMessage
                   @changesetError={{this.submittableChanges.error.dcpProjectarealandmarkname}}
@@ -364,11 +374,10 @@
                 <Input
                   @type="text"
                   @value={{this.saveableChanges.dcpCityregisterfilenumber}}
-                  maxlength="25"
                   data-test-dcpcityregisterfilenumber
                 />
                 <ValidationMessage
-                  @changesetError={{this.submittableChanges.error.dcpCityregisterfilenumber}}
+                  @changesetError={{this.saveableChanges.error.dcpCityregisterfilenumber}}
                 />
               </label>
             {{/if}}
@@ -409,11 +418,10 @@
             <Input
               @type="text"
               @value={{this.saveableChanges.dcpEstimatedcompletiondate}}
-              maxlength="4"
               data-test-dcpestimatedcompletiondate
             />
             <ValidationMessage
-              @changesetError={{this.submittableChanges.error.dcpEstimatedcompletiondate}}
+              @changesetError={{this.saveableChanges.error.dcpEstimatedcompletiondate}}
             />
             {{!-- QUESTION: Should this be a date picker? --}}
           </label>
@@ -485,6 +493,9 @@
                   @value={{this.saveableChanges.dcpProposeddevelopmentsiteotherexplanation}}
                   data-test-dcpproposeddevelopmentsiteotherexplanation
                 />
+                <ValidationMessage
+                  @changesetError={{this.submittableChanges.error.dcpProposeddevelopmentsiteotherexplanation}}
+                />
               </label>
             {{/if}}
           </fieldset>
@@ -519,6 +530,9 @@
                   @type="text"
                   @value={{this.saveableChanges.dcpInclusionaryhousingdesignatedareaname}}
                   data-test-dcpinclusionaryhousingdesignatedareaname
+                />
+                <ValidationMessage
+                  @changesetError={{this.submittableChanges.error.dcpInclusionaryhousingdesignatedareaname}}
                 />
               </label>
             {{/if}}
@@ -562,6 +576,9 @@
                   </RadioButton>
                 {{/each}}
               </fieldset>
+              <ValidationMessage
+                @changesetError={{this.submittableChanges.error.dcpHousingunittype}}
+              />
             {{/if}}
           </fieldset>
         </section>
@@ -581,7 +598,6 @@
             <Textarea
               @value={{this.saveableChanges.dcpProjectdescriptionproposeddevelopment}}
               rows="5"
-              maxlength="3000"
               data-test-dcpprojectdescriptionproposeddevelopment
             />
             <ValidationMessage
@@ -594,7 +610,6 @@
             <Textarea
               @value={{this.saveableChanges.dcpProjectdescriptionbackground}}
               rows="5"
-              maxlength="2000"
               data-test-dcpprojectdescriptionbackground
             />
             <ValidationMessage
@@ -607,7 +622,6 @@
             <Textarea
               @value={{this.saveableChanges.dcpProjectdescriptionproposedactions}}
               rows="5"
-              maxlength="2000"
               data-test-dcpprojectdescriptionproposedactions
             />
             <ValidationMessage
@@ -620,7 +634,6 @@
             <Textarea
               @value={{this.saveableChanges.dcpProjectdescriptionproposedarea}}
               rows="5"
-              maxlength="3000"
               data-test-dcpprojectdescriptionproposedarea
             />
             <ValidationMessage
@@ -633,7 +646,6 @@
             <Textarea
               @value={{this.saveableChanges.dcpProjectdescriptionsurroundingarea}}
               rows="5"
-              maxlength="3000"
               data-test-dcpprojectdescriptionsurroundingarea
             />
             <ValidationMessage
@@ -649,7 +661,6 @@
             <Textarea
               @value={{this.saveableChanges.dcpProjectattachmentsotherinformation}}
               rows="5"
-              maxlength="3000"
               data-test-dcpprojectattachmentsotherinformation
             />
             <ValidationMessage

--- a/client/app/validations/saveable-pas-form.js
+++ b/client/app/validations/saveable-pas-form.js
@@ -6,6 +6,7 @@ import {
 export default {
   dcpRevisedprojectname: [
     validateLength({
+      min: 0,
       max: 50,
       message: 'Name must be between {min} and {max} characters',
     }),
@@ -13,6 +14,7 @@ export default {
 
   dcpDescriptionofprojectareageography: [
     validateLength({
+      min: 0,
       max: 2000,
       message: 'Must be between {min} and {max} characters',
     }),
@@ -20,6 +22,7 @@ export default {
 
   dcpUrbanareaname: [
     validateLength({
+      min: 0,
       max: 250,
       message: 'Name is too long (max {max} characters)',
     }),
@@ -27,6 +30,7 @@ export default {
 
   dcpPleaseexplaintypeiienvreview: [
     validateLength({
+      min: 0,
       max: 200,
       message: 'Text is too long (max {max} characters)',
     }),
@@ -34,6 +38,7 @@ export default {
 
   dcpProjectareaindutrialzonename: [
     validateLength({
+      min: 0,
       max: 250,
       message: 'Name is too long (max {max} characters)',
     }),
@@ -41,6 +46,7 @@ export default {
 
   dcpProjectarealandmarkname: [
     validateLength({
+      min: 0,
       max: 250,
       message: 'Name is too long (max {max} characters)',
     }),
@@ -48,6 +54,7 @@ export default {
 
   dcpCityregisterfilenumber: [
     validateLength({
+      min: 0,
       max: 25,
       message: 'File Number is too long (max {max} characters)',
     }),
@@ -55,6 +62,7 @@ export default {
 
   dcpEstimatedcompletiondate: [
     validateLength({
+      min: 0,
       max: 4,
       message: 'Please enter a valid year in YYYY format',
     }),
@@ -62,6 +70,7 @@ export default {
 
   dcpProjectdescriptionproposeddevelopment: [
     validateLength({
+      min: 0,
       max: 3000,
       message: 'Text is too long (max {max} characters)',
     }),
@@ -69,6 +78,7 @@ export default {
 
   dcpProjectdescriptionbackground: [
     validateLength({
+      min: 0,
       max: 2000,
       message: 'Text is too long (max {max} characters)',
     }),
@@ -76,6 +86,7 @@ export default {
 
   dcpProjectdescriptionproposedactions: [
     validateLength({
+      min: 0,
       max: 2000,
       message: 'Text is too long (max {max} characters)',
     }),
@@ -83,6 +94,7 @@ export default {
 
   dcpProjectdescriptionproposedarea: [
     validateLength({
+      min: 0,
       max: 3000,
       message: 'Text is too long (max 3000 characters)',
     }),
@@ -90,6 +102,7 @@ export default {
 
   dcpProjectdescriptionsurroundingarea: [
     validateLength({
+      min: 0,
       max: 3000,
       message: 'Text is too long (max 3000 characters)',
     }),
@@ -97,6 +110,7 @@ export default {
 
   dcpProjectattachmentsotherinformation: [
     validateLength({
+      min: 0,
       max: 2000,
       message: 'Text is too long (max 2000 characters)',
     }),

--- a/client/app/validations/submittable-pas-form.js
+++ b/client/app/validations/submittable-pas-form.js
@@ -11,6 +11,7 @@ export default {
       presence: true,
       on: 'dcpUrbanrenewalarea',
       withValue: 717170000,
+      message: 'This field is required',
     }),
   ],
   dcpPleaseexplaintypeiienvreview: [
@@ -18,6 +19,7 @@ export default {
       presence: true,
       on: 'dcpLanduseactiontype2',
       withValue: 717170000,
+      message: 'This field is required',
     }),
   ],
   dcpProjectareaindutrialzonename: [
@@ -25,6 +27,7 @@ export default {
       presence: true,
       on: 'dcpProjectareaindustrialbusinesszone',
       withValue: true,
+      message: 'This field is required',
     }),
   ],
   dcpProjectarealandmarkname: [
@@ -32,6 +35,7 @@ export default {
       presence: true,
       on: 'dcpIsprojectarealandmark',
       withValue: true,
+      message: 'This field is required',
     }),
   ],
   dcpProposeddevelopmentsiteotherexplanation: [
@@ -39,6 +43,7 @@ export default {
       presence: true,
       on: 'dcpProposeddevelopmentsiteinfoother',
       withValue: true,
+      message: 'This field is required',
     }),
   ],
   dcpInclusionaryhousingdesignatedareaname: [
@@ -46,6 +51,7 @@ export default {
       presence: true,
       on: 'dcpIsinclusionaryhousingdesignatedarea',
       withValue: true,
+      message: 'This field is required',
     }),
   ],
   dcpHousingunittype: [
@@ -53,6 +59,7 @@ export default {
       presence: true,
       on: 'dcpDiscressionaryfundingforffordablehousing',
       withValue: 717170000,
+      message: 'This field is required',
     }),
   ],
 };


### PR DESCRIPTION
Fixes validation messages not showing up for Text Input and TextArea fields.
Does so by removing maxlength attributes. This addresses Issue #231.
Later, we can add character count display to improve user experience.

This commit also:
- adds a 'min' attribute to validateLength validators so
their error messages do not show an undefined variable.
- Displays validation messages in the UI from both
saveableChangeset and submittableChangeset
next to respective fields.