### PR TITLE
326 consistent test selectors

### DIFF
--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -322,7 +322,8 @@
               <saveable-form.radio
                 @value={{radio.code}}
                 @groupValue={{saveable-form.saveableChanges.dcpIsprojectarealandmark}}
-                data-test-dcpisprojectarealandmark={{radio.label}}
+                data-test-radio="dcpIsprojectarealandmark"
+                data-test-radio-option={{radio.label}}
               >
                 {{radio.label}}
               </saveable-form.radio>

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -91,6 +91,7 @@
             <Textarea
               @value={{saveable-form.saveableChanges.dcpDescriptionofprojectareageography}}
               rows="5"
+              data-test-textarea="dcpDescriptionofprojectareageography"
             />
             <CharacterCounter
               @string={{saveable-form.saveableChanges.dcpDescriptionofprojectareageography}}
@@ -651,7 +652,7 @@
             <Textarea
               @value={{saveable-form.saveableChanges.dcpProjectdescriptionproposeddevelopment}}
               rows="5"
-              data-test-dcpprojectdescriptionproposeddevelopment
+              data-test-textarea="dcpProjectdescriptionproposeddevelopment"
             />
             <CharacterCounter
               @string={{saveable-form.saveableChanges.dcpProjectdescriptionproposeddevelopment}}
@@ -667,7 +668,7 @@
             <Textarea
               @value={{saveable-form.saveableChanges.dcpProjectdescriptionbackground}}
               rows="5"
-              data-test-dcpprojectdescriptionbackground
+              data-test-textarea="dcpProjectdescriptionbackground"
             />
             <CharacterCounter
               @string={{saveable-form.saveableChanges.dcpProjectdescriptionbackground}}
@@ -683,7 +684,7 @@
             <Textarea
               @value={{saveable-form.saveableChanges.dcpProjectdescriptionproposedactions}}
               rows="5"
-              data-test-dcpprojectdescriptionproposedactions
+              data-test-textarea="dcpProjectdescriptionproposedactions"
             />
             <CharacterCounter
               @string={{saveable-form.saveableChanges.dcpProjectdescriptionproposedactions}}
@@ -699,7 +700,7 @@
             <Textarea
               @value={{saveable-form.saveableChanges.dcpProjectdescriptionproposedarea}}
               rows="5"
-              data-test-dcpprojectdescriptionproposedarea
+              data-test-textarea="dcpProjectdescriptionproposedarea"
             />
             <CharacterCounter
               @string={{saveable-form.saveableChanges.dcpProjectdescriptionproposedarea}}
@@ -715,7 +716,7 @@
             <Textarea
               @value={{saveable-form.saveableChanges.dcpProjectdescriptionsurroundingarea}}
               rows="5"
-              data-test-dcpprojectdescriptionsurroundingarea
+              data-test-textarea="dcpProjectdescriptionsurroundingarea"
             />
             <CharacterCounter
               @string={{saveable-form.saveableChanges.dcpProjectdescriptionsurroundingarea}}
@@ -734,7 +735,7 @@
             <Textarea
               @value={{saveable-form.saveableChanges.dcpProjectattachmentsotherinformation}}
               rows="5"
-              data-test-dcpprojectattachmentsotherinformation
+              data-test-textarea="dcpProjectattachmentsotherinformation"
             />
             <CharacterCounter
               @string={{saveable-form.saveableChanges.dcpProjectattachmentsotherinformation}}

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -380,7 +380,8 @@
               <saveable-form.radio
                 @value={{radio.code}}
                 @groupValue={{saveable-form.saveableChanges.dcpProjectareaischancefloodplain}}
-                data-test-dcpprojectareaischancefloodplain={{radio.label}}
+                data-test-radio="dcpProjectareaischancefloodplain"
+                data-test-radio-option={{radio.label}}
               >
                 {{radio.label}}
               </saveable-form.radio>

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -206,7 +206,8 @@
                 <saveable-form.radio
                   @value={{radio.code}}
                   @groupValue={{saveable-form.saveableChanges.dcpLegalstreetfrontage}}
-                  data-test-dcplegalstreetfrontage={{radio.label}}
+                  data-test-radio="dcpLegalstreetfrontage"
+                  data-test-radio-option={{radio.label}}
                 >
                   {{radio.label}}
                 </saveable-form.radio>

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -235,7 +235,8 @@
               <saveable-form.radio
                 @value={{radio.code}}
                 @groupValue={{saveable-form.saveableChanges.dcpLanduseactiontype2}}
-                data-test-dcplanduseactiontype2={{radio.label}}
+                data-test-radio="dcpLanduseactiontype2"
+                data-test-radio-option={{radio.label}}
               >
                 {{radio.label}}
               </saveable-form.radio>

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -581,7 +581,7 @@
                 <Input
                   @type="text"
                   @value={{saveable-form.saveableChanges.dcpInclusionaryhousingdesignatedareaname}}
