### PR TITLE
222 Write to project dcp_anticipatedyearbuilt

### DIFF
--- a/server/src/packages/packages.module.ts
+++ b/server/src/packages/packages.module.ts
@@ -6,11 +6,12 @@ import { PasFormController } from './pas-form/pas-form.controller';
 import { ApplicantsController } from './pas-form/applicants/applicants.controller';
 import { BblsController } from './pas-form/bbls/bbls.controller';
 import { RwcdsFormController } from './rwcds-form/rwcds-form.controller';
+import { RwcdsFormService } from './rwcds-form/rwcds-form.service';
 
 @Module({
   imports: [CrmModule],
   exports: [PackagesService],
-  providers: [PackagesService],
+  providers: [PackagesService, RwcdsFormService],
   controllers: [PackagesController, PasFormController, RwcdsFormController, ApplicantsController, BblsController],
 })
 export class PackagesModule {}

--- a/server/src/packages/rwcds-form/rwcds-form.controller.spec.ts
+++ b/server/src/packages/rwcds-form/rwcds-form.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { RwcdsFormController } from './rwcds-form.controller';
 import { CrmModule } from '../../crm/crm.module';
+import { RwcdsFormService } from './rwcds-form.service';
 
 describe('RwcdsForm Controller', () => {
   let controller: RwcdsFormController;
@@ -8,6 +9,7 @@ describe('RwcdsForm Controller', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [CrmModule],
+      providers: [RwcdsFormService],
       controllers: [RwcdsFormController],
     }).compile();
 

--- a/server/src/packages/rwcds-form/rwcds-form.controller.ts
+++ b/server/src/packages/rwcds-form/rwcds-form.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Patch, Body, Param, UseGuards, UseInterceptors, UsePipes } 
 import { AuthenticateGuard } from '../../authenticate.guard';
 import { JsonApiSerializeInterceptor } from '../../json-api-serialize.interceptor';
 import { JsonApiDeserializePipe } from '../../json-api-deserialize.pipe';
