### PR TITLE
307:  Update add and remove applicant state management

### DIFF
--- a/client/app/components/packages/applicant-team-editor.hbs
+++ b/client/app/components/packages/applicant-team-editor.hbs
@@ -1,4 +1,4 @@
-<div {{did-insert this.addApplicantIfEmpty}}>
+<div>
   {{#each @applicants as |applicant index|}}
     <Packages::ApplicantFieldset
       @elementId={{concat 'applicant-fieldset-' index}}

--- a/client/app/components/packages/applicant-team-editor.hbs
+++ b/client/app/components/packages/applicant-team-editor.hbs
@@ -1,5 +1,5 @@
 <div>
-  {{#each @applicants as |applicant index|}}
+  {{#each this.displayApplicants as |applicant index|}}
     <Packages::ApplicantFieldset
       @elementId={{concat 'applicant-fieldset-' index}}
       @applicant={{applicant}}

--- a/client/app/components/packages/applicant-team-editor.js
+++ b/client/app/components/packages/applicant-team-editor.js
@@ -19,6 +19,14 @@ export default class ApplicantTeamEditorComponent extends Component {
   // allow a user to remove an applicant fieldset
   @action
   removeApplicant(applicant) {
-      applicant.deleteRecord();
+    applicant.deleteRecord();
+
+    // FIXME: this updates the applicants array to update the UI
+    // but if we do this save buttton becomes disabled and user can't save
+    // because the way we compute pasForm.isApplicantsDirty is iterating through applicants array
+    // and checking each applicant model for dirtiness -- if we remove this applicant here,
+    // then it won't be included in the iteration and won't appear as dirty
+
+    // this.args.applicants.popObject(applicant);
   }
 }

--- a/client/app/components/packages/applicant-team-editor.js
+++ b/client/app/components/packages/applicant-team-editor.js
@@ -19,18 +19,6 @@ export default class ApplicantTeamEditorComponent extends Component {
   // allow a user to remove an applicant fieldset
   @action
   removeApplicant(applicant) {
-    // remove the applicant from the ember store
-    // this.store.deleteRecord(applicant);
-    applicant.destroyRecord();
-
-    // remove the DOM node by removing the object from the array passed to the editor component
-    this.args.applicants.removeObject(applicant);
-  }
-
-  @action
-  addApplicantIfEmpty() {
-    if (!this.args.applicants.length) {
-      this.addApplicant();
-    }
+      applicant.deleteRecord();
   }
 }

--- a/client/app/components/packages/applicant-team-editor.js
+++ b/client/app/components/packages/applicant-team-editor.js
@@ -6,6 +6,10 @@ export default class ApplicantTeamEditorComponent extends Component {
   @service
   store;
 
+  get displayApplicants() {
+    return this.args.applicants.filter((applicant) => !applicant.isDeleted);
+  }
+
   // allow a user to add a new applicant fieldset
   @action
   addApplicant(targetEntity) {
@@ -20,13 +24,5 @@ export default class ApplicantTeamEditorComponent extends Component {
   @action
   removeApplicant(applicant) {
     applicant.deleteRecord();
-
-    // FIXME: this updates the applicants array to update the UI
-    // but if we do this save buttton becomes disabled and user can't save
-    // because the way we compute pasForm.isApplicantsDirty is iterating through applicants array
-    // and checking each applicant model for dirtiness -- if we remove this applicant here,
-    // then it won't be included in the iteration and won't appear as dirty
-
-    // this.args.applicants.popObject(applicant);
   }
 }

--- a/client/app/components/saveable-form.js
+++ b/client/app/components/saveable-form.js
@@ -13,13 +13,13 @@ export default class SaveableFormComponent extends Component {
       submittabilityValidations = {},
     ] = this.args.validators || [];
 
-    this.saveableChanges = new Changeset(
+    this.saveableChanges = Changeset(
       this.args.model,
       lookupValidator(saveabilityValidations),
       saveabilityValidations,
     );
 
-    this.submittableChanges = new Changeset(
+    this.submittableChanges = Changeset(
       this.args.model,
       lookupValidator(submittabilityValidations),
       submittabilityValidations,

--- a/client/tests/acceptance/pas-form-validation-messages-display-test.js
+++ b/client/tests/acceptance/pas-form-validation-messages-display-test.js
@@ -28,8 +28,6 @@ module('Acceptance | pas form validation messages display', function(hooks) {
     await visit('/packages/1/edit');
 
     assert.dom('[data-test-submit-button]').hasAttribute('disabled');
-    assert.dom('[data-test-save-button]').hasNoAttribute('disabled');
-    await click('[data-test-save-button]');
     assert.dom('[data-test-save-button]').hasAttribute('disabled');
 
     // dcpRevisedprojectname (length limits and presence required)

--- a/client/tests/acceptance/user-can-click-package-edit-test.js
+++ b/client/tests/acceptance/user-can-click-package-edit-test.js
@@ -63,15 +63,6 @@ module('Acceptance | user can click package edit', function(hooks) {
 
     await visit('/packages/2/edit');
 
-    // ! We remove the pregenerated applicant here to disable the "save" button.
-    // Clicking "Save" to disable the Save button causes a race condition:
-    // The automated clicks act so fast that the file is marked for deletion
-    // BEFORE the full Save operation completes,
-    // causing the file marked for deletion to be immediately cleared.
-    // TODO: Perhaps rework frontend using a Task group to prevent
-    // this race condition.
-    await click('[data-test-remove-applicant-button]');
-
     assert.dom('[data-test-save-button]').isDisabled();
 
     await click('[data-test-delete-file-button="0"]');
@@ -86,10 +77,6 @@ module('Acceptance | user can click package edit', function(hooks) {
     });
 
     await visit('/packages/2/edit');
-
-    // See note in previous test about why this click to remove applicant
-    // is performed.
-    await click('[data-test-remove-applicant-button]');
 
     assert.dom('[data-test-save-button]').isDisabled();
 

--- a/client/tests/integration/components/packages/applicant-team-editor-test.js
+++ b/client/tests/integration/components/packages/applicant-team-editor-test.js
@@ -55,13 +55,12 @@ module('Integration | Component | packages/applicant-team-editor', function(hook
   test('user can remove applicants', async function(assert) {
     // create an applicant model
     let applicant = this.server.create('applicant', 'organizationApplicant');
+    // get the reference to the model instance
+    applicant = await this.owner.lookup('service:store').findRecord('applicant', applicant.id);
 
     this.applicants = [
-      await this.owner.lookup('service:store').findRecord('applicant', applicant.id),
+      applicant,
     ];
-
-    // get the reference to the model instance
-    applicant = await this.owner.lookup('service:store').findRecord('applicant', applicant.id),
 
     await render(hbs`
       <Packages::ApplicantTeamEditor
@@ -69,16 +68,16 @@ module('Integration | Component | packages/applicant-team-editor', function(hook
       />
     `);
 
-    
-    assert.equal(applicant.hasDirtyAttributes, false);
-    assert.equal(applicant.isDeleted, false);
+
+    await assert.equal(applicant.hasDirtyAttributes, false);
+    await assert.equal(applicant.isDeleted, false);
 
     // remove the applicant
     await click('[data-test-remove-applicant-button');
 
     // should trigger dirty state, be queued for deletion when user saves
-    assert.equal(applicant.hasDirtyAttributes, true);
-    assert.equal(applicant.isDeleted, true);
+    await assert.equal(applicant.hasDirtyAttributes, true);
+    await assert.equal(applicant.isDeleted, true);
 
     // FIXME: user shouldn't see the fieldset
     assert.dom('[data-test-applicant-fieldset="0"]').doesNotExist();


### PR DESCRIPTION
This PR addresses #307.

Previously, if the applicants array was empty we were adding a blank applicant record so we could render an empty applicant fieldset for the user.   This commit removes that to simplify UX and DX.

When a user clicked “Remove Applicant” button, we were using model.destroyRecord(), which would immediately send a DELETE request to the api server.

In this commit, we use model.deleteRecord() instead, which sets model.isDeleted = true.  This queues the record for deletion when the user clicks “Save” (which ultimately will trigger model.save(), where Ember Data makes the api reqeust to DELETE.