-                  data-test-dcpinclusionaryhousingdesignatedareaname
+                  data-test-input="dcpInclusionaryhousingdesignatedareaname"
                 />
                 <ValidationMessage
                   @changesetError={{saveable-form.submittableChanges.error.dcpInclusionaryhousingdesignatedareaname}}

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -440,7 +440,8 @@
               <saveable-form.radio
                 @value={{radio.code}}
                 @groupValue={{saveable-form.saveableChanges.dcpRestrictivedeclarationrequired}}
-                data-test-dcprestrictivedeclarationrequired={{radio.label}}
+                data-test-radio="dcpRestrictivedeclarationrequired"
+                data-test-radio-option={{radio.label}}
               >
                 {{radio.label}}
               </saveable-form.radio>

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -335,7 +335,7 @@
                 <Input
                   @type="text"
                   @value={{saveable-form.saveableChanges.dcpProjectarealandmarkname}}
-                  data-test-dcpprojectarealandmarkname
+                  data-test-input="dcpProjectarealandmarkname"
                 />
                 <CharacterCounter
                   @string={{saveable-form.saveableChanges.dcpProjectarealandmarkname}}

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -285,7 +285,8 @@
               <saveable-form.radio
                 @value={{radio.code}}
                 @groupValue={{saveable-form.saveableChanges.dcpProjectareaindustrialbusinesszone}}
-                data-test-dcpprojectareaindustrialbusinesszone={{radio.label}}
+                data-test-radio="dcpProjectareaindustrialbusinesszone"
+                data-test-radio-option={{radio.label}}
               >
                 {{radio.label}}
               </saveable-form.radio>

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -297,7 +297,7 @@
                 <Input
                   @type="text"
                   @value={{saveable-form.saveableChanges.dcpProjectareaindutrialzonename}}
-                  data-test-dcpprojectareaindutrialzonename
+                  data-test-input="dcpProjectareaindutrialzonename"
                 />
                 <CharacterCounter
                   @string={{saveable-form.saveableChanges.dcpProjectareaindutrialzonename}}

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -464,7 +464,7 @@
             <Input
               @type="text"
               @value={{saveable-form.saveableChanges.dcpEstimatedcompletiondate}}
-              data-test-dcpestimatedcompletiondate
+              data-test-input="dcpEstimatedcompletiondate"
             />
             <ValidationMessage
               @changesetError={{saveable-form.saveableChanges.error.dcpEstimatedcompletiondate}}

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -622,7 +622,8 @@
                   <saveable-form.radio
                     @value={{radio.code}}
                     @groupValue={{saveable-form.saveableChanges.dcpHousingunittype}}
-                    data-test-dcphousingunittype={{radio.label}}
+                    data-test-radio="dcpHousingunittype"
+                    data-test-radio-option={{radio.label}}
                   >
                     {{radio.label}}
                   </saveable-form.radio>

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -543,7 +543,7 @@
                 <Input
                   @type="text"
                   @value={{saveable-form.saveableChanges.dcpProposeddevelopmentsiteotherexplanation}}
-                  data-test-dcpproposeddevelopmentsiteotherexplanation
+                  data-test-input="dcpProposeddevelopmentsiteotherexplanation"
                 />
                 <ValidationMessage
                   @changesetError={{saveable-form.submittableChanges.error.dcpProposeddevelopmentsiteotherexplanation}}

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -37,7 +37,8 @@
           <strong>Project Name</strong>
           <Input
             @type="text"
-            @value={{saveable-form.saveableChanges.dcpRevisedprojectname}} data-test-dcprevisedprojectname
+            @value={{saveable-form.saveableChanges.dcpRevisedprojectname}}
+            data-test-input="dcpRevisedprojectname"
           />
           <ValidationMessage
             @changesetError={{saveable-form.saveableChanges.error.dcpRevisedprojectname}}

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -251,7 +251,7 @@
                 <Input
                   @type="text"
                   @value={{saveable-form.saveableChanges.dcpPleaseexplaintypeiienvreview}}
-                  data-test-dcppleaseexplaintypeiienvreview
+                  data-test-input="dcpPleaseexplaintypeiienvreview"
                 />
                 <CharacterCounter
                   @string={{saveable-form.saveableChanges.dcpPleaseexplaintypeiienvreview}}

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -601,7 +601,8 @@
               <saveable-form.radio
                 @value={{radio.code}}
                 @groupValue={{saveable-form.saveableChanges.dcpDiscressionaryfundingforffordablehousing}}
-                data-test-dcpdiscressionaryfundingforffordablehousing={{radio.label}}
+                data-test-radio="dcpDiscressionaryfundingforffordablehousing"
+                data-test-radio-option={{radio.label}}
               >
                 {{radio.label}}
               </saveable-form.radio>

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -177,7 +177,7 @@
                 <Input
                   @type="text"
                   @value={{saveable-form.saveableChanges.dcpUrbanareaname}}
