### PR TITLE
293: reset conditional input value when radio button set to no

### DIFF
--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -167,6 +167,7 @@
               <saveable-form.radio
                 @value={{radio.code}}
                 @groupValue={{saveable-form.saveableChanges.dcpUrbanrenewalarea}}
+                @changed={{fn (mut saveable-form.saveableChanges.dcpUrbanareaname) ""}}
                  data-test-radio="dcpUrbanrenewalarea"
                  data-test-radio-option={{radio.label}}
               >
@@ -238,6 +239,7 @@
               <saveable-form.radio
                 @value={{radio.code}}
                 @groupValue={{saveable-form.saveableChanges.dcpLanduseactiontype2}}
+                @changed={{fn (mut saveable-form.saveableChanges.dcpPleaseexplaintypeiienvreview) ""}}
                 data-test-radio="dcpLanduseactiontype2"
                 data-test-radio-option={{radio.label}}
               >
@@ -288,6 +290,7 @@
               <saveable-form.radio
                 @value={{radio.code}}
                 @groupValue={{saveable-form.saveableChanges.dcpProjectareaindustrialbusinesszone}}
+                @changed={{fn (mut saveable-form.saveableChanges.dcpProjectareaindutrialzonename) ""}}
                 data-test-radio="dcpProjectareaindustrialbusinesszone"
                 data-test-radio-option={{radio.label}}
               >
@@ -325,6 +328,7 @@
               <saveable-form.radio
                 @value={{radio.code}}
                 @groupValue={{saveable-form.saveableChanges.dcpIsprojectarealandmark}}
+                @changed={{fn (mut saveable-form.saveableChanges.dcpProjectarealandmarkname) ""}}
                 data-test-radio="dcpIsprojectarealandmark"
                 data-test-radio-option={{radio.label}}
               >
@@ -402,6 +406,7 @@
               <saveable-form.radio
                 @value={{radio.code}}
                 @groupValue={{saveable-form.saveableChanges.dcpRestrictivedeclaration}}
+                @changed={{fn (mut saveable-form.saveableChanges.dcpCityregisterfilenumber) null}}
                 data-test-radio="dcpRestrictivedeclaration"
                 data-test-radio-option={{radio.label}}
               >
@@ -536,6 +541,7 @@
               <li>
                 <Input
                   @type="checkbox"
+                  {{on "click" (fn (mut saveable-form.saveableChanges.dcpProposeddevelopmentsiteotherexplanation) "")}}
                   @checked={{saveable-form.saveableChanges.dcpProposeddevelopmentsiteinfoother}}
                   id="dcpproposeddevelopmentsiteinfoother"
                   data-test-checkbox="dcpProposeddevelopmentsiteinfoother"
@@ -573,6 +579,7 @@
               <saveable-form.radio
                 @value={{radio.code}}
                 @groupValue={{saveable-form.saveableChanges.dcpIsinclusionaryhousingdesignatedarea}}
+                @changed={{fn (mut saveable-form.saveableChanges.dcpInclusionaryhousingdesignatedareaname) ""}}
                 data-test-radio="dcpIsinclusionaryhousingdesignatedarea"
                 data-test-radio-option={{radio.label}}
               >
@@ -606,6 +613,7 @@
               <saveable-form.radio
                 @value={{radio.code}}
                 @groupValue={{saveable-form.saveableChanges.dcpDiscressionaryfundingforffordablehousing}}
+                @changed={{fn (mut saveable-form.saveableChanges.dcpHousingunittype) ""}}
                 data-test-radio="dcpDiscressionaryfundingforffordablehousing"
                 data-test-radio-option={{radio.label}}
               >

--- a/client/tests/acceptance/user-can-click-package-edit-test.js
+++ b/client/tests/acceptance/user-can-click-package-edit-test.js
@@ -307,4 +307,52 @@ module('Acceptance | user can click package edit', function(hooks) {
 
     assert.dom('[data-test-section="attachments"').hasTextContaining('PAS Form.pdf');
   });
+
+  test('For input dependent on radio button/checkbox -- when user fills out input, then clicks radio button/checkbox that hides input, text is not saved to model', async function(assert) {
+    this.server.create('package', 1, {
+      pasForm: this.server.create('pas-form'),
+      project: this.server.create('project'),
+    });
+
+    await visit('/packages/1/edit');
+
+    // dcpInclusionaryhousingdesignatedareaname (radio button) -----------------------------------------
+    // user selects "Yes" radio button and fills out input, then saves
+    await click('[data-test-radio="dcpIsinclusionaryhousingdesignatedarea"][data-test-radio-option="Yes"]');
+    await fillIn('[data-test-input="dcpInclusionaryhousingdesignatedareaname"]', 'bananas');
+    await click('[data-test-save-button]');
+    await settled();
+    assert.equal(this.server.db.pasForms[0].dcpInclusionaryhousingdesignatedareaname, 'bananas');
+    // user selects "No" radio button and fills out input, then saves
+    await click('[data-test-radio="dcpIsinclusionaryhousingdesignatedarea"][data-test-radio-option="No"]');
+    await click('[data-test-save-button]');
+    await settled();
+    // clicking on the radio button should set the value to an empty string
+    assert.equal(this.server.db.pasForms[0].dcpInclusionaryhousingdesignatedareaname, '');
+    // user re-selects "Yes" radio button and re-fills out input, then saves
+    await click('[data-test-radio="dcpIsinclusionaryhousingdesignatedarea"][data-test-radio-option="Yes"]');
+    await fillIn('[data-test-input="dcpInclusionaryhousingdesignatedareaname"]', 'peaches');
+    await click('[data-test-save-button]');
+    await settled();
+    assert.equal(this.server.db.pasForms[0].dcpInclusionaryhousingdesignatedareaname, 'peaches');
+
+    // dcpProposeddevelopmentsiteotherexplanation (checkbox) -----------------------------------------
+    // user selects checkbox and fills out input, then saves
+    await click('[data-test-checkbox="dcpProposeddevelopmentsiteinfoother"]');
+    await fillIn('[data-test-input="dcpProposeddevelopmentsiteotherexplanation"]', 'pecan pie');
+    await click('[data-test-save-button]');
+    await settled();
+    assert.equal(this.server.db.pasForms[0].dcpProposeddevelopmentsiteotherexplanation, 'pecan pie');
+    await click('[data-test-checkbox="dcpProposeddevelopmentsiteinfoother"]');
+    await click('[data-test-save-button]');
+    await settled();
+    // clicking the checkbox should set the value to an empty string
+    assert.equal(this.server.db.pasForms[0].dcpProposeddevelopmentsiteotherexplanation, '');
+    // user re-selects checkbox and re-fills out input, then saves
+    await click('[data-test-checkbox="dcpProposeddevelopmentsiteinfoother"]');
+    await fillIn('[data-test-input="dcpProposeddevelopmentsiteotherexplanation"]', 'strawberry rhubarb');
+    await click('[data-test-save-button]');
+    await settled();
+    assert.equal(this.server.db.pasForms[0].dcpProposeddevelopmentsiteotherexplanation, 'strawberry rhubarb');
+  });
 });


### PR DESCRIPTION
When a user enters text into a conditional input (which only displays when the associated radio button is set to Yes or checkbox is `checked`), then clicks the No radio button or the checkbox again -- the text value is reset to empty string or null, so that text is not saved to the model.

Setting a conditional `@value` on the input (through an inline `if` statement) did not work. So instead, an action was defined on the radio buttons (`@checked`) and on the checkboxes (`click`) to set the targeted input value to an empty string or null anytime that the radio button/checkbox was selected.

Addresses #293 