### PR TITLE
222 Add null/NA option to dcpConstructionphasing

### DIFF
--- a/client/app/components/packages/rwcds-form/project-description.hbs
+++ b/client/app/components/packages/rwcds-form/project-description.hbs
@@ -66,7 +66,10 @@
               (hash
                 code=(optionset 'rwcdsForm' 'dcpConstructionphasing' 'code' 'MULTIPLE')
                 label=(optionset 'rwcdsForm' 'dcpConstructionphasing' 'label' 'MULTIPLE'))
-            }}
+              (hash
+                code=(optionset 'rwcdsForm' 'dcpConstructionphasing' 'code' 'NOT_APPLICABLE')
+                label=(optionset 'rwcdsForm' 'dcpConstructionphasing' 'label' 'NOT_APPLICABLE'))
+              }}
           />
         </form.Field>
       <br>

--- a/client/app/models/rwcds-form.js
+++ b/client/app/models/rwcds-form.js
@@ -20,6 +20,10 @@ export const DCPCONSTRUCTIONPHASING_OPTIONSET = {
     code: 717170001,
     label: 'Multiple',
   },
+  NOT_APPLICABLE: {
+    code: null,
+    label: 'Not Applicable',
+  },
 };
 
 export default class RwcdsFormModel extends Model {


### PR DESCRIPTION
For RWCDS form `dcp_constructionphasing` field (i.e. "Will construction be done in multiple phases?" question), add the NULL option. The label is displayed as "Not Applicable".