-                  data-test-dcpurbanareaname
+                  data-test-input="dcpUrbanareaname"
                 />
                 <CharacterCounter
                   @string={{saveable-form.saveableChanges.dcpUrbanareaname}}

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -360,7 +360,8 @@
               <saveable-form.radio
                 @value={{radio.code}}
                 @groupValue={{saveable-form.saveableChanges.dcpProjectareacoastalzonelocatedin}}
-                data-test-dcpprojectareacoastalzonelocatedin={{radio.label}}
+                data-test-radio="dcpProjectareacoastalzonelocatedin"
+                data-test-radio-option={{radio.label}}
               >
                 {{radio.label}}
               </saveable-form.radio>

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -485,6 +485,7 @@
                   @type="checkbox"
                   @checked={{saveable-form.saveableChanges.dcpProposeddevelopmentsitenewconstruction}}
                   id="dcpproposeddevelopmentsitenewconstruction"
+                  data-test-checkbox="dcpProposeddevelopmentsitenewconstruction"
                 /><label for="dcpproposeddevelopmentsitenewconstruction">Newly constructed buildings</label>
               </li>
               <li>
@@ -492,6 +493,7 @@
                   @type="checkbox"
                   @checked={{saveable-form.saveableChanges.dcpProposeddevelopmentsitedemolition}}
                   id="dcpproposeddevelopmentsitedemolition"
+                  data-test-checkbox="dcpProposeddevelopmentsitedemolition"
                 /><label for="dcpproposeddevelopmentsitedemolition">Demolition</label>
               </li>
               <li>
@@ -499,6 +501,7 @@
                   @type="checkbox"
                   @checked={{saveable-form.saveableChanges.dcpProposeddevelopmentsiteinfoalteration}}
                   id="dcpproposeddevelopmentsiteinfoalteration"
+                  data-test-checkbox="dcpProposeddevelopmentsiteinfoalteration"
                 /><label for="dcpproposeddevelopmentsiteinfoalteration">Alteration</label>
               </li>
               <li>
@@ -506,6 +509,7 @@
                   @type="checkbox"
                   @checked={{saveable-form.saveableChanges.dcpProposeddevelopmentsiteinfoaddition}}
                   id="dcpproposeddevelopmentsiteinfoaddition"
+                  data-test-checkbox="dcpProposeddevelopmentsiteinfoaddition"
                 /><label for="dcpproposeddevelopmentsiteinfoaddition">Addition</label>
               </li>
               <li>
@@ -513,6 +517,7 @@
                   @type="checkbox"
                   @checked={{saveable-form.saveableChanges.dcpProposeddevelopmentsitechnageofuse}}
                   id="dcpproposeddevelopmentsitechnageofuse"
+                  data-test-checkbox="dcpProposeddevelopmentsitechnageofuse"
                 /><label for="dcpproposeddevelopmentsitechnageofuse">Change of use</label>
               </li>
               <li>
@@ -520,6 +525,7 @@
                   @type="checkbox"
                   @checked={{saveable-form.saveableChanges.dcpProposeddevelopmentsiteenlargement}}
                   id="dcpproposeddevelopmentsiteenlargement"
+                  data-test-checkbox="dcpProposeddevelopmentsiteenlargement"
                 /><label for="dcpproposeddevelopmentsiteenlargement">Enlargement</label>
               </li>
               <li>

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -143,7 +143,8 @@
               <saveable-form.radio
                 @value={{radio.code}}
                 @groupValue={{saveable-form.saveableChanges.dcpProposedprojectorportionconstruction}}
-                data-test-dcpproposedprojectorportionconstruction={{radio.label}}
+                data-test-radio="dcpProposedprojectorportionconstruction"
+                data-test-radio-option={{radio.label}}
               >
                 {{radio.label}}
               </saveable-form.radio>

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -399,7 +399,8 @@
               <saveable-form.radio
                 @value={{radio.code}}
                 @groupValue={{saveable-form.saveableChanges.dcpRestrictivedeclaration}}
-                data-test-dcprestrictivedeclaration={{radio.label}}
+                data-test-radio="dcpRestrictivedeclaration"
+                data-test-radio-option={{radio.label}}
               >
                 {{radio.label}}
               </saveable-form.radio>

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -164,7 +164,8 @@
               <saveable-form.radio
                 @value={{radio.code}}
                 @groupValue={{saveable-form.saveableChanges.dcpUrbanrenewalarea}}
-                 data-test-dcpurbanrenewalarea={{radio.label}}
+                 data-test-radio="dcpUrbanrenewalarea"
+                 data-test-radio-option={{radio.label}}
               >
                 {{radio.label}}
               </saveable-form.radio>

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -415,7 +415,7 @@
                 <Input
                   @type="text"
                   @value={{saveable-form.saveableChanges.dcpCityregisterfilenumber}}
