### PR TITLE
PAS form headers

### DIFF
--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -6,26 +6,32 @@
   as |saveable-form|
 >
 
-<div class="grid-x grid-margin-x">
+  <div class="grid-x grid-margin-x">
 
     <div class="cell large-8">
-      <p>
-        The <strong>Pre-Application Statement</strong> requests pertinent information about a site and proposed project. By
-        submitting the PAS, a prospective applicant acknowledges that they intend to file a land use application with NYC
-        Planning. Submission allows staff to be assigned from appropriate divisions and project tracking to commence.
-      </p>
+      <section class="form-section">
+        <h1>
+          Pre-Application Statement
+        </h1>
 
-      <p>
-        NYC Planning understands that some projects may not be fully formed at the submission of the PAS. Give as much
-        detailed information as possible. Failure to provide detailed, relevant information will result in the PAS being
-        rejected.
-      </p>
+        <p>
+          The <strong>Pre-Application Statement</strong> requests pertinent information about a site and proposed project. By
+          submitting the PAS, a prospective applicant acknowledges that they intend to file a land use application with NYC
+          Planning. Submission allows staff to be assigned from appropriate divisions and project tracking to commence.
+        </p>
+
+        <p>
+          NYC Planning understands that some projects may not be fully formed at the submission of the PAS. Give as much
+          detailed information as possible. Failure to provide detailed, relevant information will result in the PAS being
+          rejected.
+        </p>
+      </section>
 
       <section class="form-section">
-        <h3 class="section-header">
+        <h2 class="section-header">
           <span id="project-info" class="section-anchor"></span>
           Project Information
-        </h3>
+        </h2>
 
         <label>
           <strong>Project Name</strong>
@@ -40,10 +46,10 @@
       </section>
 
       <section class="form-section">
-        <h3 class="section-header">
+        <h2 class="section-header">
           <span id="applicant-team" class="section-anchor"></span>
           Applicant Team
-        </h3>
+        </h2>
 
           <p>
             Add all applicants (either individuals or organizations) and other team members (including land use consultants and environmental consultants, agency staff, etc.).
@@ -55,10 +61,10 @@
         </section>
 
         <section class="form-section">
-          <h3 class="section-header">
+          <h2 class="section-header">
             <span id="project-geography" class="section-anchor"></span>
             Project Geography
-          </h3>
+          </h2>
 
           <p>
             Please identify the tax lots that are included in the proposed project area and/or development site.
@@ -96,10 +102,10 @@
         </section>
 
         <section class="form-section">
-          <h3 class="section-header">
+          <h2 class="section-header">
             <span id="proposed-land-use-actions" class="section-anchor"></span>
             Proposed Land Use Actions
-          </h3>
+          </h2>
 
           <p>
             What land use actions does the proposed project require? Identify all that apply and fill in the appropriate related information.
@@ -115,10 +121,10 @@
         </section>
 
         <section class="form-section">
-          <h3 class="section-header">
+          <h2 class="section-header">
             <span id="project-area" class="section-anchor"></span>
             Project Area
-          </h3>
+          </h2>
 
           <p>
             Project Area refers to all property that would be subject to the proposed actions.
@@ -430,10 +436,10 @@
         </section>
 
         <section class="form-section">
-          <h3 class="section-header">
+          <h2 class="section-header">
             <span id="proposed-development-site" class="section-anchor"></span>
             Proposed Development Site
-          </h3>
+          </h2>
 
           <p class="text-small">
             <b>Development Site</b> refers to all property to be developed as part of the applicant’s specific proposal which the land use actions would facilitate. Typically, the Development Site and the Project Area will comprise the same property(ies) unless the application is requesting a zoning map amendment covering an area greater than an applicant’s property to be developed or a large-scale special approval involving multiple tax lots. In these cases, the Development Site may be one or several tax lots within a broader Project Area.
@@ -608,10 +614,10 @@
         </section>
 
         <section class="form-section">
-          <h3 class="section-header">
+          <h2 class="section-header">
             <span id="project-description" class="section-anchor"></span>
             Project Description
-          </h3>
+          </h2>
 
           <p class="text-small">
             For complex proposals, feel free to upload a draft document (in the Attachments section) explaining this information instead of filling out the form inputs.
@@ -718,10 +724,10 @@
         </section>
 
         <section class="form-section">
-          <h3 class="section-header">
+          <h2 class="section-header">
             <span id="attached-documents" class="section-anchor"></span>
             Attached Documents
-          </h3>
+          </h2>
 
           <p>
             Please attach the following required documents. (Additional materials that help to explain the proposed project may also be submitted.)
@@ -886,6 +892,7 @@
         </nav>
       </div>{{!-- end .sticky-sidebar --}}
     </div>
-</div>
+
+  </div>
 
 </SaveableForm>


### PR DESCRIPTION
This PR improves the headers on PAS form — adding an `<h1>` so it's clear what form you are editing, increasing the visual hierarchy, and visually separating the intro text from the first form section. 