### PR TITLE
fix PAS show funding source var

### DIFF
--- a/client/app/components/packages/pas-form/show.hbs
+++ b/client/app/components/packages/pas-form/show.hbs
@@ -515,16 +515,16 @@
         </span>
       </p>
 
-      {{#if @package.pasForm.dcpHousingunittypeCity}}
+      {{#if @package.pasForm.dcpHousingunittype}}
         <p class="grid-x ruled-adjacent tight">
           <strong class="cell auto large-padding-right">
             Funding source
           </strong>
           <span class="cell large-3">
-            {{if (eq @package.pasForm.dcpHousingunittypeCity 717170000) "City"}}
-            {{if (eq @package.pasForm.dcpHousingunittypeCity 717170001) "State"}}
-            {{if (eq @package.pasForm.dcpHousingunittypeCity 717170002) "Federal"}}
-            {{if (eq @package.pasForm.dcpHousingunittypeCity 717170003) "Other"}}
+            {{if (eq @package.pasForm.dcpHousingunittype 717170000) "City"}}
+            {{if (eq @package.pasForm.dcpHousingunittype 717170001) "State"}}
+            {{if (eq @package.pasForm.dcpHousingunittype 717170002) "Federal"}}
+            {{if (eq @package.pasForm.dcpHousingunittype 717170003) "Other"}}
           </span>
         </p>
       {{/if}}


### PR DESCRIPTION
This PR fixes some bad copy/paste which broke the display of "Funding source" in the PAS show template. Addresses #335. 