### PR TITLE
223: create Proposed Actions component on RWCDS form

### DIFF
--- a/client/app/components/packages/proposed-actions.hbs
+++ b/client/app/components/packages/proposed-actions.hbs
@@ -1,0 +1,111 @@
+<div>
+  <h5 class="small-margin-bottom">
+    Listed below are actions proposed in this project
+  </h5>
+</div>
+{{#each @rwcdsForm.affectedZoningResolutions as |landUseAction|}}
+  <fieldset class="fieldset relative">
+    <legend>
+      <strong>
+        <span class="label">
+          {{~landUseAction.dcpZoningresolutiontype~}}
+          {{#if (lookup-action-type landUseAction.dcpZoningresolutiontype)}}
+            <LabsUi::IconTooltip
+              @tip={{lookup-action-type landUseAction.dcpZoningresolutiontype}}
+              @icon="info-circle"
+              @side="bottom"
+              @transform="shrink-4 up-2"
+              @fixedWidth={{true}}
+            />
+          {{/if}}
+        </span>
+        {{#if (in-array this.actionsWithSectionNumber landUseAction.dcpZoningresolutiontype)}}
+          {{landUseAction.dcpZrsectionnumber}}
+        {{/if}}
+        {{#if (and (eq landUseAction.dcpZoningresolutiontype 'ZR') (eq landUseAction.dcpZrsectionnumber 'Appendix F'))}}
+          {{landUseAction.dcpZrsectionnumber}}
+        {{/if}}
+      </strong>
+    </legend>
+    {{#if (in-array this.actionsWithModifiedZrSectionNumberQuestion landUseAction.dcpZoningresolutiontype)}}
+      <label class="action-form-label">
+        Which sections of the Zoning Resolution does this modify?
+        <small class="help-text display-block">
+          Provide the Zoning Resolution section number(s). Ex. ZR Sec. 42-10 and 43-17
+        </small>
+          <TextInput
+            @property={{landUseAction.dcpModifiedzrsectionnumber}}
+            @propertyName="dcpModifiedzrsectionnumber"
+            @showCounter={{false}}
+            data-test-input="{{landUseAction.dcpZoningresolutiontype}}"
+          />
+      </label>
+    {{else if (and (eq landUseAction.dcpZoningresolutiontype "ZR") (eq landUseAction.dcpZrsectionnumber "Appendix F"))}}
+      This action {{if @rwcdsForm.dcpIncludezoningtextamendment "includes" "does not include"}} MIH. If this is a mistake, please contact City Planning. 
+    {{else}}
+      <span class="help-text">No additional information required for this action</span>
+    {{/if}}
+
+  </fieldset>
+{{/each}}
+<label>
+  <strong>Describe the purpose and need for all the proposed actions.</strong>
+  <TextArea
+    @property={{@rwcdsForm.dcpPurposeandneedfortheproposedaction}}
+    @propertyName="dcpPurposeandneedfortheproposedaction"
+    data-test-input="dcpPurposeandneedfortheproposedaction"
+
+  />
+</label>
+<legend>
+  <strong>Does the applicant plan to develop a 100% affordable housing development?</strong>
+</legend>
+{{#each (array
+  (hash code=true label='Yes')
+  (hash code=false label='No')) as |radio|
+}}
+  <RadioButton
+    @value={{radio.code}}
+    @groupValue={{@rwcdsForm.dcpIsplannigondevelopingaffordablehousing}}
+    data-test-radio="dcpIsplannigondevelopingaffordablehousing"
+    data-test-radio-option={{radio.label}}
+  >
+    {{radio.label}}
+</RadioButton>
+{{/each}}
+<legend>
+  <strong>Is the applicant seeking action from other City/State/Federal agencies?</strong>
+</legend>
+<small class="help-text display-block">
+  Note that financing for affordable housing is considered an action.
+</small>
+<div class="cell medium-6">
+{{#each (array
+  (hash code=717170000 label='Yes')
+  (hash code=717170001 label='No')
+  (hash code=717170002 label='Do not know')) as |radio|
+}}
+  <RadioButton
+    @value={{radio.code}}
+    @groupValue={{@rwcdsForm.dcpIsapplicantseekingaction}}
+    @changed={{fn (mut @rwcdsForm.dcpWhichactionsfromotheragenciesaresought) ""}}
+    data-test-radio="dcpIsapplicantseekingaction"
+    data-test-radio-option={{radio.label}}
+  >
+    {{radio.label}}
+  </RadioButton>
+{{/each}}
+</div>
+{{#if (eq @rwcdsForm.dcpIsapplicantseekingaction 717170000)}}
+  <label>
+    Which actions from other agencies are sought?
+    <TextInput
+      @property={{@rwcdsForm.dcpWhichactionsfromotheragenciesaresought}}
+      @propertyName="dcpWhichactionsfromotheragenciesaresought"
+      @changesetError={{@rwcdsForm.dcpWhichactionsfromotheragenciesaresought}}
+      @maxlength="200"
+      @showCounter={{true}}
+      data-test-input="dcpWhichactionsfromotheragenciesaresought"
+    />
+  </label>
+{{/if}}

--- a/client/app/components/packages/proposed-actions.js
+++ b/client/app/components/packages/proposed-actions.js
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export default class ProposedActionsComponent extends Component {
+  actionsWithSectionNumber = [
+    'ZS', 'ZA', 'ZC', 'SD', 'SA', 'SC', 'RS', 'RA', 'RC',
+  ];
+
+  actionsWithModifiedZrSectionNumberQuestion = [
+    'ZS', 'ZA', 'SD', 'SA', 'RS', 'RA',
+  ];
+}

--- a/client/app/helpers/in-array.js
+++ b/client/app/helpers/in-array.js
@@ -1,0 +1,11 @@
+import { helper } from '@ember/component/helper';
+
+/**
+ * @param { Any [] } arr
+ * @param { Any } elem
+ * returns true if elem is in arr
+ */
+export default helper(function inArray(params) {
+  const [arr, elem] = params;
+  return arr.includes(elem);
+});

--- a/client/app/helpers/lookup-action-type.js
+++ b/client/app/helpers/lookup-action-type.js
@@ -1,0 +1,92 @@
+import { helper } from '@ember/component/helper';
+
+export const actions = [
+  ['BD', 'Business Improvement Districts', '(Non-ULURP) Applicants working to create a Business Improvement District (BID) work with the NYC Department of Small Business Services to create an application for a (BID). Please contact the NYC Department of Small Business Services for more information.'],
+  ['BF', 'Business Franchise', ''],
+  ['CM', 'Renewal', '(Non-ULURP) Many times special permit actions or other land use approvals  are approved for a limited time period, and may require renewal should development under the approvals be delayed or take longer than anticipated. Renewals of past actions require early and close consultation with the Department of City Planning.  Please contact the appropriate Borough Office to discuss your project, and be mindful that such outreach should occur well in advance of the expiry date of your initial approvals to avoid lapses.'],
+  ['CP', '', ''],
+  ['DL', 'Disposition for Residential Low-Income Use', ''],
+  ['DM', 'Disposition for Residential Not Low-Income Use', ''],
+  ['EB', 'CEQR Application', ''],
+  ['EC', 'Enclosed Sidewalk Cafes', '(Non-ULURP) Enclosed Sidewalk Cafés allow restaurateurs to enliven public streets by creating outdoor seating for restaurants in approved locations, along specific streets. The application requirements for Enclosed Sidewalk Cafés are governed by the NYC Department of Consumer Affairs. For more information regarding Sidewalk Cafés of all types, please contact the NYC Department of Consumer Affairs.'],
+  ['EE', 'CEQR Application', ''],
+  ['EF', 'CEQR Application', ''],
+  ['EM', 'CEQR Application', ''],
+  ['EN', 'CEQR Application', ''],
+  ['EU', 'CEQR Application', ''],
+  ['GF', 'Franchise or Revocable Consent', '(ULURP) A revocable consent is a grant by the city, revocable at will, for private use on, over or under city property such as bridges over streets or street furniture. Revocable consents that the Department of City Planning has determined do not have land use impacts or implications are not subject to ULURP.'],
+  ['HA', 'Urban Development Action Area', '(ULURP) Housing and urban renewal plans and projects, pursuant to city, state and federal laws are required to be reviewed by the City Planning Commission.'],
+  ['HC', 'Minor Change', ' A modification in which the proposed changes may alter elements of the prior approval, but without increasing the extent of any waiver or modification of the underlying zoning regulations granted under the prior ULURP approvals, and without requiring any new waivers or modifications of zoning regulations.'],
+  ['HD', 'Disposition of Urban Renewal Site', ''],
+  ['HF', 'Community Dev. Application/Amendment', ''],
+  ['HG', 'Urban Renewal Designation', ''],
+  ['HI', 'Landmarks - Individual Sites', ''],
+  ['HK', 'Landmarks - Historic Districts ', '(Non-ULURP) Proposed New York City Landmarks and Historic Districts are submitted to the Department of City Planning by the Landmarks Preservation Commission to ensure that the landmark designation does not conflict with the Zoning Resolution, projected public improvements or any plans for development, growth, improvement, or renewal in the vicinity of the landmark. Landmark designations are non-ULURP actions.'],
+  ['HL', 'Housing/Urban Renewal/Pub Ben Corp Lease', ''],
+  ['HM', 'Currently Residential/Not Low-Income', ''],
+  ['HN', 'Urban Development Action Area - UDAAP Non-ULURP', 'A project may qualify for the Urban Development Action Area Program (UDAAP) exemption if it involves rehabilitating housing or building new housing on land that used to be owned by the City and has been designated by the City Council as an area in need of urban renewal.'],
+  ['HO', 'Housing Application (Plan and Project)', ''],
+  ['HP', 'Plan & Project/Land Disposition Agreement (LDA) ', ''],
+  ['HR', 'Assignments & Transfers', ''],
+  ['HS', 'Special District/Mall Plan/REMIC NPA', ''],
+  ['HU', 'Urban Renewal Plan and Amendments', ''],
+  ['HZ', 'Preliminary Site Approval Application', ''],
+  ['LD', 'Legal Document (NOC, NOR, RD)', 'An LD action indicates that a project has one or more additional actions related to associated legal documents (such as a "Restrictive Declaration" RD, "Notice of Restriction" NOR, or "Notices of Certification" NOC) that impose additional property controls beyond zoning regulations. Such additional actions could be, for example, that a legal document is being created or modified, or that there is a follow-up approval pursuant to an existing legal document being processed.'],
+  ['MA', 'Assignment/Acquisition', ''],
+  ['MC', 'Major Concessions', '(ULURP) A major concession is a grant made by an agency for the private use of city-owned property, and which has significant land use impacts and implications or which requires the preparation of an environmental impact statement. The City Planning Commission has established rules for determining if a concession is major and requires ULURP review.'],
+  ['MD', 'Drainage Plan', ''],
+  ['ME', 'Easements (Administrative)', '(Non-ULURP) An easement allows for an entity or individual to have limited use of another’s property for a specific purpose. Please contact the Department’s Technical Review Division to discuss new easements or modifications to existing easements and the associated application requirements.'],
+  ['MF', 'Franchise Applic - Not Sidewalk Café', ''],
+  ['ML', 'Landfill', '(ULURP) Landfill applications are applications for the establishment of sanitary or waterfront landfills.'],
+  ['MM', 'Change in City Map', '(ULURP) The City Map is the official adopted map of the city. It shows the location, dimension and grades of streets, parks, public places, and certain public easements. The Director of City Planning is the custodian of the City Map. City Map changes are applications to alter, add, or remove elements from the City Map.'],
+  ['MP', 'Prior Action', ''],
+  ['MY', 'Administration Demapping', ''],
+  ['NP', '197-A Plan', '(Non-ULURP) 197-A Plans are formal community-based plans, as set out in Section 197-A of the City Charter, which authorizes community boards and borough boards, along with the Mayor, the City Planning Commission, the Department of City Planning, and any Borough President, to sponsor plans for the development, growth, and improvement of the city, its boroughs and communities. Once approved by the Commission and adopted by the City Council, 197-a plans guide future actions of city agencies in the areas addressed in the plans.'],
+  ['PA', 'Transfer/Assignment', ''],
+  ['PC', 'Combination Acquisition and Site Selection by the City', '(ULURP) Acquisition and site selection actions are used to purchase and site public facilities in one action.  The Combination Acquisitions and Site Selection action is commonly used for projects including the selection of sites for new city facilities such as sanitation garages, fire houses, libraries and sewage treatment plants. These actions are subject to the Uniform Land Use Review Procedure.'],
+  ['PD', 'Amended Drainage Plan', 'Amended drainage plans are submitted to the Department of City Planning for a review of their consistency with the City Map. Drainage plans are non-ULURP actions submitted to DCP by the NYC Department of Environmental Protection.'],
+  ['PE', 'Exchange of City Property with Private Property', ''],
+  ['PI', 'Private Improvement', ''],
+  ['PL', 'Leasing of Private Property by the City', ''],
+  ['PM', 'Map Change Related to Site Selection', ''],
+  ['PN', 'Negotiated Disposition of City Property', ''],
+  ['PO', 'OTB Site Selection', ''],
+  ['PP', 'Disposition of Non-Residential City-Owned Property', '(ULURP) Dispositions of non-residential city-owned property are used to release property acquired by the city for use or development by another party.  This includes the sale, lease, or exchange of real property. This action is subject to the Uniform Land Use Review Procedure.'],
+  ['PQ', 'Acquisition of Property by the City', '(ULURP) Acquisition of real property by the city occurs when the city endeavors to acquire real property for the purposes of community or city use.  Office space acquisition is excluded and subject to a separate review pursuant to Section 195 of the City Charter. This action is subject to the Uniform Land Use Review Procedure.'],
+  ['PR', "Release of City's Interest", ''],
+  ['PS', 'Site Selection (City Facility) ', '(ULURP) Site selection for capital projects includes the selection of sites for new city facilities such as sanitation garages, fire houses, libraries and sewage treatment plants. A capital project is the construction or acquisition of a public improvement classified as a capital asset of the city. This action is subject to the Uniform Land Use Review Procedure.'],
+  ['PX', 'Office Space', '(Non-ULURP) Applications for the leasing of office space by city agencies are typically filed by the Department of Citywide Administrative Services. Office space lease actions are non-ULURP and are required to move through the approval process on a specific timeline.'],
+  ['RA', 'South Richmond District Authorizations ', '(Non-ULURP) A Zoning Authorization within the Special South Richmond Development District (SSRDD) is a discretionary action taken by the City Planning Commission (CPC) that modifies specific zoning requirements if certain findings have been met. Authorizations are not subject to ULURP review and the CPC does not hold public hearings on authorizations. The CPC generally refers such applications to the appropriate community board(s) for comments.'],
+  ['RC', 'South Richmond District Certifications', '(Non-ULURP) A Special South Richmond Development District certification is a non-discretionary action taken by the City Planning Commission, or its Chairperson, informing the Department of Buildings that an as-of-right development has complied with specific conditions set forth in accordance with provisions of the Zoning Resolution.'],
+  ['RS', 'South Richmond District Special Permits', '(ULURP) Special permits within the Special South Richmond Development District (SSRDD) are discretionary approvals that can modify zoning controls within the Special District, such as use, bulk, and parking. Special Permits are reviewed by the City Planning Commission pursuant to the Zoning Resolution and are subject to the Uniform Land Use Review Procedure.'],
+  ['SC', 'Special Natural Area Certifications', 'The purpose of the Special Natural Area District (NA) is to guide new development and site alterations in areas endowed with unique natural characteristics, including forests, rock outcrops, steep slopes, creeks and a variety of botanic and aquatic environments.'],
+  ['TC', 'Consent - Sidewalk Café', ''],
+  ['TL', 'Leasing of C-O-P By Private Applicants', 'Leasing of City-Owned Properties by Private Applicants.'],
+  ['UC', 'Unenclosed Café', ''],
+  ['VT', 'Cable TV', ''],
+  ['ZA', 'Zoning Authorization', '(Non-ULURP) An authorization is a discretionary action taken by the City Planning Commission (CPC) that modifies specific zoning requirements if certain findings have been met. Authorizations are not subject to ULURP review, and the CPC does not hold public hearings on authorizations. The CPC generally refers such applications to the appropriate community board(s) for comment.'],
+  ['ZC', 'Zoning Certification', '(Non-ULURP) Each Zoning Certification is a distinct land use action and requires specific land use application components.'],
+  ['ZD', 'Amended Restrictive Declaration', ''],
+  ['ZJ', 'Residential Loft Determination', ''],
+  ['ZL', 'Large Scale Special Permit', ''],
+  ['ZM', 'Zoning Map Amendment', '(ULURP) A Zoning Map Amendment is a change in designation or a change in district boundaries for any zoning district on the New York City Zoning Map.  Zoning Map Amendments are discretionary actions subject to the Uniform Land Use Review Procedure.'],
+  ['ZP', 'Parking Special Permit/Incl non-ULURP Ext', 'A special permit was a discretionary action by the City Planning Commission (CPC), subject to ULURP review, or the Board of Standards and Appeals (BSA), which may modify use, bulk or parking regulations if certain condi­tions and findings specified in the Zoning Resolution are met.'],
+  ['ZR', 'Zoning Text Amendment', '(non-ULURP) Zoning Text Amendments are changes to the text of the New York City Zoning Resolution.  Text Amendments do not require the Uniform Land Use Review Procedure, however, in practice; the Department of City Planning refers Zoning Text Amendments to the Community Board for review.'],
+  ['ZS', 'Zoning Special Permit', '(ULURP) A special permit is a discretionary action by the City Planning Commission, subject to ULURP review, or the Board of Standards and Appeals, which may modify use, bulk, or parking regulations if certain conditions and findings specific in the Zoning Resolution are met.'],
+  ['ZX', "Counsel's Office - Rules of Procedure", ''],
+  ['ZZ', 'Site Plan Approval in Natural Area Districts', 'The purpose of the Special Natural Area District (NA) was to guide new development and site alterations in areas endowed with unique natural characteristics, including forests, rock outcrops, steep slopes, creeks and a variety of botanic and aquatic environments.'],
+].map(([code, short, tooltip]) => ({
+  code, short, tooltip, searchField: `${code} ${short}`,
+}));
+
+export function lookupActionType([actioncode]) {
+  // return all if no arguments are passed
+  if (actioncode === undefined) return actions;
+
+  const { tooltip } = actions.find(({ code }) => code === actioncode) || '';
+  const { short } = actions.find(({ code }) => code === actioncode) || '';
+  const titleAndTooltip = tooltip ? short.concat(': ', tooltip) : short;
+  return titleAndTooltip;
+}
+
+export default helper(lookupActionType);

--- a/client/app/models/affected-zoning-resolution.js
+++ b/client/app/models/affected-zoning-resolution.js
@@ -1,0 +1,15 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class ProjectActionModel extends Model {
+  @belongsTo('rwcds-form')
+  rwcdsForm;
+
+  @attr
+  dcpZoningresolutiontype;
+
+  @attr
+  dcpZrsectionnumber;
+
+  @attr
+  dcpModifiedzrsectionnumber;
+}

--- a/client/app/models/rwcds-form.js
+++ b/client/app/models/rwcds-form.js
@@ -1,4 +1,4 @@
-import Model, { attr, belongsTo } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 export const DCPHASPROJECTCHANGEDSINCESUBMISSIONOFTHEPAS_OPTIONSET = {
   YES: {
@@ -26,10 +26,16 @@ export default class RwcdsFormModel extends Model {
   @belongsTo('package', { async: false })
   package;
 
+  @hasMany('affected-zoning-resolution', { async: false })
+  affectedZoningResolutions;
+
   @attr('string') dcpDescribethewithactionscenario;
 
   @attr('boolean') dcpIsplannigondevelopingaffordablehousing;
 
+  // dependent on when:
+  // there's a project-action with dcpZoningresolutiontype = 'ZR'
+  // && dcpZrsectionnumber = 'Appendix F'
   @attr('number') dcpIncludezoningtextamendment;
 
   @attr('boolean') dcpExistingconditions;

--- a/client/app/routes/rwcds-form.js
+++ b/client/app/routes/rwcds-form.js
@@ -7,7 +7,7 @@ export default class RwcdsFormRoute extends Route.extend(AuthenticatedRouteMixin
   async model(params) {
     const rwcdsFormPackage = await this.store.findRecord('package', params.id, {
       reload: true,
-      include: 'rwcds-form,project',
+      include: 'rwcds-form,project,rwcds-form.affectedZoningResolutions',
     });
 
     // manually generate a file factory

--- a/client/mirage/config.js
+++ b/client/mirage/config.js
@@ -40,6 +40,13 @@ export default function() {
   this.patch('/bbls/:id');
   this.del('/bbls/:id');
 
+  this.get('/affected-zoning-resolutions');
+  this.get('/affected-zoning-resolutions/:id');
+  this.patch('/affected-zoning-resolutions/:id');
+
+  this.get('/rwcds-forms');
+  this.get('/rwcds-forms/:id');
+  this.patch('/rwcds-forms/:id');
   this.patch('/pas-forms');
   this.post('/pas-forms');
   this.patch('/pas-forms/:id');

--- a/client/mirage/models/affected-zoning-resolution.js
+++ b/client/mirage/models/affected-zoning-resolution.js
@@ -1,0 +1,5 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  rwcdsForm: belongsTo('rwcds-form'),
+});

--- a/client/mirage/models/rwcds-form.js
+++ b/client/mirage/models/rwcds-form.js
@@ -1,5 +1,6 @@
-import { Model, belongsTo } from 'ember-cli-mirage';
+import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
 
 export default Model.extend({
   package: belongsTo('package'),
+  affectedZoningResolutions: hasMany('affected-zoning-resolution'),
 });

--- a/client/tests/integration/components/packages/proposed-actions-test.js
+++ b/client/tests/integration/components/packages/proposed-actions-test.js
@@ -1,0 +1,63 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import {
+  render,
+  fillIn,
+  click,
+} from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Integration | Component | proposed-actions', function(hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  test('user can view and edit affected zoning resolution actions', async function(assert) {
+    this.package = this.server.create('package', {
+      rwcdsForm: this.server.create('rwcds-form', {
+        affectedZoningResolutions: [
+          this.server.create('affected-zoning-resolution', {
+            dcpZoningresolutiontype: 'ZA',
+            dcpZrsectionnumber: 'Section 74 7-11',
+            dcpZrsectiontitle: 'Landmark Preservation in all districts',
+          }),
+          this.server.create('affected-zoning-resolution', {
+            dcpZoningresolutiontype: 'HO',
+            dcpZrsectionnumber: '',
+            dcpZrsectiontitle: '',
+          }),
+          this.server.create('affected-zoning-resolution', {
+            dcpZoningresolutiontype: 'ZR',
+            dcpZrsectionnumber: 'Appendix F',
+            dcpZrsectiontitle: 'Inclusionary Housing Designated Areas and Mandatory Inclusionary Housing Areas',
+          }),
+        ],
+        dcpIncludezoningtextamendment: true,
+      }),
+    });
+
+    this.rwcdsPackage = await this.owner.lookup('service:store').findRecord('package', this.package.id, { include: 'rwcds-form,rwcds-form.affectedZoningResolutions' });
+
+    // Template block usage:
+    await render(hbs`
+      <Packages::ProposedActions
+        @rwcdsForm={{this.rwcdsPackage.rwcdsForm}}>
+      </Packages::ProposedActions>
+    `);
+
+    await fillIn('[data-test-input="ZA"]', 'my section number');
+    assert.equal(this.rwcdsPackage.rwcdsForm.affectedZoningResolutions.firstObject.dcpModifiedzrsectionnumber, 'my section number');
+
+    await fillIn('[data-test-input="dcpPurposeandneedfortheproposedaction"]', 'my purpose and need');
+    assert.equal(this.rwcdsPackage.rwcdsForm.dcpPurposeandneedfortheproposedaction, 'my purpose and need');
+
+    await click('[data-test-radio="dcpIsplannigondevelopingaffordablehousing"][data-test-radio-option="Yes"]');
+    assert.equal(this.rwcdsPackage.rwcdsForm.dcpIsplannigondevelopingaffordablehousing, true);
+
+    await click('[data-test-radio="dcpIsapplicantseekingaction"][data-test-radio-option="Yes"]');
+    assert.equal(this.rwcdsPackage.rwcdsForm.dcpIsapplicantseekingaction, 717170000);
+
+    await fillIn('[data-test-input="dcpWhichactionsfromotheragenciesaresought"]', 'actions from agencies');
+    assert.equal(this.rwcdsPackage.rwcdsForm.dcpWhichactionsfromotheragenciesaresought, 'actions from agencies');
+  });
+});

--- a/client/tests/integration/helpers/in-array-test.js
+++ b/client/tests/integration/helpers/in-array-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | in-array', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('check that item is in array', async function(assert) {
+    this.inputValue = 'B';
+    this.ourArray = ['A', 'B', 'C'];
+
+    await render(hbs`{{in-array this.ourArray this.inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), 'true');
+  });
+});

--- a/client/tests/integration/helpers/lookup-action-type-test.js
+++ b/client/tests/integration/helpers/lookup-action-type-test.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | lookup-action-type', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it returns the expected action type', async function(assert) {
+    this.set('inputValue', 'ZM');
+
+    await render(hbs`{{lookup-action-type inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), 'Zoning Map Amendment: (ULURP) A Zoning Map Amendment is a change in designation or a change in district boundaries for any zoning district on the New York City Zoning Map.  Zoning Map Amendments are discretionary actions subject to the Uniform Land Use Review Procedure.');
+  });
+});


### PR DESCRIPTION
New component `ProposedActions` for the RWCDS form 
- the backend will handle copying over data from `dcp_projectaction` entity to `dcp_affectedzoningresolution` entity
- the frontend only interacts with `dcp_affectedzoningresolution` patching to it when a user enters input and Saves on the RWCDS form
- the component built in this PR is isolated and has not been rendered on the RWCDS form yet. It is only rendered in its integration test. Another PR will handle the rendering on the form, as well as the passing in of saveable-form and necessary validations

Addresses frontend changes for #223 
Next step: Backend changes required
