### PR TITLE
Refactor how filemanager is invoked; add test case

### DIFF
--- a/client/app/components/packages/attachments.hbs
+++ b/client/app/components/packages/attachments.hbs
@@ -1,4 +1,4 @@
-<div class="site-main grid-x grid-margin-x">
+<div class="site-main grid-x grid-margin-x" ...attributes>
   <div class="cell">
     <fieldset class="fieldset">
       <legend>

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -780,6 +780,7 @@
           <Packages::Attachments
             @package={{@package}}
             @fileManager={{@package.fileManager}}
+            data-test-section="attachments"
           />
         </section>
 

--- a/client/app/models/package.js
+++ b/client/app/models/package.js
@@ -71,7 +71,7 @@ export const PACKAGE_STATE_CODES = {
 };
 
 export default class PackageModel extends Model {
-  ready() {
+  createFileQueue() {
     const fileQueue = this.fileQueue.create(this.id);
 
     this.fileManager = new FileManager(

--- a/client/app/routes/packages.js
+++ b/client/app/routes/packages.js
@@ -4,10 +4,15 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
 export default class PackagesRoute extends Route.extend(AuthenticatedRouteMixin) {
   authenticationRoute = '/';
 
-  model(params) {
-    return this.store.findRecord('package', params.id, {
+  async model(params) {
+    const projectPackage = await this.store.findRecord('package', params.id, {
       reload: true,
       include: 'pas-form.bbls,project',
     });
+
+    // manually generate a file factory
+    projectPackage.createFileQueue();
+
+    return projectPackage;
   }
 }

--- a/client/tests/acceptance/user-can-click-package-edit-test.js
+++ b/client/tests/acceptance/user-can-click-package-edit-test.js
@@ -293,4 +293,26 @@ module('Acceptance | user can click package edit', function(hooks) {
 
     assert.equal(this.server.db.bbls.firstObject.projectId, '42');
   });
+
+  test('Docs appear in attachments section when visiting from another route', async function(assert) {
+    this.server.create('package', 'applicant', 'withExistingDocuments', {
+      id: '1',
+      project: this.server.create('project'),
+    });
+
+    // simulate a "sparse fieldset"
+    this.server.get('/projects', function (schema) {
+      const projects = schema.projects.all();
+      const json = this.serialize(projects);
+
+      json.included[0].attributes.documents = [];
+
+      return json;
+    });
+
+    await visit('/projects');
+    await click('[data-test-project="edit-pas"]');
+
+    assert.dom('[data-test-section="attachments"').hasTextContaining('PAS Form.pdf');
+  });
 });

--- a/client/tests/integration/components/packages/attachments-test.js
+++ b/client/tests/integration/components/packages/attachments-test.js
@@ -21,6 +21,7 @@ module('Integration | Component | packages/attachments', function(hooks) {
 
     const store = this.owner.lookup('service:store');
     this.package = await store.findRecord('package', '123');
+    this.package.createFileQueue();
 
     await render(hbs`<
       Packages::Attachments
@@ -37,6 +38,7 @@ module('Integration | Component | packages/attachments', function(hooks) {
 
     const store = this.owner.lookup('service:store');
     this.package = await store.findRecord('package', '123');
+    this.package.createFileQueue();
 
     await render(hbs`<
       Packages::Attachments
@@ -82,6 +84,7 @@ module('Integration | Component | packages/attachments', function(hooks) {
 
     const store = this.owner.lookup('service:store');
     this.package = await store.findRecord('package', '123');
+    this.package.createFileQueue();
 
     const file = new File(['foo'], 'PAS Form.pdf', { type: 'text/plain' });
     const file2 = new File(['foo'], 'Action Changes.excel', { type: 'text/plain' });
@@ -114,6 +117,7 @@ module('Integration | Component | packages/attachments', function(hooks) {
 
     const store = this.owner.lookup('service:store');
     this.package = await store.findRecord('package', '123');
+    this.package.createFileQueue();
 
     const file = new File(['foo'], 'PAS Form.pdf', { type: 'text/plain' });
     const file2 = new File(['foo'], 'Action Changes.excel', { type: 'text/plain' });
@@ -142,6 +146,7 @@ module('Integration | Component | packages/attachments', function(hooks) {
 
     const store = this.owner.lookup('service:store');
     this.package = await store.findRecord('package', '123');
+    this.package.createFileQueue();
 
     await render(hbs`<
       Packages::Attachments

--- a/client/tests/unit/models/package-test.js
+++ b/client/tests/unit/models/package-test.js
@@ -21,6 +21,9 @@ module('Unit | Model | package', function(hooks) {
 
     bbl.dcpDevelopmentsite = true;
 
+    // TODO: manually called. refactor this away.
+    model.createFileQueue();
+
     await model.save();
 
     assert.ok(model);


### PR DESCRIPTION
Changes how filemanger is instantiated on the package model. This is called manually now instead from the deprecated ready hook.

Includes a test cause simulating the server response.