### PR TITLE
311 Use revision sharepoint folder for documents

### DIFF
--- a/server/src/document/document.controller.ts
+++ b/server/src/document/document.controller.ts
@@ -54,7 +54,16 @@ export class DocumentController {
 
     const { records: [ { dcp_name: packageName }]} = packageRecord;
 
-    const folderName = `${packageName}_${instanceId.replace(/\-/g,'').toUpperCase()}`;
+    // Here, we make sure the packageName matches the format used by Sharepoint
+    // document folders that hold documents from previous revisions.
+    const strippedPackageName = packageName.replace(/-/g, '').replace(/\s+/g, '').replace(/'+/g,'');
+
+    // We upload documents to the Sharepoint folder that holds documents from
+    // previous revisions. This way, the revision folder holds both documents
+    // from current and past revisions. When retrieving documents, we can then
+    // only look up this one folder, instead of two separate folders (one for
+    // previous revision documents and one for current revision documents).
+    const folderName = `${strippedPackageName}_${instanceId.toUpperCase()}`;
 
     return this.documentService.uploadDocument('dcp_package',
       instanceId,

--- a/server/src/packages/packages.service.ts
+++ b/server/src/packages/packages.service.ts
@@ -89,9 +89,14 @@ export class PackagesService {
     return this.crmService.update('dcp_packages', id, allowedAttrs);
   }
 
+  // We retrieve documents from the Sharepoint folder (`folderIdentifier` in the
+  // code below) that holds both documents from past revisions and the current
+  // revision. CRM automatically carries over documents from past revisions into
+  // this folder, and we deliberately upload documents for the latest/current
+  // revision into this folder.
   async findPackageSharepointDocuments(packageName, id:string) {
-    const cleanedId = id.toUpperCase().replace(/-/g, '');
-    const folderIdentifier = `${packageName}_${cleanedId}`;
+    const strippedPackageName = packageName.replace(/-/g, '').replace(/\s+/g, '').replace(/'+/g,'');
+    const folderIdentifier = `${strippedPackageName}_${id.toUpperCase()}`;
 
     return this.crmService.getSharepointFolderFiles(`dcp_package/${folderIdentifier}`);
   }


### PR DESCRIPTION
This commit updates the document upload and retrieval
sections of the backend (document controller and package
service, respectively) to reference Sharepoint document
folders created automatically by the package revision loop.
Those folders use a slightly different naming convention than
the default folders used previously.

Package Revision folders:
```
<formatted package name>_<unformatted package id>
```

Previous/default Package folders:
```
<unformatted package name>_<formatted package id>
```

As long as the client+server uploads and retrieves documents to
packages starting from the very first revision,
any given package revision folder will hold all documents uploaded
to the revision itself and all previous revisions. This is because
CRM automatically carries over documents from previous revisions
into the folder for the latest revision.
_____

I've done manual testing on this for both packages already with multiple revisions, and packages on the very first revision. 