### PR TITLE
252: Standardize and add test for PAS form validation

### DIFF
--- a/client/app/components/land-use-action.hbs
+++ b/client/app/components/land-use-action.hbs
@@ -38,6 +38,7 @@
             />
             <ValidationMessage
               @changesetError={{get @submittableChanges.error landUseAction.countField}}
+              data-test-validation-message="{{landUseAction.countField}}"
             />
           </div>
         </div>
@@ -51,6 +52,7 @@
           />
           <ValidationMessage
             @changesetError={{get @submittableChanges.error landUseAction.attr1}}
+            data-test-validation-message="{{landUseAction.attr1}}"
           />
           <span class="help-text">Provide the Zoning Resolution section number. Ex. ZR Sec. 74-711</span>
         </label>
@@ -64,6 +66,7 @@
           />
           <ValidationMessage
             @changesetError={{get @submittableChanges.error landUseAction.attr2}}
+            data-test-validation-message="{{landUseAction.attr2}}"
           />
           <span class="help-text">Provide the Zoning Resolution section number(s). Ex. ZR Sec. 42-10 and 43-17</span>
         </label>
@@ -79,6 +82,7 @@
           />
           <ValidationMessage
             @changesetError={{get @submittableChanges.error landUseAction.attr1}}
+            data-test-validation-message="{{landUseAction.attr1}}"
           />
           <span class="help-text">ex. R7-1/C2-4</span>
         </label>
@@ -92,6 +96,7 @@
           />
           <ValidationMessage
             @changesetError={{get @submittableChanges.error landUseAction.attr2}}
+            data-test-validation-message="{{landUseAction.attr2}}"
           />
           <span class="help-text">ex. C4-5X</span>
         </label>
@@ -107,6 +112,7 @@
           />
           <ValidationMessage
             @changesetError={{get @submittableChanges.error landUseAction.attr1}}
+            data-test-validation-message="{{landUseAction.attr1}}"
           />
           <span class="help-text">Provide the Zoning Resolution section number. Ex. ZR Sec. 74-711</span>
         </label>
@@ -120,6 +126,7 @@
           />
           <ValidationMessage
             @changesetError={{get @submittableChanges.error landUseAction.attr2}}
+            data-test-validation-message="{{landUseAction.attr2}}"
           />
           <span class="help-text">Provide the Zoning Resolution section Title. Ex. EXAMPLE</span>
         </label>
@@ -135,6 +142,7 @@
           />
           <ValidationMessage
             @changesetError={{get @submittableChanges.error landUseAction.attr1}}
+            data-test-validation-message="{{landUseAction.attr1}}"
           />
           <span class="help-text">ex. 200307ZRK</span>
         </label>

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -41,7 +41,8 @@
             data-test-input="dcpRevisedprojectname"
           />
           <ValidationMessage
-            @changesetError={{saveable-form.saveableChanges.error.dcpRevisedprojectname}}
+            @changesetError={{saveable-form.submittableChanges.error.dcpRevisedprojectname}}
+            data-test-validation-message="dcpRevisedprojectname"
           />
         </label>
       </section>
@@ -99,6 +100,7 @@
             />
             <ValidationMessage
               @changesetError={{saveable-form.submittableChanges.error.dcpDescriptionofprojectareageography}}
+              data-test-validation-message="dcpDescriptionofprojectgeography"
             />
           </label>
         </section>
@@ -424,6 +426,7 @@
                 />
                 <ValidationMessage
                   @changesetError={{saveable-form.saveableChanges.error.dcpCityregisterfilenumber}}
+                  data-test-validation-message="dcpCityregisterfilenumber"
                 />
               </label>
             {{/if}}
@@ -469,6 +472,7 @@
             />
             <ValidationMessage
               @changesetError={{saveable-form.saveableChanges.error.dcpEstimatedcompletiondate}}
+              data-test-validation-message="dcpEstimatedcompletiondate"
             />
             {{!-- QUESTION: Should this be a date picker? --}}
           </label>
@@ -632,6 +636,7 @@
               </fieldset>
               <ValidationMessage
                 @changesetError={{saveable-form.submittableChanges.error.dcpHousingunittype}}
+                data-test-validation-message="dcpHousingunittype"
               />
             {{/if}}
           </fieldset>
@@ -660,6 +665,7 @@
             />
             <ValidationMessage
               @changesetError={{saveable-form.submittableChanges.error.dcpProjectdescriptionproposeddevelopment}}
+              data-test-validation-message="dcpProjectdescriptionproposeddevelopment"
             />
           </label>
 
@@ -676,6 +682,7 @@
             />
             <ValidationMessage
               @changesetError={{saveable-form.submittableChanges.error.dcpProjectdescriptionbackground}}
+              data-test-validation-message="dcpProjectdescriptionbackground"
             />
           </label>
 
