### PR TITLE
Properly extend submittable from saveable changeset

### DIFF
--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -174,7 +174,7 @@
                 <Input
                   @type="text"
                   @value={{saveable-form.saveableChanges.dcpUrbanareaname}}
-                  data-test-dcpurbanrenewalareaname
+                  data-test-dcpurbanareaname
                 />
                 <CharacterCounter
                   @string={{saveable-form.saveableChanges.dcpUrbanareaname}}

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -182,7 +182,7 @@
                 />
                 <ValidationMessage
                   @changesetError={{saveable-form.submittableChanges.error.dcpUrbanareaname}}
-                  data-test-dcpurbanrenewalareaname-validation
+                  data-test-validation-message="dcpUrbanareaname"
                 />
               </label>
             {{/if}}
@@ -253,10 +253,8 @@
                   @maxlength="200"
                 />
                 <ValidationMessage
-                  @changesetError={{saveable-form.saveableChanges.error.dcpPleaseexplaintypeiienvreview}}
-                />
-                <ValidationMessage
                   @changesetError={{saveable-form.submittableChanges.error.dcpPleaseexplaintypeiienvreview}}
+                  data-test-validation-message="dcpPleaseexplaintypeiienvreview"
                 />
               </label>
             {{/if}}
@@ -264,7 +262,16 @@
 
           <fieldset class="medium-margin-bottom">
             <legend>
-              <strong>Is the proposed Project Area in an <a href="https://zola.planning.nyc.gov/" target="_blank" rel="noopener noreferrer">Industrial Business Zone<sup><FaIcon @icon="external-link-alt" @prefix="fas" @fixedWidth={{true}} /></sup></a>?</strong>
+              <strong>
+                Is the proposed Project Area in an&nbsp;
+                <a href="https://zola.planning.nyc.gov/" target="_blank" rel="noopener noreferrer">
+                  Industrial Business Zone
+                  <sup>
+                    <FaIcon @icon="external-link-alt" @prefix="fas" @fixedWidth={{true}} />
+                  </sup>
+                </a>
+                ?
+              </strong>
             </legend>
             {{#each (array
               (hash code=true label='Yes')
@@ -284,17 +291,15 @@
                 <Input
                   @type="text"
                   @value={{saveable-form.saveableChanges.dcpProjectareaindutrialzonename}}
-                  data-test-dcpprojectareaindustrialbusinesszonename
+                  data-test-dcpprojectareaindutrialzonename
                 />
                 <CharacterCounter
                   @string={{saveable-form.saveableChanges.dcpProjectareaindutrialzonename}}
                   @maxlength="200"
                 />
                 <ValidationMessage
-                  @changesetError={{saveable-form.saveableChanges.error.dcpProjectareaindutrialzonename}}
-                />
-                <ValidationMessage
                   @changesetError={{saveable-form.submittableChanges.error.dcpProjectareaindutrialzonename}}
+                  data-test-validation-message="dcpProjectareaindutrialzonename"
                 />
               </label>
             {{/if}}
@@ -323,17 +328,15 @@
                 <Input
                   @type="text"
                   @value={{saveable-form.saveableChanges.dcpProjectarealandmarkname}}
-                  data-test-dcpisprojectarealandmarkname
+                  data-test-dcpprojectarealandmarkname
                 />
                 <CharacterCounter
                   @string={{saveable-form.saveableChanges.dcpProjectarealandmarkname}}
                   @maxlength="250"
                 />
                 <ValidationMessage
-                  @changesetError={{saveable-form.saveableChanges.error.dcpProjectarealandmarkname}}
-                />
-                <ValidationMessage
                   @changesetError={{saveable-form.submittableChanges.error.dcpProjectarealandmarkname}}
+                  data-test-validation-message="dcpProjectarealandmarkname"
                 />
               </label>
             {{/if}}

--- a/client/app/validations/saveable-pas-form.js
+++ b/client/app/validations/saveable-pas-form.js
@@ -214,7 +214,7 @@ export default {
     }),
   ],
 
