### PR TITLE
Ac breadcrumbs

### DIFF
--- a/client/app/components/breadcrumbs-item.hbs
+++ b/client/app/components/breadcrumbs-item.hbs
@@ -1,0 +1,12 @@
+<li class="{{if @disabled 'disabled'}}">
+  {{#if @current}}
+    <span class="show-for-sr">Current:</span>
+  {{/if}}
+  {{#if @route}}
+    <LinkTo @route={{@route}}>
+      {{@text}}
+    </LinkTo>
+  {{else}}
+    {{@text}}
+  {{/if}}
+</li>

--- a/client/app/components/breadcrumbs.hbs
+++ b/client/app/components/breadcrumbs.hbs
@@ -1,5 +1,9 @@
-<nav aria-label="You are here:" role="navigation">
-  <ul class="breadcrumbs">
+<nav
+  aria-label="You are here:"
+  role="navigation"
+  data-test-breadcrumb-nav
+>
+  <ul class="breadcrumbs" data-test-breadcrumb-list>
     {{yield (component "breadcrumbs-item")}}
   </ul>
 </nav>

--- a/client/app/components/breadcrumbs.hbs
+++ b/client/app/components/breadcrumbs.hbs
@@ -1,23 +1,6 @@
-{{!-- TODO: Make this hardcoded breadcrumb trail dynamic--}}
-
 <nav aria-label="You are here:" role="navigation">
   <ul class="breadcrumbs">
-    <li>
-      <LinkTo @route='projects'>My Projects</LinkTo>
-    </li>
-    <li class="disabled">
-      {{@package.project.dcpProjectname}}
-    </li>
-    <li class="disabled">
-      {{#if (eq @package.dcpPackagetype '717170000')}}
-        Pre-Application Statement
-      {{/if}}
-      {{#if (eq @package.dcpPackagetype '717170004')}}
-        Reasonable Worst Case Development Scenario
-      {{/if}}
-    </li>
-    <li>
-      <span class="show-for-sr">Current: </span> {{this.router.currentRoute.localName}}
-    </li>
+    {{yield (component "breadcrumbs-item")}}
   </ul>
 </nav>
+<hr class="large-margin-bottom">

--- a/client/app/components/breadcrumbs.js
+++ b/client/app/components/breadcrumbs.js
@@ -1,7 +1,0 @@
-import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
-
-export default class BreadcrumbsComponent extends Component {
-  @service
-  router;
-}

--- a/client/app/templates/pas-form.hbs
+++ b/client/app/templates/pas-form.hbs
@@ -1,5 +1,1 @@
-<Breadcrumbs @package={{this.model}} />
-
-<hr class="large-margin-bottom">
-
 {{outlet}}

--- a/client/app/templates/pas-form/edit.hbs
+++ b/client/app/templates/pas-form/edit.hbs
@@ -1,3 +1,10 @@
+<Breadcrumbs as |crumb|>
+  <crumb @text="My Projects" @route='projects' />
+  <crumb @text={{model.project.dcpProjectname}} @disabled={{true}} />
+  <crumb @text="PAS" @disabled={{true}} />
+  <crumb @text="Edit" @current={{true}} />
+</Breadcrumbs>
+
 <Packages::PasForm::Edit
   @package={{@model}}
 />

--- a/client/app/templates/pas-form/edit.hbs
+++ b/client/app/templates/pas-form/edit.hbs
@@ -1,8 +1,8 @@
-<Breadcrumbs as |crumb|>
-  <crumb @text="My Projects" @route='projects' />
-  <crumb @text={{model.project.dcpProjectname}} @disabled={{true}} />
-  <crumb @text="PAS" @disabled={{true}} />
-  <crumb @text="Edit" @current={{true}} />
+<Breadcrumbs as |Crumb|>
+  <Crumb @text="My Projects" @route='projects' />
+  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb @text="PAS" @disabled={{true}} />
+  <Crumb @text="Edit" @current={{true}} />
 </Breadcrumbs>
 
 <Packages::PasForm::Edit

--- a/client/app/templates/pas-form/loading.hbs
+++ b/client/app/templates/pas-form/loading.hbs
@@ -1,8 +1,8 @@
-<Breadcrumbs as |crumb|>
-  <crumb @text="My Projects" @route='projects' />
-  <crumb @text="..." @disabled={{true}} />
-  <crumb @text="..." @disabled={{true}} />
-  <crumb @text="..." @disabled={{true}} />
+<Breadcrumbs as |Crumb|>
+  <Crumb @text="My Projects" @route='projects' />
+  <Crumb @text="..." @disabled={{true}} />
+  <Crumb @text="..." @disabled={{true}} />
+  <Crumb @text="..." @disabled={{true}} />
 </Breadcrumbs>
 
 <div class="text-center xlarge-padding-top xlarge-padding-bottom xlarge-margin-top xlarge-margin-bottom">

--- a/client/app/templates/pas-form/loading.hbs
+++ b/client/app/templates/pas-form/loading.hbs
@@ -1,3 +1,10 @@
+<Breadcrumbs as |crumb|>
+  <crumb @text="My Projects" @route='projects' />
+  <crumb @text="..." @disabled={{true}} />
+  <crumb @text="..." @disabled={{true}} />
+  <crumb @text="..." @disabled={{true}} />
+</Breadcrumbs>
+
 <div class="text-center xlarge-padding-top xlarge-padding-bottom xlarge-margin-top xlarge-margin-bottom">
   <FaIcon @icon="spinner" @spin={{true}} @pulse={{true}} @size="6x" class="text-silver" />
 </div>

--- a/client/app/templates/pas-form/show.hbs
+++ b/client/app/templates/pas-form/show.hbs
@@ -1,3 +1,9 @@
+<Breadcrumbs as |crumb|>
+  <crumb @text="My Projects" @route='projects' />
+  <crumb @text={{model.project.dcpProjectname}} @disabled={{true}} />
+  <crumb @text="PAS" @current={{true}} />
+</Breadcrumbs>
+
 <Packages::PasForm::Show @package={{@model}} />
 
 {{outlet}}

--- a/client/app/templates/pas-form/show.hbs
+++ b/client/app/templates/pas-form/show.hbs
@@ -1,7 +1,7 @@
-<Breadcrumbs as |crumb|>
-  <crumb @text="My Projects" @route='projects' />
-  <crumb @text={{model.project.dcpProjectname}} @disabled={{true}} />
-  <crumb @text="PAS" @current={{true}} />
+<Breadcrumbs as |Crumb|>
+  <Crumb @text="My Projects" @route='projects' />
+  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb @text="PAS" @current={{true}} />
 </Breadcrumbs>
 
 <Packages::PasForm::Show @package={{@model}} />

--- a/client/app/templates/projects-error.hbs
+++ b/client/app/templates/projects-error.hbs
@@ -1,5 +1,5 @@
-<Breadcrumbs as |crumb|>
-  <crumb @text="My Projects" @current={{true}} />
+<Breadcrumbs as |Crumb|>
+  <Crumb @text="My Projects" @current={{true}} />
 </Breadcrumbs>
 
 <div class="text-center xlarge-padding-top xlarge-padding-bottom xlarge-margin-top xlarge-margin-bottom">

--- a/client/app/templates/projects-error.hbs
+++ b/client/app/templates/projects-error.hbs
@@ -1,15 +1,6 @@
-{{!-- TODO:  Make this breadcrumb dynamic with application routing --}}
-{{!-- breadcrumb --}}
-<nav aria-label="You are here:" role="navigation">
-  <ul class="breadcrumbs">
-    <li class="text-extra-large">
-      <span class="show-for-sr">Current: </span>
-      My Projects
-    </li>
-  </ul>
-</nav>
-
-<hr />
+<Breadcrumbs as |crumb|>
+  <crumb @text="My Projects" @current={{true}} />
+</Breadcrumbs>
 
 <div class="text-center xlarge-padding-top xlarge-padding-bottom xlarge-margin-top xlarge-margin-bottom">
   <span>Hmm, something went wrong:</span>

--- a/client/app/templates/projects-loading.hbs
+++ b/client/app/templates/projects-loading.hbs
@@ -1,15 +1,6 @@
-{{!-- TODO:  Make this breadcrumb dynamic with application routing --}}
-{{!-- breadcrumb --}}
-<nav aria-label="You are here:" role="navigation">
-  <ul class="breadcrumbs">
-    <li class="text-extra-large">
-      <span class="show-for-sr">Current: </span>
-      My Projects
-    </li>
-  </ul>
-</nav>
-
-<hr />
+<Breadcrumbs as |crumb|>
+  <crumb @text="My Projects" @current={{true}} />
+</Breadcrumbs>
 
 <div class="text-center xlarge-padding-top xlarge-padding-bottom xlarge-margin-top xlarge-margin-bottom">
   <FaIcon @icon="spinner" @spin={{true}} @pulse={{true}} @size="6x" class="text-silver" />

--- a/client/app/templates/projects-loading.hbs
+++ b/client/app/templates/projects-loading.hbs
@@ -1,5 +1,5 @@
-<Breadcrumbs as |crumb|>
-  <crumb @text="My Projects" @current={{true}} />
+<Breadcrumbs as |Crumb|>
+  <Crumb @text="My Projects" @current={{true}} />
 </Breadcrumbs>
 
 <div class="text-center xlarge-padding-top xlarge-padding-bottom xlarge-margin-top xlarge-margin-bottom">

--- a/client/app/templates/projects.hbs
+++ b/client/app/templates/projects.hbs
@@ -1,15 +1,6 @@
-{{!-- TODO:  Make this breadcrumb dynamic with application routing --}}
-{{!-- breadcrumb --}}
-<nav aria-label="You are here:" role="navigation">
-  <ul class="breadcrumbs">
-    <li class="text-extra-large">
-      <span class="show-for-sr">Current: </span>
-      My Projects
-    </li>
-  </ul>
-</nav>
-
-<hr class="large-margin-bottom" />
+<Breadcrumbs as |crumb|>
+  <crumb @text="My Projects" @current={{true}} />
+</Breadcrumbs>
 
 <div class="grid-x grid-padding-x">
   <div class="cell large-8">

--- a/client/app/templates/projects.hbs
+++ b/client/app/templates/projects.hbs
@@ -1,5 +1,5 @@
-<Breadcrumbs as |crumb|>
-  <crumb @text="My Projects" @current={{true}} />
+<Breadcrumbs as |Crumb|>
+  <Crumb @text="My Projects" @current={{true}} />
 </Breadcrumbs>
 
 <div class="grid-x grid-padding-x">

--- a/client/app/templates/rwcds-form.hbs
+++ b/client/app/templates/rwcds-form.hbs
@@ -1,5 +1,1 @@
-<Breadcrumbs @package={{this.model}} />
-
-<hr class="large-margin-bottom">
-
 {{outlet}}

--- a/client/app/templates/rwcds-form/edit.hbs
+++ b/client/app/templates/rwcds-form/edit.hbs
@@ -1,8 +1,8 @@
-<Breadcrumbs as |crumb|>
-  <crumb @text="My Projects" @route='projects' />
-  <crumb @text={{model.project.dcpProjectname}} @disabled={{true}} />
-  <crumb @text="RWCDS" @disabled={{true}} />
-  <crumb @text="Edit" @current={{true}} />
+<Breadcrumbs as |Crumb|>
+  <Crumb @text="My Projects" @route='projects' />
+  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb @text="RWCDS" @disabled={{true}} />
+  <Crumb @text="Edit" @current={{true}} />
 </Breadcrumbs>
 
 <Packages::RwcdsForm::Edit

--- a/client/app/templates/rwcds-form/edit.hbs
+++ b/client/app/templates/rwcds-form/edit.hbs
@@ -1,3 +1,10 @@
+<Breadcrumbs as |crumb|>
+  <crumb @text="My Projects" @route='projects' />
+  <crumb @text={{model.project.dcpProjectname}} @disabled={{true}} />
+  <crumb @text="RWCDS" @disabled={{true}} />
+  <crumb @text="Edit" @current={{true}} />
+</Breadcrumbs>
+
 <Packages::RwcdsForm::Edit
   @package={{@model}}
 />

--- a/client/tests/integration/components/breadcrumbs-item-test.js
+++ b/client/tests/integration/components/breadcrumbs-item-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | breadcrumbs-item', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<BreadcrumbsItem />`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      <BreadcrumbsItem>
+        template block text
+      </BreadcrumbsItem>
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});

--- a/client/tests/integration/components/breadcrumbs-item-test.js
+++ b/client/tests/integration/components/breadcrumbs-item-test.js
@@ -6,21 +6,11 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Component | breadcrumbs-item', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders a breadcrumb list item', async function(assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    await render(hbs`<BreadcrumbsItem />`);
-
-    assert.equal(this.element.textContent.trim(), '');
-
-    // Template block usage:
-    await render(hbs`
-      <BreadcrumbsItem>
-        template block text
-      </BreadcrumbsItem>
-    `);
-
-    assert.equal(this.element.textContent.trim(), 'template block text');
+    await render(hbs`<BreadcrumbsItem @text="foo" />`);
+    assert.equal(this.element.textContent.trim(), 'foo');
   });
 });

--- a/client/tests/integration/components/breadcrumbs-test.js
+++ b/client/tests/integration/components/breadcrumbs-test.js
@@ -1,4 +1,4 @@
-import { module, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -6,21 +6,13 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Component | breadcrumbs', function(hooks) {
   setupRenderingTest(hooks);
 
-  skip('it renders', async function(assert) {
+  test('it renders a list in a nav', async function(assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
     await render(hbs`<Breadcrumbs />`);
 
-    assert.equal(this.element.textContent.trim(), '');
-
-    // Template block usage:
-    await render(hbs`
-      <Breadcrumbs>
-        template block text
-      </Breadcrumbs>
-    `);
-
-    assert.equal(this.element.textContent.trim(), 'template block text');
+    assert.dom('nav[data-test-breadcrumb-nav]').exists();
+    assert.dom('ul[data-test-breadcrumb-list]').exists();
   });
 });


### PR DESCRIPTION
This PR refactors the breadcrumbs so that they'll work with any routes or model. 

Previously, we had the breadcrumbs hardcoded in the projects template, and used a component that only worked for the PAS form. 

The proposed changes allow the `<Breadcrumbs />` component to be call from any template with a contextual component used for its list items. This lets us nix `breadcrumbs.js`, as we no longer rely on the router service for comparing the current route. This also adds breadcrumbs to the appropriate templates, and adds tests to make sure we render breadcrumbs correctly. 

Other methods explored (brainstormed w/ @godfreyyeung): 
- We attempted to simply pass the model to `<Breadcrumbs />` and let the component create the list items. However, this involved complex logic to dynamically show/hide parts of the breadcrumb trail and would be further complicated with each form or route that needs breadcrumbs. That logic also made assumptions about the data being passed to the component — e.g. the projects/project models will have a different schema than the packages (which also might have differing schemas). 
- Just hardcoding the breadcrumbs in each template, since they're rather simple. However, the `breadcrumbs-item.js` slims the markup significantly. 