-                  data-test-dcpcityregisterfilenumber
+                  data-test-input="dcpCityregisterfilenumber"
                 />
                 <CharacterCounter
                   @string={{saveable-form.saveableChanges.dcpCityregisterfilenumber}}

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -527,7 +527,7 @@
                   @type="checkbox"
                   @checked={{saveable-form.saveableChanges.dcpProposeddevelopmentsiteinfoother}}
                   id="dcpproposeddevelopmentsiteinfoother"
-                  data-test-dcpproposeddevelopmentsiteinfoother
+                  data-test-checkbox="dcpProposeddevelopmentsiteinfoother"
                 /><label for="dcpproposeddevelopmentsiteinfoother">Other&hellip;</label>
               </li>
             </ul>

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -568,7 +568,8 @@
               <saveable-form.radio
                 @value={{radio.code}}
                 @groupValue={{saveable-form.saveableChanges.dcpIsinclusionaryhousingdesignatedarea}}
-                data-test-dcpisinclusionaryhousingdesignatedarea={{radio.label}}
+                data-test-radio="dcpIsinclusionaryhousingdesignatedarea"
+                data-test-radio-option={{radio.label}}
               >
                 {{radio.label}}
               </saveable-form.radio>

--- a/client/app/components/packages/pas-form/show.hbs
+++ b/client/app/components/packages/pas-form/show.hbs
@@ -7,7 +7,8 @@
         Pre-Application Statement
       </h1>
 
-      <h2 class="section-header header-xxlarge" data-test-show-dcprevisedprojectname>
+      <h2 class="section-header header-xxlarge"
+        data-test-show="dcpRevisedprojectname">
         {{@package.pasForm.dcpRevisedprojectname}}
       </h2>
     </section>

