### PR TITLE
Encode and escape Sharepoint folder paths

### DIFF
--- a/server/src/crm/crm.service.ts
+++ b/server/src/crm/crm.service.ts
@@ -434,8 +434,12 @@ export class CrmService {
   async getSharepointFolderFiles(folderIdentifier): Promise<any> {
     const { access_token } = await this.generateSharePointAccessToken();
     const SHAREPOINT_CRM_SITE = this.config.get('SHAREPOINT_CRM_SITE');
-    const url = `https://nyco365.sharepoint.com/sites/${SHAREPOINT_CRM_SITE}/_api/web/GetFolderByServerRelativeUrl('/sites/${SHAREPOINT_CRM_SITE}/${folderIdentifier}')/Files`;
-  
+
+    // Escape apostrophes by duplicating any apostrophes.
+    // See https://sharepoint.stackexchange.com/a/165224
+    const formattedFolderIdentifier = folderIdentifier.replace("'", "''");
+    const url = encodeURI(`https://nyco365.sharepoint.com/sites/${SHAREPOINT_CRM_SITE}/_api/web/GetFolderByServerRelativeUrl('/sites/${SHAREPOINT_CRM_SITE}/${formattedFolderIdentifier}')/Files`);
+    
     const options = {
       url,
       headers: {


### PR DESCRIPTION
The Sharepoint REST API requires special formatting of
any folder paths passed as arguments. Here we escape
apostrophes in the folder path. Otherwise, Packages
with apostrophes in their name causes an error upon
requesting their associated documents.