### PR TITLE
290: assure that uploaded files show up in existing files list after save

### DIFF
--- a/client/app/components/packages/pas-form-error.hbs
+++ b/client/app/components/packages/pas-form-error.hbs
@@ -1,4 +1,4 @@
-{{#if @pasForm.adapterError}}
+{{#if (or @package.pasForm.adapterError @package.adapterError)}}
   <div class="callout alert" data-test-error-saving>
     <h5 class="text-red-dark">
       <FaIcon
@@ -8,8 +8,11 @@
       />
         There was a problem saving your information.
     </h5>
-      {{#each @pasForm.adapterError.errors as |error|}}
-        <p class="font-mono text-red-dark bg-red-white small-padding text-small" data-test-error-message>{{error.details}}</p>
+      {{#each @package.pasForm.adapterError.errors as |error|}}
+        <p class="font-mono text-red-dark bg-red-white small-padding text-small" data-test-error-message>{{error.detail}}</p>
+      {{/each}}
+      {{#each @package.adapterError.errors as |error|}}
+        <p class="font-mono text-red-dark bg-red-white small-padding text-small" data-test-error-message>{{error.detail}}</p>
       {{/each}}
       <p class="text-red-dark text-small">
         Please try again. If the problem persists, please contact City Planning at <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or <a href="tel:212-720-3300" class="nowrap">212-720-3300</a>.

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -860,7 +860,7 @@
           data-test-save-button
         />
         {{!-- Error Handling --}}
-        <Packages::PasFormError @pasForm={{this.pasForm}} />
+        <Packages::PasFormError @package={{@package}} />
         <saveable-form.submitButton
           @onClick={{this.toggleModal}}
           @isEnabled={{saveable-form.submittableChanges.isValid}}
@@ -895,7 +895,7 @@
                 </div>
               </div>
               {{!-- Error Handling --}}
-              <Packages::PasFormError @pasForm={{this.pasForm}}/>
+              <Packages::PasFormError @package={{@package}}/>
             </RevealModal>
           </EmberWormhole>
         {{/if}}

--- a/client/app/components/packages/pas-form/edit.js
+++ b/client/app/components/packages/pas-form/edit.js
@@ -30,7 +30,14 @@ export default class PasFormComponent extends Component {
 
   @action
   async savePackage() {
-    await this.args.package.save();
+    try {
+      await this.args.package.save();
+      await this.args.package.reload();
+    } catch (error) {
+      console.log('Save package error:', error);
+    }
+
+    this.args.package.refreshExistingDocuments();
   }
 
   @action

--- a/client/app/models/package.js
+++ b/client/app/models/package.js
@@ -87,6 +87,10 @@ export default class PackageModel extends Model {
     );
   }
 
+  refreshExistingDocuments() {
+    this.fileManager.existingFiles = this.documents;
+  }
+
   @service
   fileQueue;
 

--- a/client/app/services/file-manager.js
+++ b/client/app/services/file-manager.js
@@ -3,11 +3,6 @@ import fetch from 'fetch';
 import { tracked } from '@glimmer/tracking';
 
 // This class supports the FileManagement service
-// TODO: We need to handle rehydrating the existingFiles.
-// After the app calls fileManager.save(), the Package
-// model should have new associated documents.
-// We need to re-request the package with associated documents
-// and rehydrate existingFiles.
 export default class FileManager {
   constructor(
     packageId,
@@ -20,6 +15,8 @@ export default class FileManager {
     this.filesToDelete = filesToDelete || [];
     this.filesToUpload = filesToUpload; // EmberFileUpload QUEUE Object
   }
+
+  @tracked existingFiles;
 
   @tracked filesToDelete;
 


### PR DESCRIPTION
Previously, because `existingFiles` is only loaded once when the fileManager is instantiated, the `existingFiles` array was not being updated (and therefore not displaying) the recently uploaded files after the user had clicked save. They would only display when a user refreshed. This PR assures that the uploaded file objects are pushed to the `existingFiles` array so that they show in the UI. 

<img width="891" alt="Screen Shot 2020-05-29 at 12 49 38 AM" src="https://user-images.githubusercontent.com/26672885/83225876-555a8600-a146-11ea-8e07-b1485041b1ee.png">

`pas-form-error` component was also updated to account for package errors, since `documents` exist as an attribute on the package model rather than the PAS Form model.

Closes #290 