--- a/client/tests/acceptance/error-message-appears-when-save-fails-test.js
+++ b/client/tests/acceptance/error-message-appears-when-save-fails-test.js
@@ -33,7 +33,7 @@ module('Acceptance | error message appears when save fails', function(hooks) {
 
     assert.dom('[data-test-error-message]').doesNotExist();
 
-    await fillIn('[data-test-dcprevisedprojectname]', 'Some Cool New Project Name');
+    await fillIn('[data-test-input="dcpRevisedprojectname"]', 'Some Cool New Project Name');
 
     // save it
     await click('[data-test-save-button]');

--- a/client/tests/acceptance/user-can-click-package-edit-test.js
+++ b/client/tests/acceptance/user-can-click-package-edit-test.js
@@ -177,7 +177,7 @@ module('Acceptance | user can click package edit', function(hooks) {
     await visit('/packages/1/edit');
 
     assert.dom('[data-test-dcpinclusionaryhousingdesignatedareaname]').doesNotExist();
-    await click('[data-test-dcpisinclusionaryhousingdesignatedarea="Yes"]');
+    await click('[data-test-radio="dcpIsinclusionaryhousingdesignatedarea"][data-test-radio-option="Yes"]');
     assert.dom('[data-test-dcpinclusionaryhousingdesignatedareaname]').exists();
   });
 

--- a/client/tests/acceptance/user-can-click-package-edit-test.js
+++ b/client/tests/acceptance/user-can-click-package-edit-test.js
@@ -166,9 +166,9 @@ module('Acceptance | user can click package edit', function(hooks) {
 
     await visit('/packages/1/edit');
 
-    assert.dom('[data-test-dcpproposeddevelopmentsiteotherexplanation]').doesNotExist();
+    assert.dom('[data-test-input="dcpProposeddevelopmentsiteotherexplanation"]').doesNotExist();
     await click('[data-test-checkbox="dcpProposeddevelopmentsiteinfoother"]');
-    assert.dom('[data-test-dcpproposeddevelopmentsiteotherexplanation]').exists();
+    assert.dom('[data-test-input="dcpProposeddevelopmentsiteotherexplanation"]').exists();
   });
 
   test('MIH sub Q shows conditionally', async function (assert) {

--- a/client/tests/acceptance/user-can-click-package-edit-test.js
+++ b/client/tests/acceptance/user-can-click-package-edit-test.js
@@ -137,7 +137,7 @@ module('Acceptance | user can click package edit', function(hooks) {
     await visit('/packages/1/edit');
 
     assert.dom('[data-test-dcppleaseexplaintypeiienvreview]').doesNotExist();
-    await click('[data-test-dcplanduseactiontype2="Yes"]');
+    await click('[data-test-radio="dcpLanduseactiontype2"][data-test-radio-option="Yes"]');
     assert.dom('[data-test-dcppleaseexplaintypeiienvreview]').exists();
   });
 
@@ -343,7 +343,7 @@ module('Acceptance | user can click package edit', function(hooks) {
     assert.dom('[data-test-validation-message="dcpUrbanareaname"]').hasText('Name is too long (max 250 characters)');
 
     // SEQRA or CEQR criteria for Type II status
-    await click('[data-test-dcplanduseactiontype2="Yes"]');
+    await click('[data-test-radio="dcpLanduseactiontype2"][data-test-radio-option="Yes"]');
 
     assert.dom('[data-test-validation-message="dcpPleaseexplaintypeiienvreview"]').hasText('This field is required');
 

--- a/client/tests/acceptance/user-can-click-package-edit-test.js
+++ b/client/tests/acceptance/user-can-click-package-edit-test.js
@@ -167,7 +167,7 @@ module('Acceptance | user can click package edit', function(hooks) {
     await visit('/packages/1/edit');
 
     assert.dom('[data-test-dcpproposeddevelopmentsiteotherexplanation]').doesNotExist();
-    await click('[data-test-dcpproposeddevelopmentsiteinfoother]');
+    await click('[data-test-checkbox="dcpProposeddevelopmentsiteinfoother"]');
     assert.dom('[data-test-dcpproposeddevelopmentsiteotherexplanation]').exists();
   });
 

--- a/client/tests/acceptance/user-can-click-package-edit-test.js
+++ b/client/tests/acceptance/user-can-click-package-edit-test.js
@@ -191,7 +191,7 @@ module('Acceptance | user can click package edit', function(hooks) {
     assert.dom('[data-test-dcphousingunittype="Federal"]').doesNotExist();
     assert.dom('[data-test-dcphousingunittype="Other"]').doesNotExist();
 
-    await click('[data-test-dcpdiscressionaryfundingforffordablehousing="Yes"]');
+    await click('[data-test-radio="dcpDiscressionaryfundingforffordablehousing"][data-test-radio-option="Yes"]');
     assert.dom('[data-test-dcphousingunittype="City"]').exists();
     assert.dom('[data-test-dcphousingunittype="State"]').exists();
     assert.dom('[data-test-dcphousingunittype="Federal"]').exists();

--- a/client/tests/acceptance/user-can-click-package-edit-test.js
+++ b/client/tests/acceptance/user-can-click-package-edit-test.js
@@ -136,9 +136,9 @@ module('Acceptance | user can click package edit', function(hooks) {
 
     await visit('/packages/1/edit');
 
-    assert.dom('[data-test-dcppleaseexplaintypeiienvreview]').doesNotExist();
+    assert.dom('[data-test-input="dcpPleaseexplaintypeiienvreview"]').doesNotExist();
     await click('[data-test-radio="dcpLanduseactiontype2"][data-test-radio-option="Yes"]');
-    assert.dom('[data-test-dcppleaseexplaintypeiienvreview]').exists();
+    assert.dom('[data-test-input="dcpPleaseexplaintypeiienvreview"]').exists();
   });
 
   test('Industrial Business Zone sub Q shows conditionally', async function (assert) {
@@ -347,11 +347,11 @@ module('Acceptance | user can click package edit', function(hooks) {
 
     assert.dom('[data-test-validation-message="dcpPleaseexplaintypeiienvreview"]').hasText('This field is required');
 
-    await fillIn('[data-test-dcppleaseexplaintypeiienvreview]', 'abc');
+    await fillIn('[data-test-input="dcpPleaseexplaintypeiienvreview"]', 'abc');
 
     assert.dom('[data-test-validation-message="dcpPleaseexplaintypeiienvreview"]').doesNotExist();
 
-    await fillIn('[data-test-dcppleaseexplaintypeiienvreview]', longText);
+    await fillIn('[data-test-input="dcpPleaseexplaintypeiienvreview"]', longText);
 
     assert.dom('[data-test-validation-message="dcpPleaseexplaintypeiienvreview"]').hasText('Text is too long (max 200 characters)');
 

--- a/client/tests/acceptance/user-can-click-package-edit-test.js
+++ b/client/tests/acceptance/user-can-click-package-edit-test.js
@@ -146,9 +146,9 @@ module('Acceptance | user can click package edit', function(hooks) {
 
     await visit('/packages/1/edit');
 
-    assert.dom('[data-test-dcpprojectareaindutrialzonename]').doesNotExist();
+    assert.dom('[data-test-input="dcpProjectareaindutrialzonename"]').doesNotExist();
     await click('[data-test-radio="dcpProjectareaindustrialbusinesszone"][data-test-radio-option="Yes"]');
-    assert.dom('[data-test-dcpprojectareaindutrialzonename]').exists();
+    assert.dom('[data-test-input="dcpProjectareaindutrialzonename"]').exists();
   });
 
   test('Landmark or Historic District sub Q shows conditionally', async function (assert) {
@@ -360,11 +360,11 @@ module('Acceptance | user can click package edit', function(hooks) {
 
     assert.dom('[data-test-validation-message="dcpProjectareaindutrialzonename"]').hasText('This field is required');
 
-    await fillIn('[data-test-dcpprojectareaindutrialzonename]', 'abc');
+    await fillIn('[data-test-input="dcpProjectareaindutrialzonename"]', 'abc');
 
     assert.dom('[data-test-validation-message="dcpProjectareaindutrialzonename"]').doesNotExist();
 
-    await fillIn('[data-test-dcpprojectareaindutrialzonename]', longText);
+    await fillIn('[data-test-input="dcpProjectareaindutrialzonename"]', longText);
 
     assert.dom('[data-test-validation-message="dcpProjectareaindutrialzonename"]').hasText('Name is too long (max 250 characters)');
 

--- a/client/tests/acceptance/user-can-click-package-edit-test.js
+++ b/client/tests/acceptance/user-can-click-package-edit-test.js
@@ -48,7 +48,7 @@ module('Acceptance | user can click package edit', function(hooks) {
 
     // use waitFor as a way to "wait" for the transition
     // within the pas-form/edit Component submit() task
-    await waitFor('[data-test-show-dcprevisedprojectname]');
+    await waitFor('[data-test-show="dcpRevisedprojectname"]');
 
     assert.equal(currentURL(), '/packages/1');
   });
@@ -208,7 +208,7 @@ module('Acceptance | user can click package edit', function(hooks) {
     // assert.dom('[data-test-save-button').hasProperty('disabled', true);
 
     // edit a field to make it pasForm dirty
-    await fillIn('[data-test-dcprevisedprojectname]', 'Some Cool New Project Name');
+    await fillIn('[data-test-input="dcpRevisedprojectname"]', 'Some Cool New Project Name');
 
     // save button should become active when dirty
     assert.dom('[data-test-save-button').hasProperty('disabled', false);

--- a/client/tests/acceptance/user-can-click-package-edit-test.js
+++ b/client/tests/acceptance/user-can-click-package-edit-test.js
@@ -147,7 +147,7 @@ module('Acceptance | user can click package edit', function(hooks) {
     await visit('/packages/1/edit');
 
     assert.dom('[data-test-dcpprojectareaindutrialzonename]').doesNotExist();
-    await click('[data-test-dcpprojectareaindustrialbusinesszone="Yes"]');
+    await click('[data-test-radio="dcpProjectareaindustrialbusinesszone"][data-test-radio-option="Yes"]');
     assert.dom('[data-test-dcpprojectareaindutrialzonename]').exists();
   });
 
@@ -356,7 +356,7 @@ module('Acceptance | user can click package edit', function(hooks) {
     assert.dom('[data-test-validation-message="dcpPleaseexplaintypeiienvreview"]').hasText('Text is too long (max 200 characters)');
 
     // Industrial Business Zone
-    await click('[data-test-dcpProjectareaindustrialbusinesszone="Yes"]');
+    await click('[data-test-radio="dcpProjectareaindustrialbusinesszone"][data-test-radio-option="Yes"]');
 
     assert.dom('[data-test-validation-message="dcpProjectareaindutrialzonename"]').hasText('This field is required');
 

--- a/client/tests/acceptance/user-can-click-package-edit-test.js
+++ b/client/tests/acceptance/user-can-click-package-edit-test.js
@@ -127,7 +127,7 @@ module('Acceptance | user can click package edit', function(hooks) {
     await visit('/packages/1/edit');
     assert.dom('[data-test-dcpurbanareaname]').doesNotExist();
 
-    await click('[data-test-dcpurbanrenewalarea="Yes"]');
+    await click('[data-test-radio="dcpUrbanrenewalarea"][data-test-radio-option="Yes"]');
     assert.dom('[data-test-dcpurbanareaname]').exists();
   });
 
@@ -261,7 +261,7 @@ module('Acceptance | user can click package edit', function(hooks) {
     assert.dom('[data-test-save-button]').hasNoAttribute('disabled');
     assert.dom('[data-test-submit-button]').hasNoAttribute('disabled');
 
-    await click('[data-test-dcpurbanrenewalarea="Yes"]');
+    await click('[data-test-radio="dcpUrbanrenewalarea"][data-test-radio-option="Yes"]');
 
     assert.dom('[data-test-validation-message="dcpUrbanareaname"]').exists();
     assert.dom('[data-test-save-button]').hasNoAttribute('disabled');
@@ -328,7 +328,7 @@ module('Acceptance | user can click package edit', function(hooks) {
     assert.dom('[data-test-submit-button]').hasNoAttribute('disabled');
 
     // name of the Urban Renewal Area
-    await click('[data-test-dcpurbanrenewalarea="Yes"]');
+    await click('[data-test-radio="dcpUrbanrenewalarea"][data-test-radio-option="Yes"]');
 
     assert.dom('[data-test-validation-message="dcpUrbanareaname"]').hasText('This field is required');
 

--- a/client/tests/acceptance/user-can-click-package-edit-test.js
+++ b/client/tests/acceptance/user-can-click-package-edit-test.js
@@ -157,7 +157,7 @@ module('Acceptance | user can click package edit', function(hooks) {
     await visit('/packages/1/edit');
 
     assert.dom('[data-test-dcpProjectarealandmarkname]').doesNotExist();
-    await click('[data-test-dcpIsprojectarealandmark="Yes"]');
+    await click('[data-test-radio="dcpIsprojectarealandmark"][data-test-radio-option="Yes"]');
     assert.dom('[data-test-dcpProjectarealandmarkname]').exists();
   });
 
@@ -369,7 +369,7 @@ module('Acceptance | user can click package edit', function(hooks) {
     assert.dom('[data-test-validation-message="dcpProjectareaindutrialzonename"]').hasText('Name is too long (max 250 characters)');
 
     // Landmark name
-    await click('[data-test-dcpIsprojectarealandmark="Yes"]');
+    await click('[data-test-radio="dcpIsprojectarealandmark"][data-test-radio-option="Yes"]');
 
     assert.dom('[data-test-validation-message="dcpProjectarealandmarkname"]').hasText('This field is required');
 

--- a/client/tests/acceptance/user-can-click-package-edit-test.js
+++ b/client/tests/acceptance/user-can-click-package-edit-test.js
@@ -156,9 +156,9 @@ module('Acceptance | user can click package edit', function(hooks) {
 
     await visit('/packages/1/edit');
 
-    assert.dom('[data-test-dcpProjectarealandmarkname]').doesNotExist();
+    assert.dom('[data-test-input="dcpProjectarealandmarkname"]').doesNotExist();
     await click('[data-test-radio="dcpIsprojectarealandmark"][data-test-radio-option="Yes"]');
-    assert.dom('[data-test-dcpProjectarealandmarkname]').exists();
+    assert.dom('[data-test-input="dcpProjectarealandmarkname"]').exists();
   });
 
   test('Other Type sub Q shows conditionally', async function (assert) {
@@ -373,11 +373,11 @@ module('Acceptance | user can click package edit', function(hooks) {
 
     assert.dom('[data-test-validation-message="dcpProjectarealandmarkname"]').hasText('This field is required');
 
-    await fillIn('[data-test-dcpprojectarealandmarkname]', 'abc');
+    await fillIn('[data-test-input="dcpProjectarealandmarkname"]', 'abc');
 
     assert.dom('[data-test-validation-message="dcpProjectarealandmarkname"]').doesNotExist();
 
-    await fillIn('[data-test-dcpprojectarealandmarkname]', longText);
+    await fillIn('[data-test-input="dcpProjectarealandmarkname"]', longText);
 
     assert.dom('[data-test-validation-message="dcpProjectarealandmarkname"]').hasText('Name is too long (max 250 characters)');
   });

--- a/client/tests/acceptance/user-can-click-package-edit-test.js
+++ b/client/tests/acceptance/user-can-click-package-edit-test.js
@@ -186,16 +186,16 @@ module('Acceptance | user can click package edit', function(hooks) {
 
     await visit('/packages/1/edit');
 
-    assert.dom('[data-test-dcphousingunittype="City"]').doesNotExist();
-    assert.dom('[data-test-dcphousingunittype="State"]').doesNotExist();
-    assert.dom('[data-test-dcphousingunittype="Federal"]').doesNotExist();
-    assert.dom('[data-test-dcphousingunittype="Other"]').doesNotExist();
+    assert.dom('[data-test-radio="dcpHousingunittype"][data-test-radio-option="City"]').doesNotExist();
+    assert.dom('[data-test-radio="dcpHousingunittype"][data-test-radio-option="State"]').doesNotExist();
+    assert.dom('[data-test-radio="dcpHousingunittype"][data-test-radio-option="Federal"]').doesNotExist();
+    assert.dom('[data-test-radio="dcpHousingunittype"][data-test-radio-option="Other"]').doesNotExist();
 
     await click('[data-test-radio="dcpDiscressionaryfundingforffordablehousing"][data-test-radio-option="Yes"]');
-    assert.dom('[data-test-dcphousingunittype="City"]').exists();
-    assert.dom('[data-test-dcphousingunittype="State"]').exists();
-    assert.dom('[data-test-dcphousingunittype="Federal"]').exists();
-    assert.dom('[data-test-dcphousingunittype="Other"]').exists();
+    assert.dom('[data-test-radio="dcpHousingunittype"][data-test-radio-option="City"]').exists();
+    assert.dom('[data-test-radio="dcpHousingunittype"][data-test-radio-option="State"]').exists();
+    assert.dom('[data-test-radio="dcpHousingunittype"][data-test-radio-option="Federal"]').exists();
+    assert.dom('[data-test-radio="dcpHousingunittype"][data-test-radio-option="Other"]').exists();
   });
 
   test('user can save pas form', async function (assert) {

--- a/client/tests/acceptance/user-can-click-package-edit-test.js
+++ b/client/tests/acceptance/user-can-click-package-edit-test.js
@@ -176,9 +176,9 @@ module('Acceptance | user can click package edit', function(hooks) {
 
     await visit('/packages/1/edit');
 
-    assert.dom('[data-test-dcpinclusionaryhousingdesignatedareaname]').doesNotExist();
+    assert.dom('[data-test-input="dcpInclusionaryhousingdesignatedareaname"]').doesNotExist();
     await click('[data-test-radio="dcpIsinclusionaryhousingdesignatedarea"][data-test-radio-option="Yes"]');
-    assert.dom('[data-test-dcpinclusionaryhousingdesignatedareaname]').exists();
+    assert.dom('[data-test-input="dcpInclusionaryhousingdesignatedareaname"]').exists();
   });
 
   test('Funding Source sub Q shows conditionally', async function (assert) {

--- a/client/tests/acceptance/user-can-click-package-edit-test.js
+++ b/client/tests/acceptance/user-can-click-package-edit-test.js
@@ -125,10 +125,10 @@ module('Acceptance | user can click package edit', function(hooks) {
     this.server.create('project', 1, 'applicant');
 
     await visit('/packages/1/edit');
-    assert.dom('[data-test-dcpurbanareaname]').doesNotExist();
+    assert.dom('[data-test-input="dcpUrbanareaname"]').doesNotExist();
 
     await click('[data-test-radio="dcpUrbanrenewalarea"][data-test-radio-option="Yes"]');
-    assert.dom('[data-test-dcpurbanareaname]').exists();
+    assert.dom('[data-test-input="dcpUrbanareaname"]').exists();
   });
 
   test('SEQRA or CEQR sub Q shows conditionally', async function (assert) {
@@ -267,13 +267,13 @@ module('Acceptance | user can click package edit', function(hooks) {
     assert.dom('[data-test-save-button]').hasNoAttribute('disabled');
     assert.dom('[data-test-submit-button]').hasAttribute('disabled');
 
-    await fillIn('[data-test-dcpurbanareaname]', 'abc');
+    await fillIn('[data-test-input="dcpUrbanareaname"]', 'abc');
 
     assert.dom('[data-test-validation-message="dcpUrbanareaname"]').doesNotExist();
     assert.dom('[data-test-save-button]').hasNoAttribute('disabled');
     assert.dom('[data-test-submit-button]').hasNoAttribute('disabled');
 
-    await fillIn('[data-test-dcpurbanareaname]', '');
+    await fillIn('[data-test-input="dcpUrbanareaname"]', '');
 
     assert.dom('[data-test-validation-message="dcpUrbanareaname"]').exists('it revalidates');
     assert.dom('[data-test-save-button]').hasNoAttribute('disabled');
@@ -332,13 +332,13 @@ module('Acceptance | user can click package edit', function(hooks) {
 
     assert.dom('[data-test-validation-message="dcpUrbanareaname"]').hasText('This field is required');
 
-    await fillIn('[data-test-dcpurbanareaname]', 'abc');
+    await fillIn('[data-test-input="dcpUrbanareaname"]', 'abc');
 
     assert.dom('[data-test-validation-message="dcpUrbanareaname"]').doesNotExist();
 
     const longText = 'Some long text'.repeat(20);
 
-    await fillIn('[data-test-dcpurbanareaname]', longText);
+    await fillIn('[data-test-input="dcpUrbanareaname"]', longText);
 
     assert.dom('[data-test-validation-message="dcpUrbanareaname"]').hasText('Name is too long (max 250 characters)');
 


### PR DESCRIPTION
Update all (and add a couple) test selectors that conform to the pattern

```
data-test-[element or form input type]="<dcpModelpropertyname>"
```

Radio inputs follow this pattern:
```
data-test-radio="<dcpModelpropertyname>"
data-test-radio-option="<model property value>"
```

Note that `<dcpModelpropertyname>` represents the CRM-defined property name. We keep CRM's capitalization pattern.

Examples:
```
<Input
  @type="text"
  @value={{saveable-form.saveableChanges.dcpProposeddevelopmentsiteotherexplanation}}
  data-test-input="dcpProposeddevelopmentsiteotherexplanation"
/>
```

```
<Input
  @type="checkbox"
   ....
  data-test-checkbox="dcpProposeddevelopmentsitenewconstruction"
/>
```

```
<saveable-form.radio
  @value={{radio.code}}
  @groupValue={{saveable-form.saveableChanges.dcpHousingunittype}}
  data-test-radio="dcpHousingunittype"
  data-test-radio-option={{radio.label}}
>
```

