### PR TITLE
Ui::Question component

### DIFF
--- a/client/app/components/land-use-action.hbs
+++ b/client/app/components/land-use-action.hbs
@@ -25,10 +25,14 @@
   {{/if}}
 
   {{#each this.sortedSelectedActions as |landUseAction|}}
-    <Ui::Question class="fieldset relative scale-fade-in" as |Q|>
-      <Q.Prompt data-test-action-name="{{landUseAction.name}}">
+    <Ui::Question
+      @group={{true}}
+      class="fieldset relative scale-fade-in"
+      as |Q|
+    >
+      <Q.prompt data-test-action-name="{{landUseAction.name}}">
         {{landUseAction.name}}
-      </Q.Prompt>
+      </Q.prompt>
 
       {{#if (or (eq landUseAction.name "Zoning Special Permit") (eq landUseAction.name "Zoning Certification") (eq landUseAction.name "Zoning Authorization") (eq landUseAction.name "Zoning Map Amendment") (eq landUseAction.name "Zoning Text Amendment") (eq landUseAction.name "Modification") (eq landUseAction.name "Renewal"))}}
         {{#if (or (eq landUseAction.name "Zoning Special Permit") (eq landUseAction.name "Zoning Certification") (eq landUseAction.name "Zoning Authorization"))}}
@@ -49,8 +53,12 @@
               </Form.Field>
             </div>
           </div>
-          <label class="action-form-label">
-            Where in the Zoning Resolution can this action be found?
+
+          <Ui::Question as |Q|>
+            <Q.prompt>
+              Where in the Zoning Resolution can this action be found?
+            </Q.prompt>
+
             <Form.Field
               @attribute={{landUseAction.attr1}}
               as |TextInput|
@@ -62,9 +70,13 @@
               />
             </Form.Field>
             <span class="help-text">Provide the Zoning Resolution section number. Ex. ZR Sec. 74-711</span>
-          </label>
-          <label class="action-form-label">
-            Which sections of the Zoning Resolution does this modify?
+          </Ui::Question>
+
+          <Ui::Question as |Q|>
+            <Q.prompt>
+              Which sections of the Zoning Resolution does this modify?
+            </Q.prompt>
+
             <Form.Field
               @attribute={{landUseAction.attr2}}
               as |TextInput|
@@ -76,11 +88,15 @@
               />
             </Form.Field>
             <span class="help-text">Provide the Zoning Resolution section number(s). Ex. ZR Sec. 42-10 and 43-17</span>
-          </label>
+          </Ui::Question>
         {{/if}}
+
         {{#if (eq landUseAction.name "Zoning Map Amendment")}}
-          <label class="action-form-label">
-            Existing Zoning Districts:
+          <Ui::Question as |Q|>
+            <Q.prompt>
+              Existing Zoning Districts:
+            </Q.prompt>
+
             <Form.Field
               @attribute={{landUseAction.attr1}}
               as |TextInput|
@@ -92,9 +108,13 @@
               />
             </Form.Field>
             <span class="help-text">ex. R7-1/C2-4</span>
-          </label>
-          <label>
-            Proposed Zoning Districts:
+          </Ui::Question>
+
+          <Ui::Question as |Q|>
+            <Q.prompt>
+              Proposed Zoning Districts:
+            </Q.prompt>
+
             <Form.Field
               @attribute={{landUseAction.attr2}}
               as |TextInput|
@@ -106,11 +126,15 @@
               />
             </Form.Field>
             <span class="help-text">ex. C4-5X</span>
-          </label>
+          </Ui::Question>
         {{/if}}
+
         {{#if (eq landUseAction.name "Zoning Text Amendment")}}
-          <label class="action-form-label">
-            Affected ZR Section Number:
+          <Ui::Question as |Q|>
+            <Q.prompt>
+              Affected ZR Section Number:
+            </Q.prompt>
+
             <Form.Field
               @attribute={{landUseAction.attr1}}
               as |TextInput|
@@ -122,9 +146,13 @@
               />
             </Form.Field>
             <span class="help-text">Provide the Zoning Resolution section number. Ex. ZR Sec. 74-711</span>
-          </label>
-          <label class="action-form-label">
-            Affected ZR Section Title:
+          </Ui::Question>
+
+          <Ui::Question as |Q|>
+            <Q.prompt>
+              Affected ZR Section Title:
+            </Q.prompt>
+
             <Form.Field
               @attribute={{landUseAction.attr2}}
               as |TextInput|
@@ -136,11 +164,15 @@
               />
             </Form.Field>
             <span class="help-text">Provide the Zoning Resolution section Title. Ex. EXAMPLE</span>
-          </label>
+          </Ui::Question>
         {{/if}}
+
         {{#if (or (eq landUseAction.name "Modification") (eq landUseAction.name "Renewal"))}}
-          <label class="action-form-label">
-            Previous ULURP Numbers:
+          <Ui::Question as |Q|>
+            <Q.prompt>
+              Previous ULURP Numbers:
+            </Q.prompt>
+
             <Form.Field
               @attribute={{landUseAction.attr1}}
               as |TextInput|
@@ -152,10 +184,10 @@
               />
             </Form.Field>
             <span class="help-text">ex. 200307ZRK</span>
-          </label>
+          </Ui::Question>
         {{/if}}
       {{else}}
-        <span class="help-text">No additional information required for this action</span>
+        <p class="help-text">No additional information required for this action</p>
       {{/if}}
 
       <button

--- a/client/app/components/land-use-action.hbs
+++ b/client/app/components/land-use-action.hbs
@@ -25,10 +25,10 @@
   {{/if}}
 
   {{#each this.sortedSelectedActions as |landUseAction|}}
-    <Ui::Fieldset class="fieldset relative scale-fade-in" as |Q|>
-      <Q.legend data-test-action-name="{{landUseAction.name}}">
+    <Ui::Question class="fieldset relative scale-fade-in" as |Q|>
+      <Q.prompt data-test-action-name="{{landUseAction.name}}">
         {{landUseAction.name}}
-      </Q.legend>
+      </Q.prompt>
 
       {{#if (or (eq landUseAction.name "Zoning Special Permit") (eq landUseAction.name "Zoning Certification") (eq landUseAction.name "Zoning Authorization") (eq landUseAction.name "Zoning Map Amendment") (eq landUseAction.name "Zoning Text Amendment") (eq landUseAction.name "Modification") (eq landUseAction.name "Renewal"))}}
         {{#if (or (eq landUseAction.name "Zoning Special Permit") (eq landUseAction.name "Zoning Certification") (eq landUseAction.name "Zoning Authorization"))}}
@@ -167,6 +167,6 @@
         Delete Action
         <FaIcon @icon="times" @prefix="fas" @fixedWidth={{true}} />
       </button>
-    </Ui::Fieldset>
+    </Ui::Question>
   {{/each}}
 {{/let}}

--- a/client/app/components/land-use-action.hbs
+++ b/client/app/components/land-use-action.hbs
@@ -38,7 +38,13 @@
         {{#if (or (eq landUseAction.name "Zoning Special Permit") (eq landUseAction.name "Zoning Certification") (eq landUseAction.name "Zoning Authorization"))}}
           <div class="grid-x grid-margin-x">
             <div class="shrink cell">
-              <label for="middle-label" class="middle">How many {{landUseAction.name}} actions?</label>
+              {{!-- TODO:
+                Ui::Question component doesn't work when a grid splits up label and input.
+                The label needs a functioning for="" if it doesn't wrap the input.
+              --}}
+              <label class="middle">
+                <strong>How many {{landUseAction.name}} actions?</strong>
+              </label>
             </div>
             <div class="auto cell">
               <Form.Field

--- a/client/app/components/land-use-action.hbs
+++ b/client/app/components/land-use-action.hbs
@@ -26,9 +26,9 @@
 
   {{#each this.sortedSelectedActions as |landUseAction|}}
     <Ui::Question class="fieldset relative scale-fade-in" as |Q|>
-      <Q.prompt data-test-action-name="{{landUseAction.name}}">
+      <Q.Prompt data-test-action-name="{{landUseAction.name}}">
         {{landUseAction.name}}
-      </Q.prompt>
+      </Q.Prompt>
 
       {{#if (or (eq landUseAction.name "Zoning Special Permit") (eq landUseAction.name "Zoning Certification") (eq landUseAction.name "Zoning Authorization") (eq landUseAction.name "Zoning Map Amendment") (eq landUseAction.name "Zoning Text Amendment") (eq landUseAction.name "Modification") (eq landUseAction.name "Renewal"))}}
         {{#if (or (eq landUseAction.name "Zoning Special Permit") (eq landUseAction.name "Zoning Certification") (eq landUseAction.name "Zoning Authorization"))}}

--- a/client/app/components/land-use-action.hbs
+++ b/client/app/components/land-use-action.hbs
@@ -30,9 +30,9 @@
       class="fieldset relative scale-fade-in"
       as |Q|
     >
-      <Q.prompt data-test-action-name="{{landUseAction.name}}">
+      <Q.Prompt data-test-action-name="{{landUseAction.name}}">
         {{landUseAction.name}}
-      </Q.prompt>
+      </Q.Prompt>
 
       {{#if (or (eq landUseAction.name "Zoning Special Permit") (eq landUseAction.name "Zoning Certification") (eq landUseAction.name "Zoning Authorization") (eq landUseAction.name "Zoning Map Amendment") (eq landUseAction.name "Zoning Text Amendment") (eq landUseAction.name "Modification") (eq landUseAction.name "Renewal"))}}
         {{#if (or (eq landUseAction.name "Zoning Special Permit") (eq landUseAction.name "Zoning Certification") (eq landUseAction.name "Zoning Authorization"))}}
@@ -55,9 +55,9 @@
           </div>
 
           <Ui::Question as |Q|>
-            <Q.prompt>
+            <Q.Prompt>
               Where in the Zoning Resolution can this action be found?
-            </Q.prompt>
+            </Q.Prompt>
 
             <Form.Field
               @attribute={{landUseAction.attr1}}
@@ -73,9 +73,9 @@
           </Ui::Question>
 
           <Ui::Question as |Q|>
-            <Q.prompt>
+            <Q.Prompt>
               Which sections of the Zoning Resolution does this modify?
-            </Q.prompt>
+            </Q.Prompt>
 
             <Form.Field
               @attribute={{landUseAction.attr2}}
@@ -93,9 +93,9 @@
 
         {{#if (eq landUseAction.name "Zoning Map Amendment")}}
           <Ui::Question as |Q|>
-            <Q.prompt>
+            <Q.Prompt>
               Existing Zoning Districts:
-            </Q.prompt>
+            </Q.Prompt>
 
             <Form.Field
               @attribute={{landUseAction.attr1}}
@@ -111,9 +111,9 @@
           </Ui::Question>
 
           <Ui::Question as |Q|>
-            <Q.prompt>
+            <Q.Prompt>
               Proposed Zoning Districts:
-            </Q.prompt>
+            </Q.Prompt>
 
             <Form.Field
               @attribute={{landUseAction.attr2}}
@@ -131,9 +131,9 @@
 
         {{#if (eq landUseAction.name "Zoning Text Amendment")}}
           <Ui::Question as |Q|>
-            <Q.prompt>
+            <Q.Prompt>
               Affected ZR Section Number:
-            </Q.prompt>
+            </Q.Prompt>
 
             <Form.Field
               @attribute={{landUseAction.attr1}}
@@ -149,9 +149,9 @@
           </Ui::Question>
 
           <Ui::Question as |Q|>
-            <Q.prompt>
+            <Q.Prompt>
               Affected ZR Section Title:
-            </Q.prompt>
+            </Q.Prompt>
 
             <Form.Field
               @attribute={{landUseAction.attr2}}
@@ -169,9 +169,9 @@
 
         {{#if (or (eq landUseAction.name "Modification") (eq landUseAction.name "Renewal"))}}
           <Ui::Question as |Q|>
-            <Q.prompt>
+            <Q.Prompt>
               Previous ULURP Numbers:
-            </Q.prompt>
+            </Q.Prompt>
 
             <Form.Field
               @attribute={{landUseAction.attr1}}

--- a/client/app/components/packages/applicant-fieldset.hbs
+++ b/client/app/components/packages/applicant-fieldset.hbs
@@ -5,9 +5,9 @@
     ...attributes
     as |Q|
   >
-    <Q.prompt data-test-applicant-title="{{@applicant.friendlyEntityName}}">
+    <Q.Prompt data-test-applicant-title="{{@applicant.friendlyEntityName}}">
       {{@applicant.friendlyEntityName}}
-    </Q.prompt>
+    </Q.Prompt>
 
     {{!-- if sent to CRM "Applicant Information" table, need to know "type" --}}
     {{#if (eq @applicant.friendlyEntityName "Applicant")}}
@@ -15,9 +15,9 @@
         data-test-applicant-type-radio-group
         as |Q|
       >
-        <Q.prompt class="show-for-sr">
+        <Q.Prompt class="show-for-sr">
           Type of applicant
-        </Q.prompt>
+        </Q.Prompt>
 
         <Form.Field
           @attribute="dcpType"
@@ -37,9 +37,9 @@
     {{!-- and if the applicant is on behalf of an organization, we need to know which organization --}}
     {{#if (eq @applicant.dcpType 717170001)}}
       <Ui::Question data-test-applicant-organization as |Q|>
-        <Q.prompt>
+        <Q.Prompt>
           <span class="text-weight-normal">Organization Name</span>
-        </Q.prompt>
+        </Q.Prompt>
         <Form.Field @attribute="dcpOrganization"/>
       </Ui::Question>
 
@@ -51,9 +51,9 @@
     <div class="grid-x grid-margin-x">
       <div class="cell medium-6">
         <Ui::Question as |Q|>
-          <Q.prompt>
+          <Q.Prompt>
             <span class="text-weight-normal">First Name</span>
-          </Q.prompt>
+          </Q.Prompt>
 
           <Form.Field @attribute="dcpFirstname"/>
         </Ui::Question>
@@ -61,9 +61,9 @@
 
       <div class="cell medium-6">
         <Ui::Question as |Q|>
-          <Q.prompt>
+          <Q.Prompt>
             <span class="text-weight-normal">Last Name</span>
-          </Q.prompt>
+          </Q.Prompt>
 
           <Form.Field @attribute="dcpLastname"/>
         </Ui::Question>
@@ -73,26 +73,26 @@
     {{!-- always allow input for Other Team Members --}}
     {{#if (eq @applicant.friendlyEntityName "Other Team Member")}}
       <Ui::Question as |Q|>
-        <Q.prompt>
+        <Q.Prompt>
           <span class="text-weight-normal">Organization</span>
-        </Q.prompt>
+        </Q.Prompt>
 
         <Form.Field @attribute="dcpOrganization"/>
       </Ui::Question>
     {{/if}}
 
     <Ui::Question as |Q|>
-      <Q.prompt>
+      <Q.Prompt>
         <span class="text-weight-normal">Email Address</span>
-      </Q.prompt>
+      </Q.Prompt>
 
       <Form.Field @attribute="dcpEmail"/>
     </Ui::Question>
 
     <Ui::Question as |Q|>
-      <Q.prompt>
+      <Q.Prompt>
         <span class="text-weight-normal">Address</span>
-      </Q.prompt>
+      </Q.Prompt>
 
       <Form.Field @attribute="dcpAddress"/>
     </Ui::Question>
@@ -100,9 +100,9 @@
     <div class="grid-x grid-margin-x">
       <div class="cell medium-auto">
         <Ui::Question as |Q|>
-          <Q.prompt>
+          <Q.Prompt>
             <span class="text-weight-normal">City</span>
-          </Q.prompt>
+          </Q.Prompt>
 
           <Form.Field @attribute="dcpCity"/>
         </Ui::Question>
@@ -112,9 +112,9 @@
           data-test-applicant-state-dropdown
           as |Q|
         >
-          <Q.prompt>
+          <Q.Prompt>
             <span class="text-weight-normal">State</span>
-          </Q.prompt>
+          </Q.Prompt>
 
           <PowerSelect
             supportsDataTestProperties={{true}}
@@ -132,9 +132,9 @@
 
       <div class="cell auto medium-4">
         <Ui::Question as |Q|>
-          <Q.prompt>
+          <Q.Prompt>
             <span class="text-weight-normal">ZIP</span>
-          </Q.prompt>
+          </Q.Prompt>
 
           <Form.Field @attribute="dcpZipcode"/>
         </Ui::Question>
@@ -142,9 +142,9 @@
     </div>
 
     <Ui::Question as |Q|>
-      <Q.prompt>
+      <Q.Prompt>
         <span class="text-weight-normal">Phone</span>
-      </Q.prompt>
+      </Q.Prompt>
 
       <Form.Field @attribute="dcpPhone"/>
     </Ui::Question>

--- a/client/app/components/packages/applicant-fieldset.hbs
+++ b/client/app/components/packages/applicant-fieldset.hbs
@@ -1,8 +1,8 @@
 {{#let @form as |Form|}}
   <Ui::Question class="fieldset relative" ...attributes as |Q|>
-    <Q.prompt data-test-applicant-title="{{@applicant.friendlyEntityName}}">
+    <Q.Prompt data-test-applicant-title="{{@applicant.friendlyEntityName}}">
       {{@applicant.friendlyEntityName}}
-    </Q.prompt>
+    </Q.Prompt>
 
     {{!-- if sent to CRM "Applicant Information" table, need to know "type" --}}
     {{#if (eq @applicant.friendlyEntityName "Applicant")}}

--- a/client/app/components/packages/applicant-fieldset.hbs
+++ b/client/app/components/packages/applicant-fieldset.hbs
@@ -1,12 +1,24 @@
 {{#let @form as |Form|}}
-  <Ui::Question class="fieldset relative" ...attributes as |Q|>
-    <Q.Prompt data-test-applicant-title="{{@applicant.friendlyEntityName}}">
+  <Ui::Question
+    @fieldset={{true}}
+    class="fieldset relative"
+    ...attributes
+    as |Q|
+  >
+    <Q.prompt data-test-applicant-title="{{@applicant.friendlyEntityName}}">
       {{@applicant.friendlyEntityName}}
-    </Q.Prompt>
+    </Q.prompt>
 
     {{!-- if sent to CRM "Applicant Information" table, need to know "type" --}}
     {{#if (eq @applicant.friendlyEntityName "Applicant")}}
-      <div class="cell medium-6" data-test-applicant-type-radio-group>
+      <Ui::Question
+        data-test-applicant-type-radio-group
+        as |Q|
+      >
+        <Q.prompt class="show-for-sr">
+          Type of applicant
+        </Q.prompt>
+
         <Form.Field
           @attribute="dcpType"
           @type="radio-group"
@@ -19,57 +31,91 @@
             }}
           />
         </Form.Field>
-      </div>
+      </Ui::Question>
     {{/if}}
 
     {{!-- and if the applicant is on behalf of an organization, we need to know which organization --}}
     {{#if (eq @applicant.dcpType 717170001)}}
-      <label data-test-applicant-organization>
-        Organization
+      <Ui::Question data-test-applicant-organization as |Q|>
+        <Q.prompt>
+          <span class="text-weight-normal">Organization Name</span>
+        </Q.prompt>
         <Form.Field @attribute="dcpOrganization"/>
-      </label>
+      </Ui::Question>
+
       <hr/>
+
       <h5>Authorized Organization Representative</h5>
     {{/if}}
 
     <div class="grid-x grid-margin-x">
       <div class="cell medium-6">
-        <label>First Name</label>
-        <Form.Field @attribute="dcpFirstname"/>
+        <Ui::Question as |Q|>
+          <Q.prompt>
+            <span class="text-weight-normal">First Name</span>
+          </Q.prompt>
+
+          <Form.Field @attribute="dcpFirstname"/>
+        </Ui::Question>
       </div>
+
       <div class="cell medium-6">
-        <label>Last Name</label>
+        <Ui::Question as |Q|>
+          <Q.prompt>
+            <span class="text-weight-normal">Last Name</span>
+          </Q.prompt>
+
           <Form.Field @attribute="dcpLastname"/>
+        </Ui::Question>
       </div>
     </div>
 
     {{!-- always allow input for Other Team Members --}}
     {{#if (eq @applicant.friendlyEntityName "Other Team Member")}}
-      <label>
-        Organization
+      <Ui::Question as |Q|>
+        <Q.prompt>
+          <span class="text-weight-normal">Organization</span>
+        </Q.prompt>
+
         <Form.Field @attribute="dcpOrganization"/>
-      </label>
+      </Ui::Question>
     {{/if}}
 
-    <label>
-      Email Address
+    <Ui::Question as |Q|>
+      <Q.prompt>
+        <span class="text-weight-normal">Email Address</span>
+      </Q.prompt>
+
       <Form.Field @attribute="dcpEmail"/>
-    </label>
-    <label>
-      Address
+    </Ui::Question>
+
+    <Ui::Question as |Q|>
+      <Q.prompt>
+        <span class="text-weight-normal">Address</span>
+      </Q.prompt>
+
       <Form.Field @attribute="dcpAddress"/>
-    </label>
+    </Ui::Question>
 
     <div class="grid-x grid-margin-x">
       <div class="cell medium-auto">
-        <label>
-          City
+        <Ui::Question as |Q|>
+          <Q.prompt>
+            <span class="text-weight-normal">City</span>
+          </Q.prompt>
+
           <Form.Field @attribute="dcpCity"/>
-        </label>
+        </Ui::Question>
       </div>
       <div class="cell auto medium-2">
-        <label data-test-applicant-state-dropdown>
-          State
+        <Ui::Question
+          data-test-applicant-state-dropdown
+          as |Q|
+        >
+          <Q.prompt>
+            <span class="text-weight-normal">State</span>
+          </Q.prompt>
+
           <PowerSelect
             supportsDataTestProperties={{true}}
             @selected={{@applicant.dcpState}}
@@ -81,20 +127,27 @@
           as |stateCode|>
             {{optionset 'applicant' 'state' 'label' stateCode}}
           </PowerSelect>
-        </label>
+        </Ui::Question>
       </div>
+
       <div class="cell auto medium-4">
-        <label>
-          ZIP
+        <Ui::Question as |Q|>
+          <Q.prompt>
+            <span class="text-weight-normal">ZIP</span>
+          </Q.prompt>
+
           <Form.Field @attribute="dcpZipcode"/>
-        </label>
+        </Ui::Question>
       </div>
     </div>
 
-    <label>
-      Phone
+    <Ui::Question as |Q|>
+      <Q.prompt>
+        <span class="text-weight-normal">Phone</span>
+      </Q.prompt>
+
       <Form.Field @attribute="dcpPhone"/>
-    </label>
+    </Ui::Question>
 
     <button
       type="button"

--- a/client/app/components/packages/applicant-fieldset.hbs
+++ b/client/app/components/packages/applicant-fieldset.hbs
@@ -1,8 +1,8 @@
 {{#let @form as |Form|}}
-  <Ui::Fieldset class="fieldset relative" ...attributes as |Q|>
-    <Q.legend data-test-applicant-title="{{@applicant.friendlyEntityName}}">
+  <Ui::Question class="fieldset relative" ...attributes as |Q|>
+    <Q.prompt data-test-applicant-title="{{@applicant.friendlyEntityName}}">
       {{@applicant.friendlyEntityName}}
-    </Q.legend>
+    </Q.prompt>
 
     {{!-- if sent to CRM "Applicant Information" table, need to know "type" --}}
     {{#if (eq @applicant.friendlyEntityName "Applicant")}}
@@ -106,5 +106,5 @@
       <FaIcon @icon="times" @prefix="fas" @fixedWidth={{true}} />
     </button>
 
-  </Ui::Fieldset>
+  </Ui::Question>
 {{/let}}

--- a/client/app/components/packages/attachments.hbs
+++ b/client/app/components/packages/attachments.hbs
@@ -1,9 +1,9 @@
 <div class="site-main grid-x grid-margin-x" ...attributes>
   <div class="cell">
-    <Ui::Fieldset class="fieldset" as |Q|>
-      <Q.legend>
+    <Ui::Question class="fieldset" as |Q|>
+      <Q.prompt>
         Attachments
-      </Q.legend>
+      </Q.prompt>
 
       <ul class="no-bullet">
         {{#each @fileManager.existingFiles as |file idx|}}
@@ -125,6 +125,6 @@
           Choose Files
         </FileUpload>
       </div>
-    </Ui::Fieldset>
+    </Ui::Question>
   </div>
 </div>

--- a/client/app/components/packages/attachments.hbs
+++ b/client/app/components/packages/attachments.hbs
@@ -1,9 +1,9 @@
 <div class="site-main grid-x grid-margin-x" ...attributes>
   <div class="cell">
     <Ui::Question class="fieldset" as |Q|>
-      <Q.prompt>
+      <Q.Prompt>
         Attachments
-      </Q.prompt>
+      </Q.Prompt>
 
       <ul class="no-bullet">
         {{#each @fileManager.existingFiles as |file idx|}}

--- a/client/app/components/packages/pas-form/project-area.hbs
+++ b/client/app/components/packages/pas-form/project-area.hbs
@@ -4,10 +4,10 @@
       Project Area refers to all property that would be subject to the proposed actions.
     </p>
 
-    <Ui::Fieldset as |Q|>
-      <Q.legend>
+    <Ui::Question @group={{true}} as |Q|>
+      <Q.prompt>
         Does the proposed Project, or portion thereof, require a NYC DEP Storm Water Construction Permit?
-      </Q.legend>
+      </Q.prompt>
 
       <Form.Field
         @attribute="dcpProposedprojectorportionconstruction"
@@ -22,12 +22,12 @@
           }}
         />
       </Form.Field>
-    </Ui::Fieldset>
+    </Ui::Question>
 
-    <Ui::Fieldset as |Q|>
-      <Q.legend>
+    <Ui::Question @group={{true}} as |Q|>
+      <Q.prompt>
         Is the proposed Project Area located in a current or former <Ui::ExternalLink @href="https://www1.nyc.gov/site/hpd/services-and-information/urban-renewal.page">Urban Renewal Area</Ui::ExternalLink>?
-      </Q.legend>
+      </Q.prompt>
 
       <Form.Field
         @attribute="dcpUrbanrenewalarea"
@@ -53,12 +53,12 @@
           {{/if}}
         </RadioGroup>
       </Form.Field>
-    </Ui::Fieldset>
+    </Ui::Question>
 
-    <Ui::Fieldset as |Q|>
-      <Q.legend>
+    <Ui::Question @group={{true}} as |Q|>
+      <Q.prompt>
         What is the <Ui::ExternalLink @href="https://streets.planning.nyc.gov/about">Legal Street Frontage Status in the Project Area</Ui::ExternalLink>?
-      </Q.legend>
+      </Q.prompt>
 
       <Form.Field
         @attribute="dcpLegalstreetfrontage"
@@ -75,14 +75,14 @@
           }}
         />
       </Form.Field>
-    </Ui::Fieldset>
+    </Ui::Question>
 
-    <Ui::Fieldset as |Q|>
-      <Q.legend>
+    <Ui::Question @group={{true}} as |Q|>
+      <Q.prompt>
         Do all land use actions meet
         <Ui::ExternalLink @href="https://govt.westlaw.com/nycrr/Document/I4ec3a767cd1711dda432a117e6e0f345?viewType=FullText&originationContext=documenttoc&transitionType=CategoryPageItem&contextData=(sc.Default)">SEQRA or CEQR criteria</Ui::ExternalLink>
         for Type II status?
-      </Q.legend>
+      </Q.prompt>
 
       <Form.Field
         @attribute="dcpLanduseactiontype2"
@@ -112,12 +112,12 @@
           {{/if}}
         </RadioGroup>
       </Form.Field>
-    </Ui::Fieldset>
+    </Ui::Question>
 
-    <Ui::Fieldset as |Q|>
-      <Q.legend>
+    <Ui::Question @group={{true}} as |Q|>
+      <Q.prompt>
         Is the proposed Project Area in an <Ui::ExternalLink @href="https://zola.planning.nyc.gov/">Industrial Business Zone</Ui::ExternalLink>?
-      </Q.legend>
+      </Q.prompt>
 
       <Form.Field
         @attribute="dcpProjectareaindustrialbusinesszone"
@@ -142,12 +142,12 @@
           {{/if}}
         </RadioGroup>
       </Form.Field>
-    </Ui::Fieldset>
+    </Ui::Question>
 
-    <Ui::Fieldset as |Q|>
-      <Q.legend>
+    <Ui::Question @group={{true}} as |Q|>
+      <Q.prompt>
         Is the proposed Project Area within or adjacent to a designated (City or State) <Ui::ExternalLink @href="https://zola.planning.nyc.gov/">Landmark or Historic District</Ui::ExternalLink>?
-      </Q.legend>
+      </Q.prompt>
 
       <Form.Field
         @attribute="dcpIsprojectarealandmark"
@@ -171,12 +171,12 @@
           {{/if}}
         </RadioGroup>
       </Form.Field>
-    </Ui::Fieldset>
+    </Ui::Question>
 
-    <Ui::Fieldset as |Q|>
-      <Q.legend>
+    <Ui::Question @group={{true}} as |Q|>
+      <Q.prompt>
         Is the proposed Project Area located within the <Ui::ExternalLink @href="https://dcp.maps.arcgis.com/apps/View/index.html?appid=90e3a9f927c2471483631a20e8a41d8d">NYC Coastal Zone</Ui::ExternalLink>?
-      </Q.legend>
+      </Q.prompt>
 
       <Form.Field
         @attribute="dcpProjectareacoastalzonelocatedin"
@@ -190,12 +190,12 @@
           }}
         />
       </Form.Field>
-    </Ui::Fieldset>
+    </Ui::Question>
 
-    <Ui::Fieldset as |Q|>
-      <Q.legend>
+    <Ui::Question @group={{true}} as |Q|>
+      <Q.prompt>
         Is the Project Area located within the <Ui::ExternalLink @href="https://dcp.maps.arcgis.com/apps/webappviewer/index.html?id=1c37d271fba14163bbb520517153d6d5">1% annual chance floodplain</Ui::ExternalLink>?
-      </Q.legend>
+      </Q.prompt>
 
       <Form.Field
         @attribute="dcpProjectareaischancefloodplain"
@@ -210,12 +210,12 @@
           }}
         />
       </Form.Field>
-    </Ui::Fieldset>
+    </Ui::Question>
 
-    <Ui::Fieldset as |Q|>
-      <Q.legend>
+    <Ui::Question @group={{true}} as |Q|>
+      <Q.prompt>
         Is a <Ui::ExternalLink @href="https://a836-acris.nyc.gov/CP/">legal instrument</Ui::ExternalLink> associated with a previous CPC or CPC Chair action recorded against the project site?
-      </Q.legend>
+      </Q.prompt>
 
       <Form.Field
         @attribute="dcpRestrictivedeclaration"
@@ -244,12 +244,12 @@
           {{/if}}
         </RadioGroup>
       </Form.Field>
-    </Ui::Fieldset>
+    </Ui::Question>
 
-    <Ui::Fieldset as |Q|>
-      <Q.legend>
+    <Ui::Question @group={{true}} as |Q|>
+      <Q.prompt>
         Will a new legal instrument or modification of a current legal instrument be necessary to approve/implement these actions?
-      </Q.legend>
+      </Q.prompt>
 
       <Form.Field
         @attribute="dcpRestrictivedeclarationrequired"
@@ -263,6 +263,6 @@
             (hash code=717170002 label='Unsure at this time')}}
         />
       </Form.Field>
-    </Ui::Fieldset>
+    </Ui::Question>
   </Form.Section>
 {{/let}}

--- a/client/app/components/packages/pas-form/project-area.hbs
+++ b/client/app/components/packages/pas-form/project-area.hbs
@@ -4,10 +4,10 @@
       Project Area refers to all property that would be subject to the proposed actions.
     </p>
 
-    <Ui::Question @group={{true}} as |Q|>
-      <Q.prompt>
+    <Ui::Question @fieldset={{true}} as |Q|>
+      <Q.Prompt>
         Does the proposed Project, or portion thereof, require a NYC DEP Storm Water Construction Permit?
-      </Q.prompt>
+      </Q.Prompt>
 
       <Form.Field
         @attribute="dcpProposedprojectorportionconstruction"
@@ -24,10 +24,10 @@
       </Form.Field>
     </Ui::Question>
 
-    <Ui::Question @group={{true}} as |Q|>
-      <Q.prompt>
+    <Ui::Question @fieldset={{true}} as |Q|>
+      <Q.Prompt>
         Is the proposed Project Area located in a current or former <Ui::ExternalLink @href="https://www1.nyc.gov/site/hpd/services-and-information/urban-renewal.page">Urban Renewal Area</Ui::ExternalLink>?
-      </Q.prompt>
+      </Q.Prompt>
 
       <Form.Field
         @attribute="dcpUrbanrenewalarea"
@@ -55,10 +55,10 @@
       </Form.Field>
     </Ui::Question>
 
-    <Ui::Question @group={{true}} as |Q|>
-      <Q.prompt>
+    <Ui::Question @fieldset={{true}} as |Q|>
+      <Q.Prompt>
         What is the <Ui::ExternalLink @href="https://streets.planning.nyc.gov/about">Legal Street Frontage Status in the Project Area</Ui::ExternalLink>?
-      </Q.prompt>
+      </Q.Prompt>
 
       <Form.Field
         @attribute="dcpLegalstreetfrontage"
@@ -77,12 +77,12 @@
       </Form.Field>
     </Ui::Question>
 
-    <Ui::Question @group={{true}} as |Q|>
-      <Q.prompt>
+    <Ui::Question @fieldset={{true}} as |Q|>
+      <Q.Prompt>
         Do all land use actions meet
         <Ui::ExternalLink @href="https://govt.westlaw.com/nycrr/Document/I4ec3a767cd1711dda432a117e6e0f345?viewType=FullText&originationContext=documenttoc&transitionType=CategoryPageItem&contextData=(sc.Default)">SEQRA or CEQR criteria</Ui::ExternalLink>
         for Type II status?
-      </Q.prompt>
+      </Q.Prompt>
 
       <Form.Field
         @attribute="dcpLanduseactiontype2"
@@ -114,10 +114,10 @@
       </Form.Field>
     </Ui::Question>
 
-    <Ui::Question @group={{true}} as |Q|>
-      <Q.prompt>
+    <Ui::Question @fieldset={{true}} as |Q|>
+      <Q.Prompt>
         Is the proposed Project Area in an <Ui::ExternalLink @href="https://zola.planning.nyc.gov/">Industrial Business Zone</Ui::ExternalLink>?
-      </Q.prompt>
+      </Q.Prompt>
 
       <Form.Field
         @attribute="dcpProjectareaindustrialbusinesszone"
@@ -144,10 +144,10 @@
       </Form.Field>
     </Ui::Question>
 
-    <Ui::Question @group={{true}} as |Q|>
-      <Q.prompt>
+    <Ui::Question @fieldset={{true}} as |Q|>
+      <Q.Prompt>
         Is the proposed Project Area within or adjacent to a designated (City or State) <Ui::ExternalLink @href="https://zola.planning.nyc.gov/">Landmark or Historic District</Ui::ExternalLink>?
-      </Q.prompt>
+      </Q.Prompt>
 
       <Form.Field
         @attribute="dcpIsprojectarealandmark"
@@ -173,10 +173,10 @@
       </Form.Field>
     </Ui::Question>
 
-    <Ui::Question @group={{true}} as |Q|>
-      <Q.prompt>
+    <Ui::Question @fieldset={{true}} as |Q|>
+      <Q.Prompt>
         Is the proposed Project Area located within the <Ui::ExternalLink @href="https://dcp.maps.arcgis.com/apps/View/index.html?appid=90e3a9f927c2471483631a20e8a41d8d">NYC Coastal Zone</Ui::ExternalLink>?
-      </Q.prompt>
+      </Q.Prompt>
 
       <Form.Field
         @attribute="dcpProjectareacoastalzonelocatedin"
@@ -192,10 +192,10 @@
       </Form.Field>
     </Ui::Question>
 
-    <Ui::Question @group={{true}} as |Q|>
-      <Q.prompt>
+    <Ui::Question @fieldset={{true}} as |Q|>
+      <Q.Prompt>
         Is the Project Area located within the <Ui::ExternalLink @href="https://dcp.maps.arcgis.com/apps/webappviewer/index.html?id=1c37d271fba14163bbb520517153d6d5">1% annual chance floodplain</Ui::ExternalLink>?
-      </Q.prompt>
+      </Q.Prompt>
 
       <Form.Field
         @attribute="dcpProjectareaischancefloodplain"
@@ -212,10 +212,10 @@
       </Form.Field>
     </Ui::Question>
 
-    <Ui::Question @group={{true}} as |Q|>
-      <Q.prompt>
+    <Ui::Question @fieldset={{true}} as |Q|>
+      <Q.Prompt>
         Is a <Ui::ExternalLink @href="https://a836-acris.nyc.gov/CP/">legal instrument</Ui::ExternalLink> associated with a previous CPC or CPC Chair action recorded against the project site?
-      </Q.prompt>
+      </Q.Prompt>
 
       <Form.Field
         @attribute="dcpRestrictivedeclaration"
@@ -246,10 +246,10 @@
       </Form.Field>
     </Ui::Question>
 
-    <Ui::Question @group={{true}} as |Q|>
-      <Q.prompt>
+    <Ui::Question @fieldset={{true}} as |Q|>
+      <Q.Prompt>
         Will a new legal instrument or modification of a current legal instrument be necessary to approve/implement these actions?
-      </Q.prompt>
+      </Q.Prompt>
 
       <Form.Field
         @attribute="dcpRestrictivedeclarationrequired"

--- a/client/app/components/packages/pas-form/project-area.hbs
+++ b/client/app/components/packages/pas-form/project-area.hbs
@@ -1,6 +1,6 @@
 {{#let @form as |Form|}}
   <Form.Section @title="Project Area">
-    <p>
+    <p class="text-small">
       Project Area refers to all property that would be subject to the proposed actions.
     </p>
 
@@ -43,13 +43,16 @@
           @onChange={{fn (mut @form.saveableChanges.dcpUrbanareaname) ""}} as |value|
         >
           {{#if (eq value 717170000)}}
-            <label>
-              What is the name of the Urban Renewal Area?
+            <Ui::Question as |Q|>
+              <Q.Prompt>
+                What is the name of the Urban Renewal Area?
+              </Q.Prompt>
+
               <Form.Field
                 @attribute="dcpUrbanareaname"
                 @showCounter={{true}}
               />
-            </label>
+            </Ui::Question>
           {{/if}}
         </RadioGroup>
       </Form.Field>
@@ -98,17 +101,20 @@
           @onChange={{fn (mut @form.saveableChanges.dcpPleaseexplaintypeiienvreview) ""}} as |value|
         >
           {{#if (eq value 717170000)}}
-            <label>
-              Indicate which SEQRA or CEQR category each action fulfills
-              <small class="help-text display-block">
-                Ex: 617.5(c)(9)
-              </small>
+            <Ui::Question as |Q|>
+              <Q.Prompt>
+                Indicate which SEQRA or CEQR category each action fulfills
+                <small class="help-text display-block text-weight-normal">
+                  Ex: 617.5(c)(9)
+                </small>
+              </Q.Prompt>
+
               <Form.Field
                 @attribute="dcpPleaseexplaintypeiienvreview"
                 @showCounter={{true}}
                 maxlength="200"
               />
-            </label>
+            </Ui::Question>
           {{/if}}
         </RadioGroup>
       </Form.Field>
@@ -131,14 +137,17 @@
           @onChange={{fn (mut @form.saveableChanges.dcpProjectareaindutrialzonename) ""}} as |value|
         >
           {{#if value}}
-            <label>
-              Name of Industrial Business Zone
+            <Ui::Question as |Q|>
+              <Q.Prompt>
+                Name of Industrial Business Zone
+              </Q.Prompt>
+
               <Form.Field
                 @attribute="dcpProjectareaindutrialzonename"
                 @maxlength="200"
                 @showCounter={{true}}
               />
-            </label>
+            </Ui::Question>
           {{/if}}
         </RadioGroup>
       </Form.Field>
@@ -161,13 +170,16 @@
           @onChange={{fn (mut @form.saveableChanges.dcpProjectarealandmarkname) ""}} as |value|
         >
           {{#if value}}
-            <label>
-              Name of Landmark or Historic District
+            <Ui::Question as |Q|>
+              <Q.Prompt>
+                Name of Landmark or Historic District
+              </Q.Prompt>
+
               <Form.Field
                 @attribute="dcpProjectarealandmarkname"
                 @showCounter={{true}}
               />
-            </label>
+            </Ui::Question>
           {{/if}}
         </RadioGroup>
       </Form.Field>
@@ -230,17 +242,20 @@
           @onChange={{fn (mut @form.saveableChanges.dcpCityregisterfilenumber) null}} as |value|
         >
           {{#if value}}
-            <label>
-              <strong>City Register file number or other identifier</strong>
-              <small class="help-text display-block">
-                Feel free to attach a copy of the legal instrument in the Attachments section.
-              </small>
+            <Ui::Question as |Q|>
+              <Q.Prompt>
+                City Register file number or other identifier
+                <small class="help-text display-block text-weight-normal">
+                  Feel free to attach a copy of the legal instrument in the Attachments section.
+                </small>
+              </Q.Prompt>
+
               <Form.Field
                 @attribute="dcpCityregisterfilenumber"
                 @maxlength="25"
                 @showCounter={{true}}
               />
-            </label>
+            </Ui::Question>
           {{/if}}
         </RadioGroup>
       </Form.Field>

--- a/client/app/components/packages/pas-form/project-description.hbs
+++ b/client/app/components/packages/pas-form/project-description.hbs
@@ -4,54 +4,73 @@
       For complex proposals, feel free to upload a draft document (in the Attachments section) explaining this information instead of filling out the form inputs.
     </p>
 
-    <label>
-      <strong>Description of the proposed development being facilitated by the land use actions</strong>
+    <Ui::Question as |Q|>
+      <Q.Prompt>
+        Description of the proposed development being facilitated by the land use actions
+      </Q.Prompt>
+
       <Form.Field
         @attribute="dcpProjectdescriptionproposeddevelopment"
         @type="text-area"
       />
-    </label>
-    <label>
-      <strong>Why is this application being proposed? What is the legal, environmental, or land use background?</strong>
+    </Ui::Question>
+
+    <Ui::Question as |Q|>
+      <Q.Prompt>
+        Why is this application being proposed? What is the legal, environmental, or land use background?
+      </Q.Prompt>
+
       <Form.Field
         @attribute="dcpProjectdescriptionbackground"
         @type="text-area"
       />
-    </label>
+    </Ui::Question>
 
-    <label>
-      <strong>What is the land use rationale for all the proposed actions?</strong>
+    <Ui::Question as |Q|>
+      <Q.Prompt>
+        What is the land use rationale for all the proposed actions?
+      </Q.Prompt>
+
       <Form.Field
         @attribute="dcpProjectdescriptionproposedactions"
         @type="text-area"
       />
-    </label>
+    </Ui::Question>
 
-    <label>
-      <strong>Description of existing land uses and structures in the proposed Project Area and Development Site</strong>
+    <Ui::Question as |Q|>
+      <Q.Prompt>
+        Description of existing land uses and structures in the proposed Project Area and Development Site
+      </Q.Prompt>
+
       <Form.Field
         @attribute="dcpProjectdescriptionproposedarea"
         @type="text-area"
       />
-    </label>
+    </Ui::Question>
 
-    <label>
-      <strong>Description of land uses and built context in surrounding area (within 1000 ft)</strong>
+    <Ui::Question as |Q|>
+      <Q.Prompt>
+        Description of land uses and built context in surrounding area (within 1000 ft)
+      </Q.Prompt>
+
       <Form.Field
         @attribute="dcpProjectdescriptionsurroundingarea"
         @type="text-area"
       />
-    </label>
+    </Ui::Question>
 
-    <label>
-      <strong>Description of proposed CEQR scope</strong>
-      <small class="help-text display-block">
-        Include to expedite CEQR guidance: If proposed actions are not approved, what is the applicant’s as-of-right development (CEQR “no-action”) proposal? What would be expected to occur on non-applicant-controlled sites because of the Proposed Actions (CEQR “with-action”)?
-      </small>
+    <Ui::Question as |Q|>
+      <Q.Prompt>
+        Description of proposed CEQR scope
+        <small class="help-text display-block text-weight-normal">
+          Include to expedite CEQR guidance: If proposed actions are not approved, what is the applicant’s as-of-right development (CEQR “no-action”) proposal? What would be expected to occur on non-applicant-controlled sites because of the Proposed Actions (CEQR “with-action”)?
+        </small>
+      </Q.Prompt>
+
       <Form.Field
         @attribute="dcpProjectattachmentsotherinformation"
         @type="text-area"
       />
-    </label>
+    </Ui::Question>
   </Form.Section>
 {{/let}}

--- a/client/app/components/packages/pas-form/project-geography.hbs
+++ b/client/app/components/packages/pas-form/project-geography.hbs
@@ -17,15 +17,18 @@
       />
     </div>
 
-    <label>
-      <strong>Description of geography</strong>
-      <small class="help-text display-block">
-        Fill in if the project area and/or development site is irregular, especially large, or does not consist of tax lots.
-      </small>
-        <Form.Field
-          @attribute="dcpDescriptionofprojectareageography"
-          @type="text-area"
-        />
-    </label>
+    <Ui::Question as |Q|>
+      <Q.prompt>
+        Description of geography
+        <small class="help-text display-block text-weight-normal">
+          Fill in if the project area and/or development site is irregular, especially large, or does not consist of tax lots.
+        </small>
+      </Q.prompt>
+
+      <Form.Field
+        @attribute="dcpDescriptionofprojectareageography"
+        @type="text-area"
+      />
+    </Ui::Question>
   </Form.Section>
 {{/let}}

--- a/client/app/components/packages/pas-form/project-geography.hbs
+++ b/client/app/components/packages/pas-form/project-geography.hbs
@@ -18,12 +18,12 @@
     </div>
 
     <Ui::Question as |Q|>
-      <Q.prompt>
+      <Q.Prompt>
         Description of geography
         <small class="help-text display-block text-weight-normal">
           Fill in if the project area and/or development site is irregular, especially large, or does not consist of tax lots.
         </small>
-      </Q.prompt>
+      </Q.Prompt>
 
       <Form.Field
         @attribute="dcpDescriptionofprojectareageography"

--- a/client/app/components/packages/pas-form/project-information.hbs
+++ b/client/app/components/packages/pas-form/project-information.hbs
@@ -1,8 +1,11 @@
 {{#let @form as |Form|}}
   <Form.Section @title="Project Information">
-    <label>
-      <strong>Project Name</strong>
+    <Ui::Question as |Q|>
+      <Q.Prompt>
+        Project Name
+      </Q.Prompt>
+
       <Form.Field @attribute="dcpRevisedprojectname" />
-    </label>
+    </Ui::Question>
   </Form.Section>
 {{/let}}

--- a/client/app/components/packages/pas-form/proposed-development-site.hbs
+++ b/client/app/components/packages/pas-form/proposed-development-site.hbs
@@ -5,9 +5,9 @@
     </p>
 
     <Ui::Question as |Q|>
-      <Q.prompt>
+      <Q.Prompt>
         In what year do you expect the development to complete?
-      </Q.prompt>
+      </Q.Prompt>
       <Form.Field
         @attribute="dcpEstimatedcompletiondate"
         @maxlength="4"
@@ -15,11 +15,11 @@
       {{!-- QUESTION: Should this be a date picker? --}}
     </Ui::Question>
 
-    <Ui::Question @group={{true}} as |Q|>
-      <Q.prompt>
+    <Ui::Question @fieldset={{true}} as |Q|>
+      <Q.Prompt>
         What type of development is proposed?
         <small class="text-weight-normal">(select all that apply)</small>
-      </Q.prompt>
+      </Q.Prompt>
 
       <ul class="no-bullet no-margin">
         {{#each (array
@@ -64,11 +64,11 @@
       {{/if}}
     </Ui::Question>
 
-    <Ui::Question @group={{true}} as |Q|>
-      <Q.prompt>
+    <Ui::Question @fieldset={{true}} as |Q|>
+      <Q.Prompt>
         Is the Development Site in an
         <Ui::ExternalLink @href="https://zola.planning.nyc.gov/">Inclusionary Housing Designated Area/Mandatory Inclusionary Housing Area</Ui::ExternalLink>?
-      </Q.prompt>
+      </Q.Prompt>
 
       <p class="text-small">
         Refer to <Ui::ExternalLink @href="https://zr.planning.nyc.gov/appendix-f-inclusionary-housing-designated-areas-and-mandatory-inclusionary-housing-areas">Appendix F</Ui::ExternalLink> of the Zoning Resolution for full list of all inclusionary housing areas which are areas that incentivize or require affordable housing in certain areas.
@@ -95,10 +95,10 @@
       </Form.Field>
     </Ui::Question>
 
-    <Ui::Question @group={{true}} as |Q|>
-      <Q.prompt>
+    <Ui::Question @fieldset={{true}} as |Q|>
+      <Q.Prompt>
         Does the proposed development involve discretionary funding for Affordable Housing Units?
-      </Q.prompt>
+      </Q.Prompt>
 
       <Form.Field
         @attribute="dcpDiscressionaryfundingforffordablehousing"
@@ -113,10 +113,10 @@
           @onChange={{fn (mut @form.saveableChanges.dcpHousingunittype) ""}} as |value|
         >
           {{#if (eq value 717170000)}}
-            <Ui::Question @group={{true}} as |Q|>
-              <Q.prompt>
+            <Ui::Question @fieldset={{true}} as |Q|>
+              <Q.Prompt>
                 Funding source
-              </Q.prompt>
+              </Q.Prompt>
 
               <Form.Field
                 @attribute="dcpHousingunittype"

--- a/client/app/components/packages/pas-form/proposed-development-site.hbs
+++ b/client/app/components/packages/pas-form/proposed-development-site.hbs
@@ -57,10 +57,12 @@
         </li>
       </ul>
       {{#if @form.saveableChanges.dcpProposeddevelopmentsiteinfoother}}
-        <label>
-          Explain:
+        <Ui::Question as |Q|>
+          <Q.prompt>
+            Explain:
+          </Q.prompt>
           <Form.Field @attribute="dcpProposeddevelopmentsiteotherexplanation"/>
-        </label>
+        </Ui::Question>
       {{/if}}
     </Ui::Question>
 
@@ -86,10 +88,12 @@
           @onChange={{fn (mut @form.saveableChanges.dcpInclusionaryhousingdesignatedareaname) ""}} as |value|
         >
           {{#if value}}
-            <label>
-              Name of Inclusionary Housing Designated Area/Mandatory Inclusionary Housing Area
+            <Ui::Question as |Q|>
+              <Q.prompt>
+                Name of Inclusionary Housing Designated Area/Mandatory Inclusionary Housing Area
+              </Q.prompt>
               <Form.Field @attribute="dcpInclusionaryhousingdesignatedareaname"/>
-            </label>
+            </Ui::Question>
           {{/if}}
         </RadioGroup>
       </Form.Field>

--- a/client/app/components/packages/pas-form/proposed-development-site.hbs
+++ b/client/app/components/packages/pas-form/proposed-development-site.hbs
@@ -58,9 +58,9 @@
       </ul>
       {{#if @form.saveableChanges.dcpProposeddevelopmentsiteinfoother}}
         <Ui::Question as |Q|>
-          <Q.prompt>
+          <Q.Prompt>
             Explain:
-          </Q.prompt>
+          </Q.Prompt>
           <Form.Field @attribute="dcpProposeddevelopmentsiteotherexplanation"/>
         </Ui::Question>
       {{/if}}
@@ -89,9 +89,9 @@
         >
           {{#if value}}
             <Ui::Question as |Q|>
-              <Q.prompt>
+              <Q.Prompt>
                 Name of Inclusionary Housing Designated Area/Mandatory Inclusionary Housing Area
-              </Q.prompt>
+              </Q.Prompt>
               <Form.Field @attribute="dcpInclusionaryhousingdesignatedareaname"/>
             </Ui::Question>
           {{/if}}

--- a/client/app/components/packages/pas-form/proposed-development-site.hbs
+++ b/client/app/components/packages/pas-form/proposed-development-site.hbs
@@ -4,20 +4,22 @@
       <b>Development Site</b> refers to all property to be developed as part of the applicant’s specific proposal which the land use actions would facilitate. Typically, the Development Site and the Project Area will comprise the same property(ies) unless the application is requesting a zoning map amendment covering an area greater than an applicant’s property to be developed or a large-scale special approval involving multiple tax lots. In these cases, the Development Site may be one or several tax lots within a broader Project Area.
     </p>
 
-    <label>
-      <strong>In what year do you expect the development to complete?</strong>
+    <Ui::Question as |Q|>
+      <Q.prompt>
+        In what year do you expect the development to complete?
+      </Q.prompt>
       <Form.Field
         @attribute="dcpEstimatedcompletiondate"
         @maxlength="4"
       />
       {{!-- QUESTION: Should this be a date picker? --}}
-    </label>
+    </Ui::Question>
 
-    <Ui::Fieldset as |Q|>
-      <Q.legend>
+    <Ui::Question @group={{true}} as |Q|>
+      <Q.prompt>
         What type of development is proposed?
         <small class="text-weight-normal">(select all that apply)</small>
-      </Q.legend>
+      </Q.prompt>
 
       <ul class="no-bullet no-margin">
         {{#each (array
@@ -60,13 +62,13 @@
           <Form.Field @attribute="dcpProposeddevelopmentsiteotherexplanation"/>
         </label>
       {{/if}}
-    </Ui::Fieldset>
+    </Ui::Question>
 
-    <Ui::Fieldset as |Q|>
-      <Q.legend>
+    <Ui::Question @group={{true}} as |Q|>
+      <Q.prompt>
         Is the Development Site in an
         <Ui::ExternalLink @href="https://zola.planning.nyc.gov/">Inclusionary Housing Designated Area/Mandatory Inclusionary Housing Area</Ui::ExternalLink>?
-      </Q.legend>
+      </Q.prompt>
 
       <p class="text-small">
         Refer to <Ui::ExternalLink @href="https://zr.planning.nyc.gov/appendix-f-inclusionary-housing-designated-areas-and-mandatory-inclusionary-housing-areas">Appendix F</Ui::ExternalLink> of the Zoning Resolution for full list of all inclusionary housing areas which are areas that incentivize or require affordable housing in certain areas.
@@ -91,12 +93,12 @@
           {{/if}}
         </RadioGroup>
       </Form.Field>
-    </Ui::Fieldset>
+    </Ui::Question>
 
-    <Ui::Fieldset as |Q|>
-      <Q.legend>
+    <Ui::Question @group={{true}} as |Q|>
+      <Q.prompt>
         Does the proposed development involve discretionary funding for Affordable Housing Units?
-      </Q.legend>
+      </Q.prompt>
 
       <Form.Field
         @attribute="dcpDiscressionaryfundingforffordablehousing"
@@ -111,10 +113,10 @@
           @onChange={{fn (mut @form.saveableChanges.dcpHousingunittype) ""}} as |value|
         >
           {{#if (eq value 717170000)}}
-            <Ui::Fieldset as |Q|>
-              <Q.legend>
+            <Ui::Question @group={{true}} as |Q|>
+              <Q.prompt>
                 Funding source
-              </Q.legend>
+              </Q.prompt>
 
               <Form.Field
                 @attribute="dcpHousingunittype"
@@ -129,10 +131,10 @@
                   }}
                 />
               </Form.Field>
-            </Ui::Fieldset>
+            </Ui::Question>
           {{/if}}
         </RadioGroup>
       </Form.Field>
-    </Ui::Fieldset>
+    </Ui::Question>
   </Form.Section>
 {{/let}}

--- a/client/app/components/project-geography.hbs
+++ b/client/app/components/project-geography.hbs
@@ -24,7 +24,7 @@
   {{#let @form as |Form|}}
     <Form.SaveableForm @model={{bbl}} as |bblForm|>
       <Ui::Question class="fieldset relative scale-fade-in" as |Q|>
-        <Q.prompt data-test-bbl-title="{{bbl.dcpBblnumber}}">
+        <Q.Prompt data-test-bbl-title="{{bbl.dcpBblnumber}}">
           {{bbl.dcpBblnumber}}
           <span class="text-weight-normal">
             {{#if bbl.temporaryAddressLabel}}
@@ -32,12 +32,12 @@
             {{/if}}
             <Ui::ExternalLink @href="https://zola.planning.nyc.gov/bbl/{{bbl.dcpBblnumber}}">View in ZoLa</Ui::ExternalLink>
           </span>
-        </Q.prompt>
+        </Q.Prompt>
 
-        <Ui::Question @group={{true}} as |Q|>
-          <Q.prompt data-test-development-site-question="{{bbl.dcpBblnumber}}-{{bblForm.saveableChanges.dcpDevelopmentsite}}">
+        <Ui::Question @fieldset={{true}} as |Q|>
+          <Q.Prompt data-test-development-site-question="{{bbl.dcpBblnumber}}-{{bblForm.saveableChanges.dcpDevelopmentsite}}">
             Is this BBL part of the development site?
-          </Q.prompt>
+          </Q.Prompt>
 
           <bblForm.Field
             @attribute="dcpDevelopmentsite"
@@ -59,10 +59,10 @@
           </bblForm.Field>
         </Ui::Question>
 
-        <Ui::Question @group={{true}} as |Q|>
-          <Q.prompt data-test-partial-lot-question="{{bbl.dcpBblnumber}}-{{bblForm.saveableChanges.dcpPartiallot}}">
+        <Ui::Question @fieldset={{true}} as |Q|>
+          <Q.Prompt data-test-partial-lot-question="{{bbl.dcpBblnumber}}-{{bblForm.saveableChanges.dcpPartiallot}}">
             Is only a portion of this lot included in the project area?
-          </Q.prompt>
+          </Q.Prompt>
 
           <bblForm.Field
             @attribute="dcpPartiallot"

--- a/client/app/components/project-geography.hbs
+++ b/client/app/components/project-geography.hbs
@@ -23,8 +23,8 @@
 {{#each @bbls as |bbl|}}
   {{#let @form as |Form|}}
     <Form.SaveableForm @model={{bbl}} as |bblForm|>
-      <Ui::Fieldset class="fieldset relative scale-fade-in" as |Q|>
-        <Q.legend data-test-bbl-title="{{bbl.dcpBblnumber}}">
+      <Ui::Question class="fieldset relative scale-fade-in" as |Q|>
+        <Q.prompt data-test-bbl-title="{{bbl.dcpBblnumber}}">
           {{bbl.dcpBblnumber}}
           <span class="text-weight-normal">
             {{#if bbl.temporaryAddressLabel}}
@@ -32,12 +32,12 @@
             {{/if}}
             <Ui::ExternalLink @href="https://zola.planning.nyc.gov/bbl/{{bbl.dcpBblnumber}}">View in ZoLa</Ui::ExternalLink>
           </span>
-        </Q.legend>
+        </Q.prompt>
 
-        <Ui::Fieldset as |Q|>
-          <Q.legend data-test-development-site-question="{{bbl.dcpBblnumber}}-{{bblForm.saveableChanges.dcpDevelopmentsite}}">
+        <Ui::Question @group={{true}} as |Q|>
+          <Q.prompt data-test-development-site-question="{{bbl.dcpBblnumber}}-{{bblForm.saveableChanges.dcpDevelopmentsite}}">
             Is this BBL part of the development site?
-          </Q.legend>
+          </Q.prompt>
 
           <bblForm.Field
             @attribute="dcpDevelopmentsite"
@@ -57,12 +57,12 @@
               No
             </RadioButton>
           </bblForm.Field>
-        </Ui::Fieldset>
+        </Ui::Question>
 
-        <Ui::Fieldset as |Q|>
-          <Q.legend data-test-partial-lot-question="{{bbl.dcpBblnumber}}-{{bblForm.saveableChanges.dcpPartiallot}}">
+        <Ui::Question @group={{true}} as |Q|>
+          <Q.prompt data-test-partial-lot-question="{{bbl.dcpBblnumber}}-{{bblForm.saveableChanges.dcpPartiallot}}">
             Is only a portion of this lot included in the project area?
-          </Q.legend>
+          </Q.prompt>
 
           <bblForm.Field
             @attribute="dcpPartiallot"
@@ -82,7 +82,7 @@
               No
             </RadioButton>
           </bblForm.Field>
-        </Ui::Fieldset>
+        </Ui::Question>
 
         <button
           type="button"
@@ -93,7 +93,7 @@
           Delete BBL
           <FaIcon @icon="times" @prefix="fas" @fixedWidth={{true}} />
         </button>
-      </Ui::Fieldset>
+      </Ui::Question>
     </Form.SaveableForm>
   {{/let}}
 {{/each}}

--- a/client/app/components/ui/fieldset.hbs
+++ b/client/app/components/ui/fieldset.hbs
@@ -1,5 +1,0 @@
-<fieldset class="medium-margin-bottom" ...attributes>
-  {{yield (hash
-    legend=(component 'ui/fieldset-legend')
-  )}}
-</fieldset>

--- a/client/app/components/ui/label-text.hbs
+++ b/client/app/components/ui/label-text.hbs
@@ -1,0 +1,3 @@
+<span class="text-weight-bold" ...attributes>
+  {{yield}}
+</span>

--- a/client/app/components/ui/question.hbs
+++ b/client/app/components/ui/question.hbs
@@ -1,18 +1,13 @@
-{{#let
-  (concat 'ui/' (if @group 'fieldset-legend' 'label-text'))
-  as |promptComponent|
-}}
-  {{#if @group}}
-    <fieldset class="medium-margin-bottom" ...attributes>
-      {{yield (hash
-        prompt=(component promptComponent)
-      )}}
-    </fieldset>
+{{#if @fieldset}}
+  <fieldset class="medium-margin-bottom" ...attributes>
+    {{yield (hash
+      Prompt=(component 'ui/fieldset-legend')
+    )}}
+  </fieldset>
   {{else}}
-    <label class="medium-margin-bottom" ...attributes>
-      {{yield (hash
-        prompt=(component promptComponent)
-      )}}
-    </label>
-  {{/if}}
-{{/let}}
+  <label class="medium-margin-bottom" ...attributes>
+    {{yield (hash
+      Prompt=(component 'ui/label-text')
+    )}}
+  </label>
+{{/if}}

--- a/client/app/components/ui/question.hbs
+++ b/client/app/components/ui/question.hbs
@@ -1,0 +1,18 @@
+{{#let
+  (concat 'ui/' (if @group 'fieldset-legend' 'label-text'))
+  as |promptComponent|
+}}
+  {{#if @group}}
+    <fieldset class="medium-margin-bottom" ...attributes>
+      {{yield (hash
+        prompt=(component promptComponent)
+      )}}
+    </fieldset>
+  {{else}}
+    <label class="medium-margin-bottom" ...attributes>
+      {{yield (hash
+        prompt=(component promptComponent)
+      )}}
+    </label>
+  {{/if}}
+{{/let}}

--- a/client/tests/acceptance/user-can-click-pas-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-pas-form-edit-test.js
@@ -432,7 +432,7 @@ module('Acceptance | user can click pas-form edit', function(hooks) {
     await click('[data-test-radio-option="Organization"]');
 
     // organization input should appear after user toggles to "Organization"
-    assert.dom('[data-test-applicant-organization]').hasText('Organization');
+    assert.dom('[data-test-applicant-organization]').hasText('Organization Name');
 
     await saveForm();
 

--- a/client/tests/integration/components/ui/fieldset-legend-test.js
+++ b/client/tests/integration/components/ui/fieldset-legend-test.js
@@ -10,15 +10,15 @@ module('Integration | Component | ui/fieldset-legend', function(hooks) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    await render(hbs`<Ui::QuestionLegend />`);
+    await render(hbs`<Ui::FieldsetLegend />`);
 
     assert.equal(this.element.textContent.trim(), '');
 
     // Template block usage:
     await render(hbs`
-      <Ui::QuestionLegend>
+      <Ui::FieldsetLegend>
         template block text
-      </Ui::QuestionLegend>
+      </Ui::FieldsetLegend>
     `);
 
     assert.equal(this.element.textContent.trim(), 'template block text');

--- a/client/tests/integration/components/ui/label-text-test.js
+++ b/client/tests/integration/components/ui/label-text-test.js
@@ -3,22 +3,22 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
-module('Integration | Component | ui/fieldset-legend', function(hooks) {
+module('Integration | Component | ui/label-text', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    await render(hbs`<Ui::QuestionLegend />`);
+    await render(hbs`<Ui::LabelText />`);
 
     assert.equal(this.element.textContent.trim(), '');
 
     // Template block usage:
     await render(hbs`
-      <Ui::QuestionLegend>
+      <Ui::LabelText>
         template block text
-      </Ui::QuestionLegend>
+      </Ui::LabelText>
     `);
 
     assert.equal(this.element.textContent.trim(), 'template block text');

--- a/client/tests/integration/components/ui/question-test.js
+++ b/client/tests/integration/components/ui/question-test.js
@@ -3,22 +3,22 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
-module('Integration | Component | ul/fieldset', function(hooks) {
+module('Integration | Component | ul/question', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    await render(hbs`<Ui::Fieldset />`);
+    await render(hbs`<Ui::Question />`);
 
     assert.equal(this.element.textContent.trim(), '');
 
     // Template block usage:
     await render(hbs`
-      <Ui::Fieldset>
+      <Ui::Question>
         template block text
-      </Ui::Fieldset>
+      </Ui::Question>
     `);
 
     assert.equal(this.element.textContent.trim(), 'template block text');


### PR DESCRIPTION
This PR refactors the `<Ui::Fieldset>` component so that it works for all form questions (including text inputs and textareas, which need to be wrapped in a `<label>` instead of a `<fieldset>`). 

The new API is: 

```
<Ui::Question [@group={{true}}] as |Q|>
  <Q.prompt>
  </Q.prompt>
  ...
</Ui::Question>
```

If you pass the optional `@group={{true}}`, the component will render a `<fieldset>` element instead of the default `<label>` element, and call the `Ui::label-text` component instead of the default `Ui::FieldsetLegend` component.

This PR also 
- Changes the validation message classes to follow the style guide
- Nixes some unnecessary CSS