@@ -692,6 +699,7 @@
             />
             <ValidationMessage
               @changesetError={{saveable-form.submittableChanges.error.dcpProjectdescriptionproposedactions}}
+              data-test-validation-message="dcpProjectdescriptionproposedactions"
             />
           </label>
 
@@ -708,6 +716,7 @@
             />
             <ValidationMessage
               @changesetError={{saveable-form.submittableChanges.error.dcpProjectdescriptionproposedarea}}
+              data-test-validation-message="dcpProjectdescriptionproposedarea"
             />
           </label>
 
@@ -724,6 +733,7 @@
             />
             <ValidationMessage
               @changesetError={{saveable-form.submittableChanges.error.dcpProjectdescriptionsurroundingarea}}
+              data-test-validation-message="dcpProjectdescriptionsurroundingarea"
             />
           </label>
 
@@ -739,10 +749,11 @@
             />
             <CharacterCounter
               @string={{saveable-form.saveableChanges.dcpProjectattachmentsotherinformation}}
-              @maxlength="3000"
+              @maxlength="2000"
             />
             <ValidationMessage
               @changesetError={{saveable-form.submittableChanges.error.dcpProjectattachmentsotherinformation}}
+              data-test-validation-message="dcpProjectattachmentsotherinformation"
             />
           </label>
         </section>

