### PR TITLE
222 Add RWCDS Project Description section

### DIFF
--- a/client/app/components/character-counter.hbs
+++ b/client/app/components/character-counter.hbs
@@ -1,10 +1,8 @@
 <div class="character-counter">
-  {{#if this.warningClass}}
-    <span
-      class="count {{this.warningClass}}"
-      data-character-counter
-    >
-      {{this.stringLength}} / {{@maxlength}}
-    </span>
-  {{/if}}
+  <span
+    class="count {{this.warningClass}}"
+    data-character-counter
+  >
+    {{this.stringLength}} / {{@maxlength}}
+  </span>
 </div>

--- a/client/app/components/packages/rwcds-form/edit.hbs
+++ b/client/app/components/packages/rwcds-form/edit.hbs
@@ -1,50 +1,55 @@
-<div class="grid-x grid-margin-x">
+<SaveableForm
+  @model={{@package.rwcdsForm}}
+  @validators={{array this.saveableRwcdsFormValidations this.submittableRwcdsFormValidations}}
+  as |saveableForm|
+>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      <section class="form-section">
+        <h1>
+          Reasonable Worst Case Development Scenario (V{{@package.dcpPackageversion}})
+        </h1>
+        <h2 class="gray">
+          {{@package.project.dcpProjectname}} ({{@package.project.dcpName}})
+        </h2>
+        <h3>
+          {{optionset 'bbl' 'boroughs' 'label' @package.project.dcpBorough}}
+        </h3>
 
-  <div class="cell large-8">
-    <section class="form-section">
-      <h1>
-        Reasonable Worst Case Development Scenario (V{{@package.dcpPackageversion}})
-      </h1>
-      <h2 class="gray">
-        {{@package.project.dcpProjectname}} ({{@package.project.dcpName}})
-      </h2>
-      <h3>
-        {{optionset 'bbl' 'boroughs' 'label' @package.project.dcpBorough}}
-      </h3>
+        <p>
+          The <strong>Reasonable Worst Case Development Scenario (RWCDS)</strong> form may be used for either site-specific or generic/area wide&nbsp;
+          actions and should only be completed once the proposed action(s) have been finalized. If there are questions, contact&nbsp;
+          the Environmental Assessment and Review Division (EARD) Project Manager.
+        </p>
+      </section>
 
-      <p>
-        The <strong>Reasonable Worst Case Development Scenario (RWCDS)</strong> form may be used for either site-specific or generic/area wide&nbsp;
-        actions and should only be completed once the proposed action(s) have been finalized. If there are questions, contact&nbsp;
-        the Environmental Assessment and Review Division (EARD) Project Manager.
-      </p>
-    </section>
-
-    <section class="form-section">
-      <h2 class="section-header">
-        <span id="project-description" class="section-anchor"></span>
-        Project Description
-      </h2>
-    </section>
-    <section class="form-section">
-      <h2 class="section-header">
-        <span id="proposed-actions" class="section-anchor"></span>
-        Proposed Actions
-      </h2>
-      <p>
-        Listed below are the actions proposed in this project:
-      </p>
-    </section>
-    <section class="form-section">
-      <h2 class="section-header">
-        <span id="analysis" class="section-anchor"></span>
-          Analysis
-      </h2>
-    </section>
-    <section class="form-section">
-      <h2 class="section-header">
-        <span id="attached-documents" class="section-anchor"></span>
-        Attached Documents
-      </h2>
-    </section>
+      <section class="form-section">
+        <h2 class="section-header">
+          <span id="project-description" class="section-anchor"></span>
+          Project Description
+        </h2>
+      </section>
+      <section class="form-section">
+        <h2 class="section-header">
+          <span id="proposed-actions" class="section-anchor"></span>
+          Proposed Actions
+        </h2>
+        <p>
+          Listed below are the actions proposed in this project:
+        </p>
+      </section>
+      <section class="form-section">
+        <h2 class="section-header">
+          <span id="analysis" class="section-anchor"></span>
+            Analysis
+        </h2>
+      </section>
+      <section class="form-section">
+        <h2 class="section-header">
+          <span id="attached-documents" class="section-anchor"></span>
+          Attached Documents
+        </h2>
+      </section>
+    </div>
   </div>
-</div>
+</SaveableForm>

--- a/client/app/components/packages/rwcds-form/edit.hbs
+++ b/client/app/components/packages/rwcds-form/edit.hbs
@@ -23,12 +23,9 @@
         </p>
       </section>
 
-      <section class="form-section">
-        <h2 class="section-header">
-          <span id="project-description" class="section-anchor"></span>
-          Project Description
-        </h2>
-      </section>
+      <Packages::RwcdsForm::ProjectDescription
+        @rwcdsForm={{saveableForm}}
+      />
       <section class="form-section">
         <h2 class="section-header">
           <span id="proposed-actions" class="section-anchor"></span>

--- a/client/app/components/packages/rwcds-form/edit.js
+++ b/client/app/components/packages/rwcds-form/edit.js
@@ -1,0 +1,9 @@
+import Component from '@glimmer/component';
+import SaveableRwcdsFormValidations from '../../../validations/saveable-rwcds-form';
+import SubmittableRwcdsFormValidations from '../../../validations/submittable-rwcds-form';
+
+export default class PackagesRwcdsFormEditComponent extends Component {
+  saveableRwcdsFormValidations = SaveableRwcdsFormValidations;
+
+  submittableRwcdsFormValidations = SubmittableRwcdsFormValidations;
+}

--- a/client/app/components/packages/rwcds-form/project-description.hbs
+++ b/client/app/components/packages/rwcds-form/project-description.hbs
@@ -1,0 +1,122 @@
+
+  <section class="form-section">
+    <h2 class="section-header">
+      <span id="project-description" class="section-anchor"></span>
+      Project Description
+    </h2>
+
+    <label>
+      <strong>
+        Has the project changed since submission of the Pre-Application Statement (PAS)?
+      </strong>
+      <br>
+        {{#each (array
+          (hash
+            code=(optionset 'rwcdsForm' 'dcpHasprojectchangedsincesubmissionofthepas' 'code' 'YES')
+            label=(optionset 'rwcdsForm' 'dcpHasprojectchangedsincesubmissionofthepas' 'label' 'YES'))
+          (hash
+            code=(optionset 'rwcdsForm' 'dcpHasprojectchangedsincesubmissionofthepas' 'code' 'NO')
+            label=(optionset 'rwcdsForm' 'dcpHasprojectchangedsincesubmissionofthepas' 'label' 'NO'))
+        ) as |radio|}}
+          <@rwcdsForm.radio
+            @value={{radio.code}}
+            @groupValue={{@rwcdsForm.saveableChanges.dcpHasprojectchangedsincesubmissionofthepas}}
+            data-test-radio="dcpHasprojectchangedsincesubmissionofthepas"
+            data-test-radio-option={{radio.label}}
+          >
+            {{radio.label}}
+          </@rwcdsForm.radio>
+        {{/each}}
+      <br>
+    </label>
+
+    <small class="help-text display-block">
+      Ensure that descriptions below account for any changes since PAS submission 
+    </small>
+
+    <label>
+      <strong>
+        Identify and describe the existing conditions of all areas affected by the proposed actions
+      </strong>
+      <TextArea
+        @property={{@rwcdsForm.saveableChanges.dcpProjectsitedescription}}
+        @propertyName="dcpProjectsitedescription"
+        @changesetError={{@rwcdsForm.submittableChanges.error.dcpProjectsitedescription}}
+        @maxlength="2400"
+      />
+    </label>
+
+    <label>
+      <strong>
+        Describe the proposed project facilitated by the proposed actions
+      </strong>
+      <TextArea
+        @property={{@rwcdsForm.saveableChanges.dcpProposedprojectdevelopmentdescription}}
+        @propertyName="dcpProposedprojectdevelopmentdescription"
+        @changesetError={{@rwcdsForm.submittableChanges.error.dcpProposedprojectdevelopmentdescription}}
+        @maxlength="1800"
+      />
+    </label>
+
+    <label>
+      <strong>
+        Will construction be done in multiple phases? 
+      </strong>
+      <br>
+        {{#each (array
+          (hash
+            code=(optionset 'rwcdsForm' 'dcpConstructionphasing' 'code' 'SINGLE')
+            label=(optionset 'rwcdsForm' 'dcpConstructionphasing' 'label' 'SINGLE'))
+          (hash
+            code=(optionset 'rwcdsForm' 'dcpConstructionphasing' 'code' 'MULTIPLE')
+            label=(optionset 'rwcdsForm' 'dcpConstructionphasing' 'label' 'MULTIPLE'))
+        ) as |radio|}}
+          <@rwcdsForm.radio
+            @value={{radio.code}}
+            @groupValue={{@rwcdsForm.saveableChanges.dcpConstructionphasing}}
+            data-test-radio="dcpConstructionphasing"
+            data-test-radio-option={{radio.label}}
+          >
+            {{radio.label}}
+          </@rwcdsForm.radio>
+        {{/each}}
+      <br>
+    </label>
+
+    <label>
+      <strong>
+        What is the proposed analysis year of the proposed action?
+      </strong>
+      <TextInput
+        @property={{@rwcdsForm.saveableChanges.dcpBuildyear}}
+        @propertyName="dcpBuildyear"
+        @changesetError={{@rwcdsForm.submittableChanges.error.dcpBuildyear}}
+        @showCounter={{true}}
+        @maxlength="4"
+      />
+    </label>
+
+    <label>
+      <strong>
+        Explain the rationale behind the analysis year
+      </strong>
+      <small class="help-text display-block">
+        Providing history allows NYC Planning to analyze potential CEQR analysis&nbsp;
+        sections/chapters, as well as development trends and previous environment&nbsp;
+        review assumptions.
+        <br>
+        Summarize any prior rezonings or discretionary City Planning Commission&nbsp;
+        approvals. Provide ULURP and CEQR Application numbers, if available.&nbsp;
+        Describe any context that is relevant to development on the site (e.g.&nbsp;
+        former uses, large scale development plans, urban renewal plans,&nbsp;
+        Mitchell Lama site plans, or other site controls, easements, restrictive&nbsp;
+        declarations, (E) designations, historic or other designations, etc.).
+      </small>
+      <TextArea
+        @property={{@rwcdsForm.saveableChanges.dcpSitehistory}}
+        @propertyName="dcpSitehistory"
+        @changesetError={{@rwcdsForm.submittableChanges.error.dcpSitehistory}}
+        @maxlength="600"
+      />
+    </label>
+  </section>

