### PR TITLE
339 list street addresses on pas form show page

### DIFF
--- a/client/app/components/packages/pas-form/show.hbs
+++ b/client/app/components/packages/pas-form/show.hbs
@@ -49,7 +49,9 @@
         <span id="project-geography" class="section-anchor"></span>
         Project Geography
       </h2>
-
+      <h3>
+        BBLs
+      </h3>
       <ul class="no-bullet">
         {{#each @package.pasForm.bbls as |bbl|}}
           <li class="ruled-adjacent tight">
@@ -62,6 +64,18 @@
             {{#if bbl.dcpPartiallot}}
               <span class="text-silver">|</span> partial lot
             {{/if}}
+          </li>
+        {{/each}}
+      </ul>
+      <h3>
+        Addresses
+      </h3>
+      <ul class="no-bullet">
+        {{#each @package.pasForm.projectAddresses as |address|}}
+          <li class="ruled-adjacent tight">
+            <strong>
+              {{address.dcpConcatenatedaddressvalidated}}
+            </strong>
           </li>
         {{/each}}
       </ul>

--- a/client/app/components/packages/pas-form/show.hbs
+++ b/client/app/components/packages/pas-form/show.hbs
@@ -71,8 +71,11 @@
         Addresses
       </h3>
       <ul class="no-bullet">
-        {{#each @package.pasForm.projectAddresses as |address|}}
-          <li class="ruled-adjacent tight">
+        {{#each @package.pasForm.projectAddresses as |address idx|}}
+          <li
+            class="ruled-adjacent tight"
+            data-test-projectAddress={{idx}}
+          >
             <strong>
               {{address.dcpConcatenatedaddressvalidated}}
             </strong>

--- a/client/app/models/pas-form.js
+++ b/client/app/models/pas-form.js
@@ -10,6 +10,8 @@ export default class PasFormModel extends Model {
   @hasMany({ async: false })
   bbls;
 
+  @hasMany('project-address', { async: false })
+  projectAddresses;
 
   @attr('string') dcpApplicantnamecompanyorganization;
 

--- a/client/app/models/project-address.js
+++ b/client/app/models/project-address.js
@@ -1,0 +1,72 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class ProjectAddressModel extends Model {
+  @belongsTo('pas-form')
+  pasForm;
+
+  @attr('string') dcpValidatedpostalcode;
+
+  @attr('date') modifiedon;
+
+  @attr('string') dcpDmsourceid;
+
+  @attr('string') dcpName;
+
+  @attr('number') dcpValidatedxcoordinate;
+
+  @attr('date') overriddencreatedon;
+
+  @attr('number') dcpValidatedccd;
+
+  @attr('date') createdon;
+
+  @attr('number') dcpUserinputborough;
+
+  @attr('boolean') dcpAddressvalidated;
+
+  @attr('string') dcpUserinputaddressnumber;
+
+  @attr('string') dcpValidatedstreet;
+
+  @attr('string') dcpResponsewarning;
+
+  @attr('string') dcpUserinputunit;
+
+  @attr('number') versionnumber;
+
+  @attr('date') dcpMigratedlastupdateddate;
+
+  @attr('number') statuscode;
+
+  @attr('number') dcpValidatedycoordinate;
+
+  @attr('number') dcpValidatedborough;
+
+  @attr('string') dcpResponseerror;
+
+  @attr('number') dcpValidatedcd;
+
+  @attr('number') timezoneruleversionnumber;
+
+  @attr('string') dcpValidatedzm;
+
+  @attr('string') dcpValidatedaddressnumber;
+
+  @attr('number') importsequencenumber;
+
+  @attr('string') dcpDcpValidatedbintext;
+
+  @attr('number') utcconversiontimezonecode;
+
+  @attr('string') dcpUserinputstreet;
+
+  @attr('string') dcpValidatedstreetcode;
+
+  @attr('string') dcpConcatenatedaddressvalidated;
+
+  @attr('boolean') dcpValidatedaddressoverride;
+
+  @attr('date') dcpAddressvalidateddate;
+
+  @attr('number') statecode;
+}

--- a/client/app/routes/packages.js
+++ b/client/app/routes/packages.js
@@ -7,7 +7,7 @@ export default class PackagesRoute extends Route.extend(AuthenticatedRouteMixin)
   async model(params) {
     const projectPackage = await this.store.findRecord('package', params.id, {
       reload: true,
-      include: 'pas-form.bbls,project',
+      include: 'pas-form.bbls,pas-form.project-addresses,project',
     });
 
     // manually generate a file factory

--- a/client/tests/integration/components/packages/pas-form/show-test.js
+++ b/client/tests/integration/components/packages/pas-form/show-test.js
@@ -6,6 +6,25 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Component | packages/pas-form/show', function(hooks) {
   setupRenderingTest(hooks);
 
+  test('Displays Project Addresses', async function(assert) {
+    this.set('packagePasForm', {
+      pasForm: {
+        projectAddresses: [
+          {
+            dcpConcatenatedaddressvalidated: '77 Frederick Douglas',
+          },
+          {
+            dcpConcatenatedaddressvalidated: '3 Adam Clayton Powell Jr.',
+          },
+        ],
+      },
+    });
+
+    await render(hbs`<Packages::PasForm::Show @package={{this.packagePasForm}} />`);
+
+    assert.dom('[data-test-projectAddress="0"]').hasText('77 Frederick Douglas');
+  });
+
   test('Displays all proposed development types', async function(assert) {
     this.set('packageHasAllTypes', {
       pasForm: {

--- a/server/src/packages/packages.controller.ts
+++ b/server/src/packages/packages.controller.ts
@@ -17,6 +17,43 @@ export const PACKAGE_ATTRS = [
   'dcp_packageversion',
 ];
 
+export const PASFORM_PROJECTADDRESS_ATTRS = [
+  'dcp_validatedpostalcode',
+  'dcp_projectaddressid',
+  'modifiedon',
+  'dcp_dmsourceid',
+  'dcp_name',
+  'dcp_validatedxcoordinate',
+  'overriddencreatedon',
+  'dcp_validatedccd',
+  'createdon',
+  'dcp_userinputborough',
+  'dcp_addressvalidated',
+  'dcp_userinputaddressnumber',
+  'dcp_validatedstreet',
+  'dcp_responsewarning',
+  'dcp_userinputunit',
+  'versionnumber',
+  'dcp_migratedlastupdateddate',
+  'statuscode',
+  'dcp_validatedycoordinate',
+  'dcp_validatedborough',
+  'dcp_responseerror',
+  'dcp_validatedcd',
+  'timezoneruleversionnumber',
+  'dcp_validatedzm',
+  'dcp_validatedaddressnumber',
+  'importsequencenumber',
+  'dcp_dcp_validatedbintext',
+  'utcconversiontimezonecode',
+  'dcp_userinputstreet',
+  'dcp_validatedstreetcode',
+  'dcp_concatenatedaddressvalidated',
+  'dcp_validatedaddressoverride',
+  'dcp_addressvalidateddate',
+  'statecode',
+]
+
 @UseInterceptors(new JsonApiSerializeInterceptor('packages', {
   id: 'dcp_packageid',
   attributes: [
@@ -44,7 +81,14 @@ export const PACKAGE_ATTRS = [
       // associations/relationships/navigation links/extensions
       'applicants',
       'bbls',
+      'project-addresses',
     ],
+    'project-addresses': {
+      ref: 'dcp_projectaddressid',
+      attributes: [
+        ...PASFORM_PROJECTADDRESS_ATTRS,
+      ],
+    },
     applicants: {
       ref: 'dcp_applicantinformationid',
       attributes: [
@@ -76,6 +120,7 @@ export const PACKAGE_ATTRS = [
         ...projectPackage,
         'pas-form': {
           ...pasForm,
+          'project-addresses': pasForm.dcp_dcp_projectaddress_dcp_pasform,
           applicants: [
             ...pasForm.dcp_dcp_applicantinformation_dcp_pasform,
             ...pasForm.dcp_dcp_applicantrepinformation_dcp_pasform.map((applicant) => {

--- a/server/src/packages/packages.service.ts
+++ b/server/src/packages/packages.service.ts
@@ -48,7 +48,8 @@ export class PackagesService {
         dcp_dcp_applicantinformation_dcp_pasform,
         dcp_dcp_applicantrepinformation_dcp_pasform,
         dcp_package,
-        dcp_dcp_projectbbl_dcp_pasform($filter=statecode eq 0)
+        dcp_dcp_projectbbl_dcp_pasform($filter=statecode eq 0),
+        dcp_dcp_projectaddress_dcp_pasform
     `);
 
     // drive-by redefine because the sharepoint lookup


### PR DESCRIPTION
This PR sideloads the Project Address entity along with Pas Forms, and lists
Project Addresses on the Pas Form "Show" page.

Details: 
BBL addresses are created automatically by CRM each time
a BBL is added. They are stored on a separate entity called Project Address.
Project Address has a many to one relationship to Pas Form. We
create this relationship on the Pas Form model to Project
Address and load this property from the backend.

On the show Pas Form page, we list each validated address
separetely from the BBLs list.

![image](https://user-images.githubusercontent.com/3311663/83687559-ec499700-a5b9-11ea-9528-6c38f81267d0.png)