--- a/client/app/components/validation-message.hbs
+++ b/client/app/components/validation-message.hbs
@@ -1,7 +1,6 @@
 {{#if @changesetError}}
   <span
     class="text-red"
-    data-test-validation-message="{{@changesetError.validation.firstObject}}"
     ...attributes
   >
     {{@changesetError.validation}}

--- a/client/app/validations/saveable-pas-form.js
+++ b/client/app/validations/saveable-pas-form.js
@@ -8,7 +8,7 @@ export default {
     validateLength({
       min: 0,
       max: 50,
-      message: 'Name must be between {min} and {max} characters',
+      message: 'Text is too long (max {max} characters)',
     }),
   ],
 
@@ -16,7 +16,7 @@ export default {
     validateLength({
       min: 0,
       max: 2000,
-      message: 'Must be between {min} and {max} characters',
+      message: 'Text is too long (max {max} characters)',
     }),
   ],
 
@@ -24,7 +24,7 @@ export default {
     validateLength({
       min: 0,
       max: 250,
-      message: 'Name is too long (max {max} characters)',
+      message: 'Text is too long (max {max} characters)',
     }),
   ],
 
@@ -40,7 +40,7 @@ export default {
     validateLength({
       min: 0,
       max: 250,
-      message: 'Name is too long (max {max} characters)',
+      message: 'Text is too long (max {max} characters)',
     }),
   ],
 
@@ -48,7 +48,7 @@ export default {
     validateLength({
       min: 0,
       max: 250,
-      message: 'Name is too long (max {max} characters)',
+      message: 'Text is too long (max {max} characters)',
     }),
   ],
 
@@ -56,7 +56,7 @@ export default {
     validateLength({
       min: 0,
       max: 25,
-      message: 'File Number is too long (max {max} characters)',
+      message: 'Number is too long (max {max} characters)',
     }),
   ],
 
@@ -96,7 +96,7 @@ export default {
     validateLength({
       min: 0,
       max: 3000,
-      message: 'Text is too long (max 3000 characters)',
+      message: 'Text is too long (max {max} characters)',
     }),
   ],
 
@@ -104,7 +104,7 @@ export default {
     validateLength({
       min: 0,
       max: 3000,
-      message: 'Text is too long (max 3000 characters)',
+      message: 'Text is too long (max {max} characters)',
     }),
   ],
 
@@ -112,112 +112,112 @@ export default {
     validateLength({
       min: 0,
       max: 2000,
-      message: 'Text is too long (max 2000 characters)',
+      message: 'Text is too long (max {max} characters)',
     }),
   ],
 
   dcpZoningauthorizationpursuantto: [
     validateLength({
       max: 250,
-      message: 'Text is too long (max 250 characters)',
+      message: 'Text is too long (max {max} characters)',
     }),
   ],
 
   dcpZoningauthorizationtomodify: [
     validateLength({
       max: 250,
-      message: 'Text is too long (max 250 characters)',
+      message: 'Text is too long (max {max} characters)',
     }),
   ],
 
   dcpZoningtomodify: [
     validateLength({
       max: 250,
-      message: 'Text is too long (max 250 characters)',
+      message: 'Text is too long (max {max} characters)',
     }),
   ],
 
   dcpZoningpursuantto: [
     validateLength({
       max: 250,
-      message: 'Text is too long (max 250 characters)',
+      message: 'Text is too long (max {max} characters)',
     }),
   ],
 
   dcpExistingmapamend: [
     validateLength({
       max: 250,
-      message: 'Text is too long (max 250 characters)',
+      message: 'Text is too long (max {max} characters)',
     }),
   ],
 
   dcpProposedmapamend: [
     validateLength({
       max: 250,
-      message: 'Text is too long (max 250 characters)',
+      message: 'Text is too long (max {max} characters)',
     }),
   ],
 
   dcpZoningspecialpermitpursuantto: [
     validateLength({
       max: 250,
-      message: 'Text is too long (max 250 characters)',
+      message: 'Text is too long (max {max} characters)',
     }),
   ],
 
   dcpZoningspecialpermittomodify: [
     validateLength({
       max: 250,
-      message: 'Text is too long (max 250 characters)',
+      message: 'Text is too long (max {max} characters)',
     }),
   ],
 
   dcpAffectedzrnumber: [
     validateLength({
       max: 250,
-      message: 'Text is too long (max 250 characters)',
+      message: 'Text is too long (max {max} characters)',
     }),
   ],
 
   dcpZoningresolutiontitle: [
     validateLength({
       max: 250,
-      message: 'Text is too long (max 250 characters)',
+      message: 'Text is too long (max {max} characters)',
     }),
   ],
 
   dcpPreviousulurpnumbers1: [
     validateLength({
       max: 100,
-      message: 'Text is too long (max 250 characters)',
+      message: 'Text is too long (max {max} characters)',
     }),
   ],
 
   dcpPreviousulurpnumbers2: [
     validateLength({
       max: 100,
-      message: 'Text is too long (max 250 characters)',
+      message: 'Text is too long (max {max} characters)',
     }),
   ],
 
   dcpPfzoningauthorization: [
     validateLength({
       max: 10,
-      message: 'Text is too long (max 10 characters)',
+      message: 'Text is too long (max {max} characters)',
     }),
   ],
 
   dcpPfzoningcertification: [
     validateLength({
       max: 10,
-      message: 'Text is too long (max 10 characters)',
+      message: 'Text is too long (max {max} characters)',
     }),
   ],
 
   dcpPfzoningspecialpermit: [
     validateLength({
       max: 10,
-      message: 'Text is too long (max 10 characters)',
+      message: 'Text is too long (max {max} characters)',
     }),
   ],
 };

--- a/client/app/validations/submittable-pas-form.js
+++ b/client/app/validations/submittable-pas-form.js
@@ -1,3 +1,6 @@
+import {
+  validatePresence,
+} from 'ember-changeset-validations/validators';
 import SaveablePasForm from './saveable-pas-form';
 import validatePresenceIf from '../validators/required-if-selected';
 import validateNumberIf from '../validators/validate-number-if';
@@ -6,6 +9,10 @@ export default {
   ...SaveablePasForm,
   dcpRevisedprojectname: [
     ...SaveablePasForm.dcpRevisedprojectname,
+    validatePresence({
+      presence: true,
+      message: 'This field is required',
+    }),
   ],
   dcpUrbanareaname: [
     ...SaveablePasForm.dcpUrbanareaname,
@@ -181,7 +188,7 @@ export default {
       on: 'dcpPfzoningauthorization',
       withValue: (target) => target !== null && target !== undefined,
       gte: 1,
-      message: 'Number of actions must be greater than 0.',
+      message: 'Number of actions must be greater than 0',
     }),
   ],
   dcpPfzoningcertification: [
@@ -190,7 +197,7 @@ export default {
       on: 'dcpPfzoningcertification',
       withValue: (target) => target !== null && target !== undefined,
       gte: 1,
-      message: 'Number of actions must be greater than 0.',
+      message: 'Number of actions must be greater than 0',
     }),
   ],
   dcpPfzoningspecialpermit: [
@@ -199,7 +206,7 @@ export default {
       on: 'dcpPfzoningspecialpermit',
       withValue: (target) => target !== null && target !== undefined,
       gte: 1,
-      message: 'Number of actions must be greater than 0.',
+      message: 'Number of actions must be greater than 0',
     }),
   ],
 };