--- a/client/app/components/text-area.hbs
+++ b/client/app/components/text-area.hbs
@@ -4,7 +4,7 @@
   rows="5"
   ...attributes
 />
-{{#if (not (eq this.showCounter false))}}
+{{#if (not (eq @showCounter false))}}
   <CharacterCounter
     @string={{@property}}
     @maxlength={{this.maxlength}}

--- a/client/app/components/text-input.hbs
+++ b/client/app/components/text-input.hbs
@@ -4,7 +4,7 @@
   data-test-input={{@propertyName}}
   ...attributes
 />
-{{#if this.showCounter}}
+{{#if @showCounter}}
   <CharacterCounter
     @string={{@property}}
     @maxlength={{this.maxlength}}

--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -12,7 +12,10 @@ import {
   PACKAGE_STATUS_OPTIONSET,
   PACKAGE_VISIBILITY_OPTIONSET,
 } from '../models/package';
-
+import {
+  DCPHASPROJECTCHANGEDSINCESUBMISSIONOFTHEPAS_OPTIONSET,
+  DCPCONSTRUCTIONPHASING_OPTIONSET,
+} from '../models/rwcds-form';
 
 const OPTIONSET_LOOKUP = {
   applicant: {
@@ -25,6 +28,10 @@ const OPTIONSET_LOOKUP = {
     state: PACKAGE_STATE_OPTIONSET,
     status: PACKAGE_STATUS_OPTIONSET,
     visibility: PACKAGE_VISIBILITY_OPTIONSET,
+  },
+  rwcdsForm: {
+    dcpHasprojectchangedsincesubmissionofthepas: DCPHASPROJECTCHANGEDSINCESUBMISSIONOFTHEPAS_OPTIONSET,
+    dcpConstructionphasing: DCPCONSTRUCTIONPHASING_OPTIONSET,
   },
 };
 

--- a/client/app/models/rwcds-form.js
+++ b/client/app/models/rwcds-form.js
@@ -1,5 +1,27 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
+export const DCPHASPROJECTCHANGEDSINCESUBMISSIONOFTHEPAS_OPTIONSET = {
+  YES: {
+    code: true,
+    label: 'Yes',
+  },
+  NO: {
+    code: false,
+    label: 'No',
+  },
+};
+
+export const DCPCONSTRUCTIONPHASING_OPTIONSET = {
+  SINGLE: {
+    code: 717170000,
+    label: 'Single',
+  },
+  MULTIPLE: {
+    code: 717170001,
+    label: 'Multiple',
+  },
+};
+
 export default class RwcdsFormModel extends Model {
   @belongsTo('package', { async: false })
   package;

--- a/client/app/validations/saveable-pas-form.js
+++ b/client/app/validations/saveable-pas-form.js
@@ -3,6 +3,10 @@ import {
 } from 'ember-changeset-validations/validators';
 
 // These validate the fields for _saving_ to the server
+// REMEMBER: You still need to manually update "maxlength"
+// attributes for TextArea and TextInput components in the
+// templates (in addition to the `max` attribute in the
+// validateLength validators here).
 export default {
   dcpRevisedprojectname: [
     validateLength({

--- a/client/app/validations/saveable-rwcds-form.js
+++ b/client/app/validations/saveable-rwcds-form.js
@@ -1,0 +1,108 @@
+import {
+  validateLength,
+} from 'ember-changeset-validations/validators';
+
+// These validate the fields for _saving_ to the server
+// REMEMBER: You still need to manually update "maxlength"
+// attributes for TextArea and TextInput components in the
+// templates (in addition to the `max` attribute in the
+// validateLength validators here).
+export default {
+  dcpDescribethewithactionscenario: [
+    validateLength({
+      min: 0,
+      max: 1500,
+      message: 'Text is too long (max {max} characters)',
+    }),
+  ],
+  dcpRationalbehindthebuildyear: [
+    validateLength({
+      min: 0,
+      max: 300,
+      message: 'Text is too long (max {max} characters)',
+    }),
+  ],
+  dcpWhichactionsfromotheragenciesaresought: [
+    validateLength({
+      min: 0,
+      max: 2400,
+      message: 'Text is too long (max {max} characters)',
+    }),
+  ],
+  dcpProposedprojectdevelopmentdescription: [
+    validateLength({
+      min: 0,
+      max: 1800,
+      message: 'Text is too long (max {max} characters)',
+    }),
+  ],
+  dcpProjectsitedescription: [
+    validateLength({
+      min: 0,
+      max: 2400,
+      message: 'Text is too long (max {max} characters)',
+    }),
+  ],
+  dcpSitehistory: [
+    validateLength({
+      min: 0,
+      max: 600,
+      message: 'Text is too long (max {max} characters)',
+    }),
+  ],
+  dcpPurposeandneedfortheproposedaction: [
+    validateLength({
+      min: 0,
+      max: 1500,
+      message: 'Text is too long (max {max} characters)',
+    }),
+  ],
+  dcpDescribethenoactionscenario: [
+    validateLength({
+      min: 0,
+      max: 1500,
+      message: 'Text is too long (max {max} characters)',
+    }),
+  ],
+  dcpRwcdsexplanation: [
+    validateLength({
+      min: 0,
+      max: 50,
+      message: 'Text is too long (max {max} characters)',
+    }),
+  ],
+  dcpHowdidyoudeterminethenoactionscenario: [
+    validateLength({
+      min: 0,
+      max: 1500,
+      message: 'Text is too long (max {max} characters)',
+    }),
+  ],
+  dcpName: [
+    validateLength({
+      min: 0,
+      max: 50,
+      message: 'Text is too long (max {max} characters)',
+    }),
+  ],
+  dcpHowdidyoudeterminethiswithactionscena: [
+    validateLength({
+      min: 600,
+      message: 'Text is too long (max {max} characters)',
+    }),
+  ],
+  dcpBuildyear: [
+    validateLength({
+      min: 0,
+      max: 4,
+      message: 'Number is too long (max {max} characters)',
+    }),
+  ],
+  dcpDevelopmentsiteassumptions: [
+    validateLength({
+      min: 0,
+      max: 2400,
+      message: 'Text is too long (max {max} characters)',
+    }),
+  ],
+};

--- a/client/app/validations/submittable-rwcds-form.js
+++ b/client/app/validations/submittable-rwcds-form.js
@@ -1,0 +1,36 @@
+import {
+  validatePresence,
+} from 'ember-changeset-validations/validators';
+import SaveableRwcdsForm from './saveable-rwcds-form';
+
+export default {
+  ...SaveableRwcdsForm,
+  dcpRwcdsexplanation: [
+    ...SaveableRwcdsForm.dcpRwcdsexplanation,
+    validatePresence({
+      presence: true,
+      message: 'This field is required',
+    }),
+  ],
+  dcpWhichactionsfromotheragenciesaresought: [
+    ...SaveableRwcdsForm.dcpWhichactionsfromotheragenciesaresought,
+    validatePresence({
+      presence: true,
+      message: 'This field is required',
+    }),
+  ],
+  dcpProjectsitedescription: [
+    ...SaveableRwcdsForm.dcpProjectsitedescription,
+    validatePresence({
+      presence: true,
+      message: 'This field is required',
+    }),
+  ],
+  dcpProposedprojectdevelopmentdescription: [
+    ...SaveableRwcdsForm.dcpProposedprojectdevelopmentdescription,
+    validatePresence({
+      presence: true,
+      message: 'This field is required',
+    }),
+  ],
+};

--- a/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
@@ -1,11 +1,13 @@
 import { module, test } from 'qunit';
 import {
+  fillIn,
   visit,
   currentURL,
 } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import exceedMaximum from '../helpers/exceed-maximum-characters';
 
 module('Acceptance | user can click rwcds edit', function(hooks) {
   setupApplicationTest(hooks);
@@ -23,5 +25,25 @@ module('Acceptance | user can click rwcds edit', function(hooks) {
     await visit('/rwcds-form/1/edit');
 
     assert.equal(currentURL(), '/rwcds-form/1/edit');
+  });
+
+  test('Validation messages display for Project Description', async function(assert) {
+    this.server.create('project', 1, 'applicant');
+
+    await visit('/rwcds-form/1/edit');
+
+    assert.equal(currentURL(), '/rwcds-form/1/edit');
+
+    await fillIn('[data-test-textarea="dcpProjectsitedescription"]', exceedMaximum(2400, 'String'));
+    assert.dom('[data-test-validation-message="dcpProjectsitedescription"').hasText('Text is too long (max 2400 characters)');
+
+    await fillIn('[data-test-textarea="dcpProposedprojectdevelopmentdescription"]', exceedMaximum(1800, 'String'));
+    assert.dom('[data-test-validation-message="dcpProposedprojectdevelopmentdescription"').hasText('Text is too long (max 1800 characters)');
+
+    await fillIn('[data-test-input="dcpBuildyear"]', exceedMaximum(4, 'Number'));
+    assert.dom('[data-test-validation-message="dcpBuildyear"').hasText('Number is too long (max 4 characters)');
+
+    await fillIn('[data-test-textarea="dcpSitehistory"]', exceedMaximum(600, 'String'));
+    assert.dom('[data-test-validation-message="dcpSitehistory"').hasText('Text is too long (max 600 characters)');
   });
 });

--- a/client/tests/integration/components/character-counter-test.js
+++ b/client/tests/integration/components/character-counter-test.js
@@ -6,7 +6,7 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Component | character-counter', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('Character counter is hidden if under 80% of maxlength', async function(assert) {
+  test('Character counter always displays', async function(assert) {
     await render(hbs`
       <CharacterCounter
         @string="abcd"
@@ -14,7 +14,7 @@ module('Integration | Component | character-counter', function(hooks) {
       />
     `);
 
-    assert.dom('[data-character-counter]').doesNotExist();
+    assert.dom('[data-character-counter]').exists();
   });
 
   test('Character counter displays as invalid when over maxlength', async function(assert) {

--- a/client/tests/integration/components/packages/rwcds-form/project-description-test.js
+++ b/client/tests/integration/components/packages/rwcds-form/project-description-test.js
@@ -1,0 +1,30 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | packages/rwcds-form/project-description', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    this.set('rwcdsForm', {
+      saveableChanges: {
+        dcpProjectsitedescription: 'Mixed use',
+        dcpProposedprojectdevelopmentdescription: 'Increase equity',
+        dcpBuildyear: '1990',
+        dcpSitehistory: 'Some history',
+      },
+    });
+
+    await render(hbs`
+      <Packages::RwcdsForm::ProjectDescription
+        @rwcdsForm={{this.rwcdsForm}}
+      />
+    `);
+
+    assert.dom('[data-test-textarea="dcpProjectsitedescription"]').hasValue('Mixed use');
+    assert.dom('[data-test-textarea="dcpProposedprojectdevelopmentdescription"]').hasValue('Increase equity');
+    assert.dom('[data-test-input="dcpBuildyear"]').hasValue('1990');
+    assert.dom('[data-test-textarea="dcpSitehistory"]').hasValue('Some history');
+  });
+});


### PR DESCRIPTION
This is a two part/commit PR. It wraps the RwcdsForm::Edit component within the SaveableForm, then wires up the inputs for the Project Description section.
--- 
### Commit 1: 
In addition to wrapping the RwcdsForm::Edit component template
inside the SaveableForm component, this commit introduces
validations and changesets for ProjectDescription to start off.
The SaveableForm component requires validations in order to
automatically generate Saveaable and Submittable changesets.

### Commit 2:
- Wires up the inputs for the Project Description section
(It does not yet prefill the inputs based on a PAS Form)
- Fixes the showCounter argument on TextArea and TextInput
- Patches CharacterCounter to always display