-  dcpPzoningspecialpermit: [
+  dcpPfzoningspecialpermit: [
     validateLength({
       max: 10,
       message: 'Text is too long (max 10 characters)',

--- a/client/app/validations/submittable-pas-form.js
+++ b/client/app/validations/submittable-pas-form.js
@@ -68,6 +68,7 @@ export default {
     }),
   ],
   dcpZoningauthorizationpursuantto: [
+    ...SaveablePasForm.dcpZoningauthorizationpursuantto,
     validatePresenceIf({
       presence: true,
       on: 'dcpPfzoningauthorization',
@@ -76,6 +77,7 @@ export default {
     }),
   ],
   dcpZoningauthorizationtomodify: [
+    ...SaveablePasForm.dcpZoningauthorizationtomodify,
     validatePresenceIf({
       presence: true,
       on: 'dcpPfzoningauthorization',
@@ -84,6 +86,7 @@ export default {
     }),
   ],
   dcpZoningtomodify: [
+    ...SaveablePasForm.dcpZoningtomodify,
     validatePresenceIf({
       presence: true,
       on: 'dcpPfzoningcertification',
@@ -92,6 +95,7 @@ export default {
     }),
   ],
   dcpZoningpursuantto: [
+    ...SaveablePasForm.dcpZoningpursuantto,
     validatePresenceIf({
       presence: true,
       on: 'dcpPfzoningcertification',
@@ -100,6 +104,7 @@ export default {
     }),
   ],
   dcpExistingmapamend: [
+    ...SaveablePasForm.dcpExistingmapamend,
     validatePresenceIf({
       presence: true,
       on: 'dcpPfzoningmapamendment',
@@ -108,6 +113,7 @@ export default {
     }),
   ],
   dcpProposedmapamend: [
+    ...SaveablePasForm.dcpProposedmapamend,
     validatePresenceIf({
       presence: true,
       on: 'dcpPfzoningmapamendment',
@@ -116,6 +122,7 @@ export default {
     }),
   ],
   dcpZoningspecialpermitpursuantto: [
+    ...SaveablePasForm.dcpZoningspecialpermitpursuantto,
     validatePresenceIf({
       presence: true,
       on: 'dcpPfzoningspecialpermit',
@@ -124,6 +131,7 @@ export default {
     }),
   ],
   dcpZoningspecialpermittomodify: [
+    ...SaveablePasForm.dcpZoningspecialpermittomodify,
     validatePresenceIf({
       presence: true,
       on: 'dcpPfzoningspecialpermit',
@@ -132,6 +140,7 @@ export default {
     }),
   ],
   dcpAffectedzrnumber: [
+    ...SaveablePasForm.dcpAffectedzrnumber,
     validatePresenceIf({
       presence: true,
       on: 'dcpPfzoningtextamendment',
@@ -140,6 +149,7 @@ export default {
     }),
   ],
   dcpZoningresolutiontitle: [
+    ...SaveablePasForm.dcpZoningresolutiontitle,
     validatePresenceIf({
       presence: true,
       on: 'dcpPfzoningtextamendment',
@@ -148,6 +158,7 @@ export default {
     }),
   ],
   dcpPreviousulurpnumbers1: [
+    ...SaveablePasForm.dcpPreviousulurpnumbers1,
     validatePresenceIf({
       presence: true,
       on: 'dcpPfmodification',
@@ -156,6 +167,7 @@ export default {
     }),
   ],
   dcpPreviousulurpnumbers2: [
+    ...SaveablePasForm.dcpPreviousulurpnumbers2,
     validatePresenceIf({
       presence: true,
       on: 'dcpPfrenewal',
@@ -164,6 +176,7 @@ export default {
     }),
   ],
   dcpPfzoningauthorization: [
+    ...SaveablePasForm.dcpPfzoningauthorization,
     validateNumberIf({
       on: 'dcpPfzoningauthorization',
       withValue: (target) => target !== null && target !== undefined,
@@ -172,6 +185,7 @@ export default {
     }),
   ],
   dcpPfzoningcertification: [
+    ...SaveablePasForm.dcpPfzoningcertification,
     validateNumberIf({
       on: 'dcpPfzoningcertification',
       withValue: (target) => target !== null && target !== undefined,
@@ -180,6 +194,7 @@ export default {
     }),
   ],
   dcpPfzoningspecialpermit: [
+    ...SaveablePasForm.dcpPfzoningspecialpermit,
     validateNumberIf({
       on: 'dcpPfzoningspecialpermit',
       withValue: (target) => target !== null && target !== undefined,

--- a/client/app/validations/submittable-pas-form.js
+++ b/client/app/validations/submittable-pas-form.js
@@ -8,6 +8,7 @@ export default {
     ...SaveablePasForm.dcpRevisedprojectname,
   ],
   dcpUrbanareaname: [
+    ...SaveablePasForm.dcpUrbanareaname,
     validatePresenceIf({
       presence: true,
       on: 'dcpUrbanrenewalarea',
@@ -16,6 +17,7 @@ export default {
     }),
   ],
   dcpPleaseexplaintypeiienvreview: [
+    ...SaveablePasForm.dcpPleaseexplaintypeiienvreview,
     validatePresenceIf({
       presence: true,
       on: 'dcpLanduseactiontype2',
@@ -24,6 +26,7 @@ export default {
     }),
   ],
   dcpProjectareaindutrialzonename: [
+    ...SaveablePasForm.dcpProjectareaindutrialzonename,
     validatePresenceIf({
       presence: true,
       on: 'dcpProjectareaindustrialbusinesszone',
@@ -32,6 +35,7 @@ export default {
     }),
   ],
   dcpProjectarealandmarkname: [
+    ...SaveablePasForm.dcpProjectarealandmarkname,
     validatePresenceIf({
       presence: true,
       on: 'dcpIsprojectarealandmark',

--- a/client/tests/acceptance/user-can-click-package-edit-test.js
+++ b/client/tests/acceptance/user-can-click-package-edit-test.js
@@ -146,9 +146,9 @@ module('Acceptance | user can click package edit', function(hooks) {
 
     await visit('/packages/1/edit');
 
-    assert.dom('[data-test-dcpprojectareaindustrialbusinesszonename]').doesNotExist();
+    assert.dom('[data-test-dcpprojectareaindutrialzonename]').doesNotExist();
     await click('[data-test-dcpprojectareaindustrialbusinesszone="Yes"]');
-    assert.dom('[data-test-dcpprojectareaindustrialbusinesszonename]').exists();
+    assert.dom('[data-test-dcpprojectareaindutrialzonename]').exists();
   });
 
   test('Landmark or Historic District sub Q shows conditionally', async function (assert) {
@@ -156,9 +156,9 @@ module('Acceptance | user can click package edit', function(hooks) {
 
     await visit('/packages/1/edit');
 
-    assert.dom('[data-test-dcpisprojectarealandmarkname]').doesNotExist();
+    assert.dom('[data-test-dcpProjectarealandmarkname]').doesNotExist();
     await click('[data-test-dcpIsprojectarealandmark="Yes"]');
-    assert.dom('[data-test-dcpisprojectarealandmarkname]').exists();
+    assert.dom('[data-test-dcpProjectarealandmarkname]').exists();
   });
 
   test('Other Type sub Q shows conditionally', async function (assert) {
@@ -263,19 +263,19 @@ module('Acceptance | user can click package edit', function(hooks) {
 
     await click('[data-test-dcpurbanrenewalarea="Yes"]');
 
-    assert.dom('[data-test-dcpurbanrenewalareaname-validation]').exists();
+    assert.dom('[data-test-validation-message="dcpUrbanareaname"]').exists();
     assert.dom('[data-test-save-button]').hasNoAttribute('disabled');
     assert.dom('[data-test-submit-button]').hasAttribute('disabled');
 
     await fillIn('[data-test-dcpurbanrenewalareaname]', 'abc');
 
-    assert.dom('[data-test-dcpurbanrenewalareaname-validation]').doesNotExist();
+    assert.dom('[data-test-validation-message="dcpUrbanareaname"]').doesNotExist();
     assert.dom('[data-test-save-button]').hasNoAttribute('disabled');
     assert.dom('[data-test-submit-button]').hasNoAttribute('disabled');
 
     await fillIn('[data-test-dcpurbanrenewalareaname]', '');
 
-    assert.dom('[data-test-dcpurbanrenewalareaname-validation]').exists('it revalidates');
+    assert.dom('[data-test-validation-message="dcpUrbanareaname"]').exists('it revalidates');
     assert.dom('[data-test-save-button]').hasNoAttribute('disabled');
     assert.dom('[data-test-submit-button]').hasAttribute('disabled');
   });
@@ -314,5 +314,71 @@ module('Acceptance | user can click package edit', function(hooks) {
     await click('[data-test-project="edit-pas"]');
 
     assert.dom('[data-test-section="attachments"').hasTextContaining('PAS Form.pdf');
+  });
+
+  test('Certain fields display both Saveable and Submittable validation errors', async function (assert) {
+    this.server.create('package', 1, {
+      pasForm: this.server.create('pas-form'),
+      project: this.server.create('project'),
+    });
+
+    await visit('/packages/1/edit');
+
+    assert.dom('[data-test-save-button]').hasNoAttribute('disabled');
+    assert.dom('[data-test-submit-button]').hasNoAttribute('disabled');
+
+    // name of the Urban Renewal Area
+    await click('[data-test-dcpurbanrenewalarea="Yes"]');
+
+    assert.dom('[data-test-validation-message="dcpUrbanareaname"]').hasText('This field is required');
+
+    await fillIn('[data-test-dcpurbanrenewalareaname]', 'abc');
+
+    assert.dom('[data-test-validation-message="dcpUrbanareaname"]').doesNotExist();
+
+    const longText = 'Some long text'.repeat(20);
+
+    await fillIn('[data-test-dcpurbanrenewalareaname]', longText);
+
+    assert.dom('[data-test-validation-message="dcpUrbanareaname"]').hasText('Name is too long (max 250 characters)');
+
+    // SEQRA or CEQR criteria for Type II status
+    await click('[data-test-dcplanduseactiontype2="Yes"]');
+
+    assert.dom('[data-test-validation-message="dcpPleaseexplaintypeiienvreview"]').hasText('This field is required');
+
+    await fillIn('[data-test-dcppleaseexplaintypeiienvreview]', 'abc');
+
+    assert.dom('[data-test-validation-message="dcpPleaseexplaintypeiienvreview"]').doesNotExist();
+
+    await fillIn('[data-test-dcppleaseexplaintypeiienvreview]', longText);
+
+    assert.dom('[data-test-validation-message="dcpPleaseexplaintypeiienvreview"]').hasText('Text is too long (max 200 characters)');
+
+    // Industrial Business Zone
+    await click('[data-test-dcpProjectareaindustrialbusinesszone="Yes"]');
+
+    assert.dom('[data-test-validation-message="dcpProjectareaindutrialzonename"]').hasText('This field is required');
+
+    await fillIn('[data-test-dcpprojectareaindutrialzonename]', 'abc');
+
+    assert.dom('[data-test-validation-message="dcpProjectareaindutrialzonename"]').doesNotExist();
+
+    await fillIn('[data-test-dcpprojectareaindutrialzonename]', longText);
+
+    assert.dom('[data-test-validation-message="dcpProjectareaindutrialzonename"]').hasText('Name is too long (max 250 characters)');
+
+    // Landmark name
+    await click('[data-test-dcpIsprojectarealandmark="Yes"]');
+
+    assert.dom('[data-test-validation-message="dcpProjectarealandmarkname"]').hasText('This field is required');
+
+    await fillIn('[data-test-dcpprojectarealandmarkname]', 'abc');
+
+    assert.dom('[data-test-validation-message="dcpProjectarealandmarkname"]').doesNotExist();
+
+    await fillIn('[data-test-dcpprojectarealandmarkname]', longText);
+
+    assert.dom('[data-test-validation-message="dcpProjectarealandmarkname"]').hasText('Name is too long (max 250 characters)');
   });
 });

--- a/client/tests/acceptance/user-can-click-package-edit-test.js
+++ b/client/tests/acceptance/user-can-click-package-edit-test.js
@@ -125,10 +125,10 @@ module('Acceptance | user can click package edit', function(hooks) {
     this.server.create('project', 1, 'applicant');
 
     await visit('/packages/1/edit');
-    assert.dom('[data-test-dcpurbanrenewalareaname]').doesNotExist();
+    assert.dom('[data-test-dcpurbanareaname]').doesNotExist();
 
     await click('[data-test-dcpurbanrenewalarea="Yes"]');
-    assert.dom('[data-test-dcpurbanrenewalareaname]').exists();
+    assert.dom('[data-test-dcpurbanareaname]').exists();
   });
 
   test('SEQRA or CEQR sub Q shows conditionally', async function (assert) {
@@ -267,13 +267,13 @@ module('Acceptance | user can click package edit', function(hooks) {
     assert.dom('[data-test-save-button]').hasNoAttribute('disabled');
     assert.dom('[data-test-submit-button]').hasAttribute('disabled');
 
-    await fillIn('[data-test-dcpurbanrenewalareaname]', 'abc');
+    await fillIn('[data-test-dcpurbanareaname]', 'abc');
 
     assert.dom('[data-test-validation-message="dcpUrbanareaname"]').doesNotExist();
     assert.dom('[data-test-save-button]').hasNoAttribute('disabled');
     assert.dom('[data-test-submit-button]').hasNoAttribute('disabled');
 
-    await fillIn('[data-test-dcpurbanrenewalareaname]', '');
+    await fillIn('[data-test-dcpurbanareaname]', '');
 
     assert.dom('[data-test-validation-message="dcpUrbanareaname"]').exists('it revalidates');
     assert.dom('[data-test-save-button]').hasNoAttribute('disabled');
@@ -332,13 +332,13 @@ module('Acceptance | user can click package edit', function(hooks) {
 
     assert.dom('[data-test-validation-message="dcpUrbanareaname"]').hasText('This field is required');
 
-    await fillIn('[data-test-dcpurbanrenewalareaname]', 'abc');
+    await fillIn('[data-test-dcpurbanareaname]', 'abc');
 
     assert.dom('[data-test-validation-message="dcpUrbanareaname"]').doesNotExist();
 
     const longText = 'Some long text'.repeat(20);
 
-    await fillIn('[data-test-dcpurbanrenewalareaname]', longText);
+    await fillIn('[data-test-dcpurbanareaname]', longText);
 
     assert.dom('[data-test-validation-message="dcpUrbanareaname"]').hasText('Name is too long (max 250 characters)');
 


### PR DESCRIPTION
This commit spreads saveable changeset properties
into their respective submittable changeset properties,
preventing them from being overriden. With this patch,
we no longer need to render a ValidationMessage component
for both saveable and submittable errors. We just need
to render one for the submittable changeset errors, since
it will also contain saveable changeset errors.

This commit also fixes a few test selector names
for consistency. The test selectors for two text input
fields (dcpprojectareaindutrialzonename, dcpUrbanareaname)
were referring to non-existant, ad hoc fields.
The test selector for dcpprojectarealandmarkname ValidationMessage
was referring to the related yes/no question,
instead of the text input itself.