### PR TITLE
Ac custom transitions

### DIFF
--- a/client/app/components/land-use-action.hbs
+++ b/client/app/components/land-use-action.hbs
@@ -16,10 +16,12 @@
   </label>
 </div>
 {{#if this.sortedSelectedActions}}
-  <h5>Land Use Actions Included in This Project</h5>
+  <h5 {{animate-with 'slide-in-top' 'slide-in-top-active'}}>
+    Land Use Actions Included in This Project
+  </h5>
 {{/if}}
 {{#each this.sortedSelectedActions as |landUseAction|}}
-  <fieldset class="fieldset relative">
+  <fieldset class="fieldset relative" {{animate-with 'scale-fade-in' 'scale-fade-in-active'}}>
     <legend>
       <strong data-test-action-name="{{landUseAction.name}}">{{landUseAction.name}}</strong>
     </legend>
@@ -30,7 +32,7 @@
             <label for="middle-label" class="middle">How many {{landUseAction.name}} actions?</label>
           </div>
           <div class="auto cell">
-            <ActionFormInput 
+            <ActionFormInput
               @pasForm={{@pasForm}}
               @fieldType="number"
               @length="10"
@@ -44,7 +46,7 @@
         </div>
         <label class="action-form-label">
           Where in the Zoning Resolution can this action be found?
-          <ActionFormInput 
+          <ActionFormInput
             @pasForm={{@pasForm}}
             @fieldType="text"
             @length="250"

--- a/client/app/components/packages/applicant-team-editor.hbs
+++ b/client/app/components/packages/applicant-team-editor.hbs
@@ -1,13 +1,17 @@
 <div>
-  {{#each this.displayApplicants as |applicant index|}}
-    <Packages::ApplicantFieldset
-      @elementId={{concat 'applicant-fieldset-' index}}
-      @applicant={{applicant}}
-      @removeApplicant={{fn this.removeApplicant}}
-      data-test-applicant-fieldset={{index}}
-      data-test-applicant-type={{applicant.friendlyEntityName}}
-    />
-  {{/each}}
+  <ul class="no-bullet">
+    {{#each this.displayApplicants as |applicant index|}}
+      <li {{animate-with 'scale-fade-in' 'scale-fade-in-active'}}>
+        <Packages::ApplicantFieldset
+          @elementId={{concat 'applicant-fieldset-' index}}
+          @applicant={{applicant}}
+          @removeApplicant={{fn this.removeApplicant}}
+          data-test-applicant-fieldset={{index}}
+          data-test-applicant-type={{applicant.friendlyEntityName}}
+        />
+      </li>
+    {{/each}}
+  </ul>
 
   {{!-- buttons for user to add new applicants --}}
   <div class="fieldset-adder">

--- a/client/app/components/packages/attachments.hbs
+++ b/client/app/components/packages/attachments.hbs
@@ -9,103 +9,103 @@
 
       <ul class="no-bullet">
         {{#each @fileManager.existingFiles as |file idx|}}
-          <li
-          class="text-justify"
-          >
-          <div class="grid-x">
-            <div class="cell small-8">
-              <a
-                href={{concat (get-env-variable 'host') '/documents' file.serverRelativeUrl}}
-                target="_blank"
-                rel="noopener noreferrer"
-                data-test-document-name={{idx}}
-              >
-                {{file.name}}
-              </a>
+          <li {{animate-with 'slide-in-bottom' 'slide-in-bottom-active'}}>
+            <div class="grid-x">
+              <div class="cell auto">
+                <a
+                  href={{concat (get-env-variable 'host') '/documents' file.serverRelativeUrl}}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  data-test-document-name={{idx}}
+                >
+                  {{file.name}}
+                </a>
+              </div>
+              <div class="cell shrink medium-padding-left">
+                <small>
+                  {{file.timeCreated}}
+                </small>
+              </div>
+              <div class="cell shrink medium-padding-left">
+                <button
+                  type="button"
+                  class="text-red-dark"
+                  {{on "click" (fn this.markFileForDeletion file)}}
+                  data-test-delete-file-button={{idx}}
+                >
+                  <FaIcon @icon="times" @prefix="fas" @fixedWidth={{true}} />
+                </button>
+              </div>
             </div>
-            <div class="cell small-3 text-right">
-              <small>
-                {{file.timeCreated}}
-              </small>
-            </div>
-            <div class="cell small-1 text-right">
-              <button
-                type="button"
-                {{on "click" (fn this.markFileForDeletion file)}}
-                data-test-delete-file-button={{idx}}
-              >
-                <FaIcon @icon="times" @prefix="fas" class="text-red" />
-              </button>
-            </div>
-          </div>
           </li>
         {{/each}}
       </ul>
       <hr>
+      {{#if (or @fileManager.filesToDelete @fileManager.filesToUpload.files)}}
+        <h6 class="medium-margin-bottom" {{animate-with 'slide-in-top' 'slide-in-top-active'}}>
+          To be
+          {{if @fileManager.filesToUpload.files 'uploaded'}}
+          {{if (and @fileManager.filesToDelete @fileManager.filesToUpload.files) '/'}}
+          {{if @fileManager.filesToDelete 'deleted'}}
+          when you save the project:
+        </h6>
+      {{/if}}
       <ul class="no-bullet">
         {{#each @fileManager.filesToDelete as |file idx|}}
-          <li
-            class="text-justify"
-          >
-          <div class="grid-x">
-            <div class="cell small-8">
-              <b
-                data-test-document-to-be-deleted-name={{idx}}
-              >
-                {{file.name}}
-              </b>
+          <li {{animate-with 'slide-in-top' 'slide-in-top-active'}}>
+            <div class="grid-x">
+              <div class="cell auto">
+                <b
+                  data-test-document-to-be-deleted-name={{idx}}
+                >
+                  {{file.name}}
+                </b>
+              </div>
+              <div class="cell shrink medium-padding-left">
+                <small>
+                  TO BE DELETED
+                </small>
+              </div>
+              <div class="cell shrink medium-padding-left">
+                <button
+                  type="button"
+                  {{on "click" (fn this.unmarkFileForDeletion file)}}
+                  data-test-undo-delete-file-button={{idx}}
+                >
+                  <FaIcon @icon="undo" @prefix="fas" @fixedWidth={{true}} />
+                </button>
+              </div>
             </div>
-            <div class="cell small-3 text-right">
-              <small>
-                TO BE DELETED
-              </small>
-            </div>
-            <div class="cell small-1 text-right">
-              <button
-                type="button"
-                {{on "click" (fn this.unmarkFileForDeletion file)}}
-                data-test-undo-delete-file-button={{idx}}
-              >
-                <FaIcon @icon="undo" @prefix="fas" />
-              </button>
-            </div>
-          </div>
           </li>
         {{/each}}
       </ul>
       <ul class="no-bullet">
         {{#each @fileManager.filesToUpload.files as |file idx|}}
-          <li
-            class="text-justify"
-          >
-          <div class="grid-x">
-            <div class="cell auto">
-              <b
-                data-test-document-to-be-uploaded-name={{idx}}
-              >
-                {{file.name}}
-              </b>
+          <li {{animate-with 'slide-in-top' 'slide-in-top-active'}}>
+            <div class="grid-x">
+              <div class="cell auto">
+                <b
+                  data-test-document-to-be-uploaded-name={{idx}}
+                >
+                  {{file.name}}
+                </b>
+              </div>
+              <div class="cell shrink medium-padding-left">
+                <small>
+                  TO BE ADDED
+                </small>
+              </div>
+              <div class="cell shrink medium-padding-left">
+                <button
+                  type="button"
+                  class="text-red-dark"
+                  {{on "click" (fn this.deselectFileForUpload file)}}
+                  data-test-deselect-file-button={{idx}}
+                >
+                  <FaIcon @icon="times" @prefix="fas" @fixedWidth={{true}} />
+                </button>
+              </div>
             </div>
-            <div class="cell shrink">
-              <small>
-                TO BE ADDED
-              </small>
-            </div>
-            <div class="cell shrink">
-              <button
-                type="button"
-                class="text-red-dark"
-                {{on "click" (fn this.deselectFileForUpload file)}}
-                data-test-deselect-file-button={{idx}}
-              >
-                <FaIcon
-                  @icon="times"
-                  @prefix="fas"
-                  @fixedWidth={{true}}
-                />
-              </button>
-            </div>
-          </div>
           </li>
         {{/each}}
       </ul>

--- a/client/app/components/project-geography.hbs
+++ b/client/app/components/project-geography.hbs
@@ -15,12 +15,13 @@
 </div>
 
 {{#if @bbls}}
-  <br>
-  <h5>Tax Lots Included in This Project</h5>
+  <h5 {{animate-with 'slide-in-top' 'slide-in-top-active'}}>
+    Tax Lots Included in This Project
+  </h5>
 {{/if}}
 
 {{#each @bbls as |bbl|}}
-  <fieldset class="fieldset relative">
+  <fieldset class="fieldset relative" {{animate-with 'scale-fade-in' 'scale-fade-in-active'}}>
     <legend data-test-bbl-title="{{bbl.dcpBblnumber}}">
       <strong>{{bbl.dcpBblnumber}}</strong>
       {{#if bbl.temporaryAddressLabel}}

--- a/client/app/modifiers/animate-with.js
+++ b/client/app/modifiers/animate-with.js
@@ -1,0 +1,10 @@
+import { modifier } from 'ember-modifier';
+
+// progressively add classes with a given duration
+export default modifier(function animateWith(element, [from, to, duration = 10]) {
+  element.classList.add(from);
+
+  setTimeout(() => {
+    element.classList.add(to);
+  }, duration);
+});

--- a/client/app/styles/app.scss
+++ b/client/app/styles/app.scss
@@ -39,6 +39,7 @@ $small-font-size: 81.25%; // TODO: update Style Guide so that <small> matches .t
 @import 'modules/_reveal-modal';
 @import 'modules/_geosearch';
 @import 'modules/_pasform';
+@import 'modules/_transitions';
 
 @import "ember-power-select";
 @import 'modules/_powerselect-overrides';

--- a/client/app/styles/modules/_transitions.scss
+++ b/client/app/styles/modules/_transitions.scss
@@ -1,0 +1,34 @@
+/* Module: Transitions */
+
+// Scale and fade in
+.scale-fade-in {
+  opacity: 0;
+  transform: scale(1.25);
+}
+.scale-fade-in.scale-fade-in-active {
+  opacity: 1;
+  transform: scale(1);
+  transition: all 0.3s ease-in;
+}
+
+// Slide in from the top
+.slide-in-top {
+  opacity: 0;
+  transform: translateY(-100%);
+}
+.slide-in-top.slide-in-top-active {
+  opacity: 1;
+  transform: translateY(0);
+  transition: all 0.3s ease-in;
+}
+
+// Slide in from the bottom
+.slide-in-bottom {
+  opacity: 0;
+  transform: translateY(100%);
+}
+.slide-in-bottom.slide-in-bottom-active {
+  opacity: 1;
+  transform: translateY(0);
+  transition: all 0.3s ease-in;
+}

--- a/client/package.json
+++ b/client/package.json
@@ -53,6 +53,7 @@
     "ember-file-upload": "^3.0.3",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-modifier": "^1.0.3",
     "ember-power-select": "^4.0.0",
     "ember-qunit": "^4.6.0",
     "ember-radio-button": "^2.0.1",

--- a/client/tests/integration/modifiers/animate-with-test.js
+++ b/client/tests/integration/modifiers/animate-with-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Modifier | animate-with', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // Replace this with your real tests.
+  test('it renders', async function(assert) {
+    await render(hbs`
+      <div data-test="animated" {{animate-with 'initial-class' 'secondary'}}></div>
+    `);
+
+    assert.dom('[data-test="animated"]').matchesSelector('.initial-class');
+  });
+});

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -5862,7 +5862,7 @@ ember-maybe-in-element@^0.4.0:
   dependencies:
     ember-cli-babel "^7.1.0"
 
-ember-modifier-manager-polyfill@^1.1.0:
+ember-modifier-manager-polyfill@^1.1.0, ember-modifier-manager-polyfill@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz#cf4444e11a42ac84f5c8badd85e635df57565dda"
   integrity sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==
@@ -5870,6 +5870,17 @@ ember-modifier-manager-polyfill@^1.1.0:
     ember-cli-babel "^7.10.0"
     ember-cli-version-checker "^2.1.2"
     ember-compatibility-helpers "^1.2.0"
+
+ember-modifier@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ember-modifier/-/ember-modifier-1.0.3.tgz#ab18250666aad17c0d9170feb178e954148eb4ed"
+  integrity sha512-vWuFyvdkULUyasvEXxe5lcfuPZV/Uqe+b0IQ1yU+TY1RSJnFdVUu/CVHT8Bu4HUJInqzAihwPMTwty7fypzi5Q==
+  dependencies:
+    ember-cli-babel "^7.11.1"
+    ember-cli-is-package-missing "^1.0.0"
+    ember-cli-normalize-entity-name "^1.0.0"
+    ember-cli-string-utils "^1.1.0"
+    ember-modifier-manager-polyfill "^1.2.0"
 
 ember-power-select@^2.0.4:
   version "2.3.5"


### PR DESCRIPTION
This PR adds CSS-only animations that make it clear to the user that an element has been inserted into the DOM — specifically, adding Team Members, BBLs, Land Use Actions, and Attachments. 

![2020-05-22 15 23 08](https://user-images.githubusercontent.com/409279/82702640-608e4d00-9c40-11ea-9585-dc0b4581d4b1.gif)

![2020-05-22 15 25 18](https://user-images.githubusercontent.com/409279/82702823-bd8a0300-9c40-11ea-9a43-43f9cbbe07b8.gif)

![2020-05-22 15 26 00](https://user-images.githubusercontent.com/409279/82702826-be229980-9c40-11ea-94ed-35094e1f4681.gif)

![2020-05-22 15 26 53](https://user-images.githubusercontent.com/409279/82702828-bebb3000-9c40-11ea-9c15-577c201a3f75.gif)