-import { CrmService } from '../../crm/crm.service';
+import { RwcdsFormService } from './rwcds-form.service';
 import { pick } from 'underscore';
 
 export const RWCDS_FORM_ATTRS = [
@@ -55,13 +55,16 @@ export const RWCDS_FORM_ATTRS = [
 @UsePipes(JsonApiDeserializePipe)
 @Controller('rwcds-forms')
 export class RwcdsFormController {
-  constructor(private readonly crmService: CrmService) {}
+  constructor(private readonly rwcdsFormService: RwcdsFormService) {}
 
   @Patch('/:id')
   async update(@Body() body, @Param('id') id) {
-    const allowedAttrs = pick(body, RWCDS_FORM_ATTRS);
+    const allowedAttrs = pick(body, [
+      ...RWCDS_FORM_ATTRS,
+      'package',
+    ]);
 
-    await this.crmService.update('dcp_rwcdsforms', id, allowedAttrs);
+    await this.rwcdsFormService.update(id, allowedAttrs);
 
     return {
       dcp_rwcdsformid: id,

--- a/server/src/packages/rwcds-form/rwcds-form.service.spec.ts
+++ b/server/src/packages/rwcds-form/rwcds-form.service.spec.ts
@@ -1,0 +1,44 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CrmModule } from '../../crm/crm.module';
+import { RwcdsFormService } from './rwcds-form.service';
+import { CrmService } from '../../crm/crm.service';
+
+describe('PackagesService', () => {
+  let rwcdsFormService: RwcdsFormService;
+  let crmService: CrmService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [CrmModule],
+      providers: [RwcdsFormService],
+    }).compile();
+
+    rwcdsFormService = module.get<RwcdsFormService>(RwcdsFormService);
+    crmService = module.get<CrmService>(CrmService);
+  });
+
+  it('RWCDS Form Service Should be defined', () => {
+    expect(rwcdsFormService).toBeDefined();
+  });
+
+  it('update() should update both RWCDS form and project if rwcdsForm.buildyear is included ', async () => {
+    jest.spyOn(rwcdsFormService, '_getPackageProjectId').mockImplementation(async () => '123');
+    const updateMock = jest.spyOn(crmService, 'update').mockImplementation(async () => true);
+
+    await rwcdsFormService.update('123', { dcp_buildyear: 2020 });
+
+    expect(updateMock).toHaveBeenCalledWith('dcp_rwcdsforms', '123', { dcp_buildyear: 2020 });
+    expect(updateMock).toHaveBeenCalledWith('dcp_projects', '123', { dcp_anticipatedyearbuilt: 2020 });
+    expect(updateMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('update() should only update RWCDS form if rwcdsForm.buildyear is NOT included ', async () => {
+    jest.spyOn(rwcdsFormService, '_getPackageProjectId').mockImplementation(async () => '123');
+    const updateMock = jest.spyOn(crmService, 'update').mockImplementation(async () => true);
+
+    await rwcdsFormService.update('123', { dcp_projectname: 'Chelsea' });
+
+    expect(updateMock).toHaveBeenCalledWith('dcp_rwcdsforms', '123', { dcp_projectname: 'Chelsea' });
+    expect(updateMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/src/packages/rwcds-form/rwcds-form.service.ts
+++ b/server/src/packages/rwcds-form/rwcds-form.service.ts
@@ -1,0 +1,40 @@
+import { Injectable, HttpStatus, HttpException } from '@nestjs/common';
+import { CrmService } from '../../crm/crm.service';
+import { pick } from 'underscore';
+import { RWCDS_FORM_ATTRS } from './rwcds-form.controller';
+
+@Injectable()
+export class RwcdsFormService {
+  constructor(private readonly crmService: CrmService) {}
+
+  async _getPackageProjectId(packageId):Promise<String> {
+    const { records: [firstPackage] } = await this.crmService.get('dcp_packages', `
+      $select=_dcp_project_value
+      &$filter=dcp_packageid eq ${packageId}
+    `);
+
+    if (!firstPackage) {
+      return undefined;
+    }
+
+    const { _dcp_project_value } = firstPackage;
+
+    return _dcp_project_value;
+  }
+
+  async update(id, body) {
+    const allowedAttrs = pick(body, RWCDS_FORM_ATTRS);
+    const { package: packageId } = body;
+    const projectId = await this._getPackageProjectId(packageId);
+
+    if(!projectId) {
+      return new HttpException('Package not found for RWCDS Form', HttpStatus.NOT_FOUND);
+    }
+
+    await this.crmService.update('dcp_rwcdsforms', id, allowedAttrs);
+
+    await this.crmService.update('dcp_projects', projectId, {
+      'dcp_anticipatedyearbuilt': allowedAttrs.dcp_buildyear,
+    });
+  }
+}

--- a/server/src/packages/rwcds-form/rwcds-form.service.ts
+++ b/server/src/packages/rwcds-form/rwcds-form.service.ts
@@ -33,8 +33,10 @@ export class RwcdsFormService {
 
     await this.crmService.update('dcp_rwcdsforms', id, allowedAttrs);
 
-    await this.crmService.update('dcp_projects', projectId, {
-      'dcp_anticipatedyearbuilt': allowedAttrs.dcp_buildyear,
-    });
+    if (allowedAttrs.hasOwnProperty('dcp_buildyear')) {
+      await this.crmService.update('dcp_projects', projectId, {
+        dcp_anticipatedyearbuilt: allowedAttrs.dcp_buildyear,
+      });
+    }
   }
 }


### PR DESCRIPTION
There are two alternatives to this implementation, see below. I explored alternative 1 but got stuck modifying the JSON API Serializer. 

## PR 
Adds a new RWCDS Service in the backend in charge of updating
the RWCDS Form. While patching the RWCDS Form, it also copies
the RWCDS buildyear property over to the associated Project's
anticipatedyearbuilt property.

The service first needs to acquire the form's projectid through
a network request for the associated package. This is because
projectid information doesn't come from the frontend.

## Alternatives
1. Create a relationship between Forms (RWCDS, PAS) and Projects in the frontend, so that that when PATCHing a form, the request payload can include the Project Id. This will avoid a double network request within the RWCDS Patch. 

2. Create a separate endpoint  (controller) for PATCHing Projects. Have the frontend set the Project.dcpAnticipatedyearbuilt and call Project.save(). At first, this seems a little less sturdy since the frontend could potentially successfully PATCH a package but then abort before PATCHing the Project. However, the frontend already faces a similar risk with uploading documents, saving applicant team, bbls, etc. 