--- a/client/tests/acceptance/land-use-action-fields-validate-test.js
+++ b/client/tests/acceptance/land-use-action-fields-validate-test.js
@@ -28,23 +28,23 @@ module('Acceptance | land use action fields validate', function(hooks) {
 
     await selectChoose('[data-test-land-use-action-picker]', 'Zoning Authorization');
 
-    assert.dom('[data-test-validation-message="Number of actions must be greater than 0."]').doesNotExist();
+    assert.dom('[data-test-validation-message="dcpPfzoningauthorization"]').doesNotExist();
 
     await fillIn('[data-test-input="dcpPfzoningauthorization"]', '-1');
 
-    assert.dom('[data-test-validation-message="Number of actions must be greater than 0."]').exists();
+    assert.dom('[data-test-validation-message="dcpPfzoningauthorization"]').hasText('Number of actions must be greater than 0');
 
     await fillIn('[data-test-input="dcpPfzoningauthorization"]', '0');
 
-    assert.dom('[data-test-validation-message="Number of actions must be greater than 0."]').exists();
+    assert.dom('[data-test-validation-message="dcpPfzoningauthorization"]').hasText('Number of actions must be greater than 0');
 
     await fillIn('[data-test-input="dcpPfzoningauthorization"]', '');
 
-    assert.dom('[data-test-validation-message="Number of actions must be greater than 0."]').exists();
+    assert.dom('[data-test-validation-message="dcpPfzoningauthorization"]').hasText('Number of actions must be greater than 0');
 
     await fillIn('[data-test-input="dcpPfzoningauthorization"]', '2');
 
-    assert.dom('[data-test-validation-message="Number of actions must be greater than 0."]').doesNotExist();
+    assert.dom('[data-test-validation-message="dcpPfzoningauthorization"]').doesNotExist();
   });
 
   test('validation message appears for extra questions when user types incorrect value', async function(assert) {
@@ -53,24 +53,41 @@ module('Acceptance | land use action fields validate', function(hooks) {
       pasForm: this.server.create('pas-form'),
     });
 
+    // representation of input that is 1 over the maximum character limit
+    const maximum = (maxLength, singleCharacter) => singleCharacter.repeat(maxLength) + singleCharacter;
+
     await visit('/packages/1/edit');
 
-    assert.dom('[data-test-validation-message="This field is required."]').doesNotExist();
+    assert.dom('[data-test-validation-message="dcpZoningauthorizationpursuantto"]').doesNotExist();
+    assert.dom('[data-test-validation-message="dcpZoningauthorizationtomodify"]').doesNotExist();
 
     // Zoning Authorization
     await selectChoose('[data-test-land-use-action-picker]', 'Zoning Authorization');
-    assert.dom('[data-test-validation-message="This field is required"]').exists({ count: 2 });
+    assert.dom('[data-test-validation-message="dcpZoningauthorizationpursuantto"]').hasText('This field is required');
+    assert.dom('[data-test-validation-message="dcpZoningauthorizationtomodify"]').hasText('This field is required');
+    // check that an empty string value for dcpPfzoningauthorization still "requires" the extra fields
     await fillIn('[data-test-input="dcpPfzoningauthorization"]', '');
-    assert.dom('[data-test-validation-message="This field is required"]').exists({ count: 2 });
+    assert.dom('[data-test-validation-message="dcpZoningauthorizationpursuantto"]').hasText('This field is required');
+    assert.dom('[data-test-validation-message="dcpZoningauthorizationtomodify"]').hasText('This field is required');
+
+    // dcpZoningauthorizationpursuantto text length
+    await fillIn('[data-test-input="dcpZoningauthorizationpursuantto"]', maximum(250, 'a'));
+    assert.dom('[data-test-validation-message="dcpZoningauthorizationpursuantto"]').hasText('Text is too long (max 250 characters)');
     await fillIn('[data-test-input="dcpZoningauthorizationpursuantto"]', 'Section 5');
-    assert.dom('[data-test-validation-message="This field is required"]').exists({ count: 1 });
+    assert.dom('[data-test-validation-message="dcpZoningauthorizationpursuantto"]').doesNotExist();
+
+    // dcpZoningauthorizationtomodify text length
+    await fillIn('[data-test-input="dcpZoningauthorizationtomodify"]', maximum(250, 'a'));
+    assert.dom('[data-test-validation-message="dcpZoningauthorizationtomodify"]').hasText('Text is too long (max 250 characters)');
     await fillIn('[data-test-input="dcpZoningauthorizationtomodify"]', 'Section B');
-    assert.dom('[data-test-validation-message="This field is required"]').doesNotExist();
+    assert.dom('[data-test-validation-message="dcpZoningauthorizationtomodify"]').doesNotExist();
 
     // Renewal
     await selectChoose('[data-test-land-use-action-picker]', 'Renewal');
-    assert.dom('[data-test-validation-message="This field is required"]').exists({ count: 1 });
-    await fillIn('[data-test-input="dcpPreviousulurpnumbers2"]', '7777777');
-    assert.dom('[data-test-validation-message="This field is required"]').doesNotExist();
+    assert.dom('[data-test-validation-message="dcpPreviousulurpnumbers2"]').hasText('This field is required');
+    await fillIn('[data-test-input="dcpPreviousulurpnumbers2"]', maximum(100, '5'));
+    assert.dom('[data-test-validation-message="dcpPreviousulurpnumbers2"]').hasText('Text is too long (max 100 characters)');
+    await fillIn('[data-test-input="dcpPreviousulurpnumbers2"]', 55555);
+    assert.dom('[data-test-validation-message="dcpPreviousulurpnumbers2"]').doesNotExist();
   });
 });

