### PR TITLE
Sets dcp_revisedprojectname to projectname if empty

### DIFF
--- a/client/app/models/pas-form.js
+++ b/client/app/models/pas-form.js
@@ -45,12 +45,7 @@ export default class PasFormModel extends Model {
 
   @attr('number') dcpProjectblock;
 
-  @attr({
-    defaultValue(pasForm) {
-      return pasForm.package.project.dcpProjectname;
-    },
-  })
-  dcpRevisedprojectname;
+  @attr('string') dcpRevisedprojectname;
 
   @attr('boolean') dcpExistingbuildingoccupied;
 

--- a/server/.eslintrc.js
+++ b/server/.eslintrc.js
@@ -20,5 +20,6 @@ module.exports = {
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/camelcase': 'off',
   },
 };

--- a/server/src/packages/packages.controller.ts
+++ b/server/src/packages/packages.controller.ts
@@ -60,8 +60,10 @@ export const PACKAGE_ATTRS = [
     },
   },
 
-  // remap verbose navigation link names to
-  // more concise names
+  // Transform here should only be used for remapping
+  // navigation links into cleaner names as well as
+  // handling special virtual properties that do not
+  // come from CRM 
   transform(projectPackage) {
     const { dcp_pasform: pasForm } = projectPackage;
 

--- a/server/src/packages/packages.service.ts
+++ b/server/src/packages/packages.service.ts
@@ -68,7 +68,12 @@ export class PackagesService {
 
     return {
       ...projectPackageForm.dcp_package,
-      dcp_pasform: projectPackageForm,
+      dcp_pasform: {
+        ...projectPackageForm,
+
+        // handling for setting the default value of the dcp_revisedprojectname.
+        dcp_revisedprojectname: projectPackageForm.dcp_revisedprojectname || dcp_project.dcp_projectname,
+      },
       project: dcp_project,
       documents: documents.map(document => ({
         name: document['Name'],


### PR DESCRIPTION
This makes changes to the backend to set the pas form 'revised project name' to the associated _project's_ name if it's empty.