### PR TITLE
add CSS overrides so Ember Power Select matches our styles

### DIFF
--- a/client/app/styles/app.scss
+++ b/client/app/styles/app.scss
@@ -24,6 +24,7 @@ $small-font-size: 81.25%; // TODO: update Style Guide so that <small> matches .t
 @import 'modules/_pasform';
 
 @import "ember-power-select";
+@import 'modules/_powerselect-overrides';
 
 
 .site-header {

--- a/client/app/styles/modules/_powerselect-overrides.scss
+++ b/client/app/styles/modules/_powerselect-overrides.scss
@@ -1,0 +1,51 @@
+/* Module: Ember Power Select overrides */
+
+.ember-power-select-trigger {
+  line-height: $input-line-height;
+  border-radius: 0;
+  border: $input-border;
+  margin-bottom: $global-margin;
+  padding-top: $input-padding;
+  padding-right: 2rem;
+  min-height: 2.4375rem;
+  min-width: 4.75rem;
+  padding-bottom: $input-padding;
+  padding-left: $input-padding;
+
+  &[aria-expanded="true"] {
+    border: $input-border-focus;
+  }
+}
+
+.ember-power-select-status-icon {
+  right: 1rem;
+}
+
+.ember-power-select-placeholder,
+.ember-basic-dropdown-content-placeholder,
+.ember-power-select-selected-item {
+  display: block;
+  margin: -1px 0;
+}
+
+.ember-power-select-dropdown {
+  border-color: $gray;
+  border-radius: 0 !important;
+
+  &.ember-basic-dropdown-content--above {
+      border-top: 1px solid $gray;
+  }
+
+  &.ember-basic-dropdown-content--below {
+      border-bottom: 1px solid $gray;
+  }
+}
+
+.ember-power-select-search-input {
+  margin-bottom: 0;
+  border: $input-border;
+
+  &:focus {
+    border: $input-border-focus;
+  }
+}


### PR DESCRIPTION
### Before

(too short, rounded corners, wrong border color)

<img src="https://user-images.githubusercontent.com/409279/82594853-b85e8280-9b72-11ea-9a9e-3c4e3133957f.png" width="300"> <img src="https://user-images.githubusercontent.com/409279/82594993-e643c700-9b72-11ea-94d3-7b4847e7fc61.png" width="170">


### After

(matches input height, square corners, matching border color)

<img src="https://user-images.githubusercontent.com/409279/82594779-9e24a480-9b72-11ea-80bc-e56035fcff3a.png" width="300"> <img src="https://user-images.githubusercontent.com/409279/82595086-05daef80-9b73-11ea-94e3-a8bce1c66e8c.png" width="170">