--- a/client/tests/acceptance/pas-form-validation-messages-display-test.js
+++ b/client/tests/acceptance/pas-form-validation-messages-display-test.js
@@ -1,0 +1,161 @@
+import { module, test } from 'qunit';
+import {
+  visit,
+  fillIn,
+  click,
+} from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import exceedMaximum from '../helpers/exceed-maximum-characters';
+
+module('Acceptance | pas form validation messages display', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(() => {
+    authenticateSession({
+      emailaddress1: 'me@me.com',
+    });
+  });
+
+  test('Certain fields display both Saveable and Submittable validation errors', async function(assert) {
+    this.server.create('package', {
+      project: this.server.create('project'),
+      pasForm: this.server.create('pas-form'),
+    });
+
+    await visit('/packages/1/edit');
+
+    assert.dom('[data-test-submit-button]').hasAttribute('disabled');
+    assert.dom('[data-test-save-button]').hasNoAttribute('disabled');
+    await click('[data-test-save-button]');
+    assert.dom('[data-test-save-button]').hasAttribute('disabled');
+
+    // dcpRevisedprojectname (length limits and presence required)
+    assert.dom('[data-test-validation-message="dcpRevisedprojectname"]').hasText('This field is required');
+    await fillIn('[data-test-input="dcpRevisedprojectname"]', 'abc');
+    // save button should NOT be disabled because dcpRevisedprojectname exists and length is correct
+    assert.dom('[data-test-save-button]').hasNoAttribute('disabled');
+    assert.dom('[data-test-validation-message="dcpRevisedprojectname"]').doesNotExist();
+    await fillIn('[data-test-input="dcpRevisedprojectname"]', exceedMaximum(50, 'String'));
+    assert.dom('[data-test-validation-message="dcpRevisedprojectname"]').hasText('Text is too long (max 50 characters)');
+    // save button SHOULD be disabled because dcpRevisedprojectname has incorrect length
+    assert.dom('[data-test-save-button]').hasAttribute('disabled');
+
+    // dcpDescriptionofprojectgeography (length limits)
+    assert.dom('[data-test-validation-message="dcpDescriptionofprojectgeography"]').doesNotExist();
+    await fillIn('[data-test-textarea="dcpDescriptionofprojectareageography"]', exceedMaximum(2000, 'String'));
+    assert.dom('[data-test-validation-message="dcpDescriptionofprojectgeography"]').exists();
+    await fillIn('[data-test-textarea="dcpDescriptionofprojectareageography"]', 'my short description');
+    assert.dom('[data-test-validation-message="dcpDescriptionofprojectgeography"]').doesNotExist();
+
+    // dcpUrbanareaname (length limits and presence required in certain conditions)
+    assert.dom('[data-test-validation-message="dcpUrbanareaname"]').doesNotExist();
+    // dcpUrbanareaname required if...
+    await click('[data-test-radio="dcpUrbanrenewalarea"][data-test-radio-option="Yes"]');
+    assert.dom('[data-test-validation-message="dcpUrbanareaname"]').hasText('This field is required');
+    await fillIn('[data-test-input="dcpUrbanareaname"]', 'abc');
+    assert.dom('[data-test-validation-message="dcpUrbanareaname"]').doesNotExist();
+    await fillIn('[data-test-input="dcpUrbanareaname"]', exceedMaximum(250, 'String'));
+    assert.dom('[data-test-validation-message="dcpUrbanareaname"]').hasText('Text is too long (max 250 characters)');
+    await fillIn('[data-test-input="dcpUrbanareaname"]', 'my short description');
+    assert.dom('[data-test-validation-message="dcpUrbanareaname"]').doesNotExist();
+
+    // dcpPleaseexplaintypeiienvreview (length limits and presence required in certain conditions)
+    assert.dom('[data-test-validation-message="dcpPleaseexplaintypeiienvreview"]').doesNotExist();
+    // dcpPleaseexplaintypeiienvreview required if...
+    await click('[data-test-radio="dcpLanduseactiontype2"][data-test-radio-option="Yes"]');
+    assert.dom('[data-test-validation-message="dcpPleaseexplaintypeiienvreview"]').hasText('This field is required');
+    await fillIn('[data-test-input="dcpPleaseexplaintypeiienvreview"]', 'abc');
+    assert.dom('[data-test-validation-message="dcpPleaseexplaintypeiienvreview"]').doesNotExist();
+    await fillIn('[data-test-input="dcpPleaseexplaintypeiienvreview"]', exceedMaximum(200, 'String'));
+    assert.dom('[data-test-validation-message="dcpPleaseexplaintypeiienvreview"]').hasText('Text is too long (max 200 characters)');
+
+    // dcpProjectareaindutrialzonename (length limits and presence required in certain conditions)
+    assert.dom('[data-test-validation-message="dcpProjectareaindutrialzonename"]').doesNotExist();
+    // dcpProjectareaindutrialzonename required if...
+    await click('[data-test-radio="dcpProjectareaindustrialbusinesszone"][data-test-radio-option="Yes"]');
+    assert.dom('[data-test-validation-message="dcpProjectareaindutrialzonename"]').hasText('This field is required');
+    await fillIn('[data-test-input="dcpProjectareaindutrialzonename"]', 'abc');
+    assert.dom('[data-test-validation-message="dcpProjectareaindutrialzonename"]').doesNotExist();
+    await fillIn('[data-test-input="dcpProjectareaindutrialzonename"]', exceedMaximum(250, 'String'));
+    assert.dom('[data-test-validation-message="dcpProjectareaindutrialzonename"]').hasText('Text is too long (max 250 characters)');
+
+    // dcpProjectarealandmarkname (length limits and presence required in certain conditions)
+    assert.dom('[data-test-validation-message="dcpProjectarealandmarkname"]').doesNotExist();
+    // dcpProjectarealandmarkname required if...
+    await click('[data-test-radio="dcpIsprojectarealandmark"][data-test-radio-option="Yes"]');
+    assert.dom('[data-test-validation-message="dcpProjectarealandmarkname"]').hasText('This field is required');
+    await fillIn('[data-test-input="dcpProjectarealandmarkname"]', 'abc');
+    assert.dom('[data-test-validation-message="dcpProjectarealandmarkname"]').doesNotExist();
+    await fillIn('[data-test-input="dcpProjectarealandmarkname"]', exceedMaximum(250, 'String'));
+    assert.dom('[data-test-validation-message="dcpProjectarealandmarkname"]').hasText('Text is too long (max 250 characters)');
+
+    // dcpHousingunittype (presence required in certain conditions)
+    assert.dom('[data-test-validation-message="dcpHousingunittype"]').doesNotExist();
+    // dcpHousingunittype required if...
+    await click('[data-test-radio="dcpDiscressionaryfundingforffordablehousing"][data-test-radio-option="Yes"]');
+    assert.dom('[data-test-validation-message="dcpHousingunittype"]').hasText('This field is required');
+    await click('[data-test-radio="dcpHousingunittype"][data-test-radio-option="City"]');
+    assert.dom('[data-test-validation-message="dcpHousingunittype"]').doesNotExist();
+
+    // dcpCityregisterfilenumber (length limits)
+    assert.dom('[data-test-validation-message="dcpCityregisterfilenumber"]').doesNotExist();
+    await click('[data-test-radio="dcpRestrictivedeclaration"][data-test-radio-option="Yes"]');
+    assert.dom('[data-test-validation-message="dcpCityregisterfilenumber"]').doesNotExist();
+    await fillIn('[data-test-input="dcpCityregisterfilenumber"]', exceedMaximum(25, 'Number'));
+    assert.dom('[data-test-validation-message="dcpCityregisterfilenumber"]').exists();
+    await fillIn('[data-test-input="dcpCityregisterfilenumber"]', '555555');
+    assert.dom('[data-test-validation-message="dcpCityregisterfilenumber"]').doesNotExist();
+
+    // dcpEstimatedcompletiondate (length limits)
+    assert.dom('[data-test-validation-message="dcpEstimatedcompletiondate"]').doesNotExist();
+    await fillIn('[data-test-input="dcpEstimatedcompletiondate"]', '12345');
+    assert.dom('[data-test-validation-message="dcpEstimatedcompletiondate"]').hasText('Please enter a valid year in YYYY format');
+    await fillIn('[data-test-input="dcpEstimatedcompletiondate"]', '2005');
+    assert.dom('[data-test-validation-message="dcpEstimatedcompletiondate"]').doesNotExist();
+
+    // dcpProjectdescriptionproposeddevelopment (length limits)
+    assert.dom('[data-test-validation-message="dcpEstimatedcompletiondate"]').doesNotExist();
+    await fillIn('[data-test-textarea="dcpProjectdescriptionproposeddevelopment"]', exceedMaximum(3000, 'String'));
+    assert.dom('[data-test-validation-message="dcpProjectdescriptionproposeddevelopment"]').exists('Text is too long (max 3000 characters)');
+    await fillIn('[data-test-textarea="dcpProjectdescriptionproposeddevelopment"]', 'abc');
+    assert.dom('[data-test-validation-message="dcpProjectdescriptionproposeddevelopment"]').doesNotExist();
+
+    // dcpProjectdescriptionbackground (length limits)
+    assert.dom('[data-test-validation-message="dcpProjectdescriptionbackground"]').doesNotExist();
+    await fillIn('[data-test-textarea="dcpProjectdescriptionbackground"]', exceedMaximum(2000, 'String'));
+    assert.dom('[data-test-validation-message="dcpProjectdescriptionbackground"]').hasText('Text is too long (max 2000 characters)');
+    await fillIn('[data-test-textarea="dcpProjectdescriptionbackground"]', 'abc');
+    assert.dom('[data-test-validation-message="dcpProjectdescriptionproposeddevelopment"]').doesNotExist();
+
+    // dcpProjectdescriptionproposedactions (length limits)
+    assert.dom('[data-test-validation-message="dcpProjectdescriptionproposedactions"]').doesNotExist();
+    await fillIn('[data-test-textarea="dcpProjectdescriptionproposedactions"]', exceedMaximum(2000, 'String'));
+    assert.dom('[data-test-validation-message="dcpProjectdescriptionproposedactions"]').hasText('Text is too long (max 2000 characters)');
+    await fillIn('[data-test-textarea="dcpProjectdescriptionproposedactions"]', 'abc');
+    assert.dom('[data-test-validation-message="dcpProjectdescriptionproposedactions"]').doesNotExist();
+
+    // dcpProjectdescriptionproposedarea (length limits)
+    assert.dom('[data-test-validation-message="dcpProjectdescriptionproposedarea"]').doesNotExist();
+    await fillIn('[data-test-textarea="dcpProjectdescriptionproposedarea"]', exceedMaximum(3000, 'String'));
+    assert.dom('[data-test-validation-message="dcpProjectdescriptionproposedarea"]').hasText('Text is too long (max 3000 characters)');
+    await fillIn('[data-test-textarea="dcpProjectdescriptionproposedarea"]', 'abc');
+    assert.dom('[data-test-validation-message="dcpProjectdescriptionproposedarea"]').doesNotExist();
+
+    // dcpProjectdescriptionsurroundingarea (length limits)
+    assert.dom('[data-test-validation-message="dcpProjectdescriptionsurroundingarea"]').doesNotExist();
+    await fillIn('[data-test-textarea="dcpProjectdescriptionsurroundingarea"]', exceedMaximum(3000, 'String'));
+    assert.dom('[data-test-validation-message="dcpProjectdescriptionsurroundingarea"]').hasText('Text is too long (max 3000 characters)');
+    await fillIn('[data-test-textarea="dcpProjectdescriptionsurroundingarea"]', 'abc');
+    assert.dom('[data-test-validation-message="dcpProjectdescriptionsurroundingarea"]').doesNotExist();
+
+    // dcpProjectattachmentsotherinformation (length limits)
+    assert.dom('[data-test-validation-message="dcpProjectattachmentsotherinformation"]').doesNotExist();
+    await fillIn('[data-test-textarea="dcpProjectattachmentsotherinformation"]', exceedMaximum(2000, 'String'));
+    assert.dom('[data-test-validation-message="dcpProjectattachmentsotherinformation"]').hasText('Text is too long (max 2000 characters)');
+    await fillIn('[data-test-textarea="dcpProjectattachmentsotherinformation"]', 'abc');
+    assert.dom('[data-test-validation-message="dcpProjectattachmentsotherinformation"]').doesNotExist();
+  });
+});

--- a/client/tests/acceptance/user-can-click-package-edit-test.js
+++ b/client/tests/acceptance/user-can-click-package-edit-test.js
@@ -37,6 +37,7 @@ module('Acceptance | user can click package edit', function(hooks) {
 
     await visit('/projects');
     await click('[data-test-project="edit-pas"]');
+    await fillIn('[data-test-input="dcpRevisedprojectname"]', 'my project name');
     await click('[data-test-save-button]');
 
     await waitFor('[data-test-submit-button]:not([disabled])');
@@ -227,6 +228,8 @@ module('Acceptance | user can click package edit', function(hooks) {
     // render form
     await visit('/packages/1/edit');
 
+    await fillIn('[data-test-input="dcpRevisedprojectname"]', 'my project name');
+
     // modal doesn't exist to start
     assert.dom('[data-test-reveal-modal]').doesNotExist();
     assert.dom('[data-test-confirm-submit-button]').doesNotExist();
@@ -257,6 +260,8 @@ module('Acceptance | user can click package edit', function(hooks) {
     });
 
     await visit('/packages/1/edit');
+
+    await fillIn('[data-test-input="dcpRevisedprojectname"]', 'my project name');
 
     assert.dom('[data-test-save-button]').hasNoAttribute('disabled');
     assert.dom('[data-test-submit-button]').hasNoAttribute('disabled');
@@ -314,71 +319,5 @@ module('Acceptance | user can click package edit', function(hooks) {
     await click('[data-test-project="edit-pas"]');
 
     assert.dom('[data-test-section="attachments"').hasTextContaining('PAS Form.pdf');
-  });
-
-  test('Certain fields display both Saveable and Submittable validation errors', async function (assert) {
-    this.server.create('package', 1, {
-      pasForm: this.server.create('pas-form'),
-      project: this.server.create('project'),
-    });
-
-    await visit('/packages/1/edit');
-
-    assert.dom('[data-test-save-button]').hasNoAttribute('disabled');
-    assert.dom('[data-test-submit-button]').hasNoAttribute('disabled');
-
-    // name of the Urban Renewal Area
-    await click('[data-test-radio="dcpUrbanrenewalarea"][data-test-radio-option="Yes"]');
-
-    assert.dom('[data-test-validation-message="dcpUrbanareaname"]').hasText('This field is required');
-
-    await fillIn('[data-test-input="dcpUrbanareaname"]', 'abc');
-
-    assert.dom('[data-test-validation-message="dcpUrbanareaname"]').doesNotExist();
-
-    const longText = 'Some long text'.repeat(20);
-
-    await fillIn('[data-test-input="dcpUrbanareaname"]', longText);
-
-    assert.dom('[data-test-validation-message="dcpUrbanareaname"]').hasText('Name is too long (max 250 characters)');
-
-    // SEQRA or CEQR criteria for Type II status
-    await click('[data-test-radio="dcpLanduseactiontype2"][data-test-radio-option="Yes"]');
-
-    assert.dom('[data-test-validation-message="dcpPleaseexplaintypeiienvreview"]').hasText('This field is required');
-
-    await fillIn('[data-test-input="dcpPleaseexplaintypeiienvreview"]', 'abc');
-
-    assert.dom('[data-test-validation-message="dcpPleaseexplaintypeiienvreview"]').doesNotExist();
-
-    await fillIn('[data-test-input="dcpPleaseexplaintypeiienvreview"]', longText);
-
-    assert.dom('[data-test-validation-message="dcpPleaseexplaintypeiienvreview"]').hasText('Text is too long (max 200 characters)');
-
-    // Industrial Business Zone
-    await click('[data-test-radio="dcpProjectareaindustrialbusinesszone"][data-test-radio-option="Yes"]');
-
-    assert.dom('[data-test-validation-message="dcpProjectareaindutrialzonename"]').hasText('This field is required');
-
-    await fillIn('[data-test-input="dcpProjectareaindutrialzonename"]', 'abc');
-
-    assert.dom('[data-test-validation-message="dcpProjectareaindutrialzonename"]').doesNotExist();
-
-    await fillIn('[data-test-input="dcpProjectareaindutrialzonename"]', longText);
-
-    assert.dom('[data-test-validation-message="dcpProjectareaindutrialzonename"]').hasText('Name is too long (max 250 characters)');
-
-    // Landmark name
-    await click('[data-test-radio="dcpIsprojectarealandmark"][data-test-radio-option="Yes"]');
-
-    assert.dom('[data-test-validation-message="dcpProjectarealandmarkname"]').hasText('This field is required');
-
-    await fillIn('[data-test-input="dcpProjectarealandmarkname"]', 'abc');
-
-    assert.dom('[data-test-validation-message="dcpProjectarealandmarkname"]').doesNotExist();
-
-    await fillIn('[data-test-input="dcpProjectarealandmarkname"]', longText);
-
-    assert.dom('[data-test-validation-message="dcpProjectarealandmarkname"]').hasText('Name is too long (max 250 characters)');
   });
 });

--- a/client/tests/helpers/exceed-maximum-characters.js
+++ b/client/tests/helpers/exceed-maximum-characters.js
@@ -1,0 +1,13 @@
+export default function exceedMaximum(maxLength, inputType) {
+  let inputText;
+
+  if (inputType === 'String') {
+    inputText = 'a'.repeat(maxLength + 1);
+  }
+
+  if (inputType === 'Number') {
+    inputText = '5'.repeat(maxLength + 1);
+  }
+
+  return inputText;
+}


### PR DESCRIPTION
This PR:
- Adds acceptance test to account for ALL validations that occur on the PAS form (although land use actions have their own acceptance test) so that we have them all in one place. Because checking the required validations can be tedious, this test is meant to capture all validations that QA has been checking for and to make sure we have generic tests for when we conduct future refactors of the form (e.g. separating out components). This file can also function as extra documentation. 
- Standardize validation messages on text length
- Adds requirement for `dcpRevisedprojectname` to exist before submitting

Addresses #252 

Also addresses #317 (`dcpProjectattachmentsotherinformation` character counter is now consistent with its maximum length of `2000`)