### PR TITLE
234 Add Attached Documents section for RWCDS Form

### DIFF
--- a/client/app/components/packages/rwcds-form/attached-documents.hbs
+++ b/client/app/components/packages/rwcds-form/attached-documents.hbs
@@ -1,0 +1,57 @@
+<@form.Section @title="Attached Documents">
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-12">
+      <p>
+        Please attach the following required documents.
+      </p>
+      <ul class="text-small">
+        <li class="small-margin-bottom">
+          <Ui::DownloadLink @href="https://www1.nyc.gov/assets/planning/download/office/applicants/applicant-portal/part2-rwcds-analysis-framework-table.xlsx">
+            RWCDS Analysis Framework Table
+          </Ui::DownloadLink>
+        </li>
+        <li class="small-margin-bottom">
+          <Ui::DownloadLink @href="https://www1.nyc.gov/assets/planning/download/office/applicants/applicant-portal/part3-rwcds-analysis-framework-spreadsheet.xlsx">
+            Official Zoning Map
+          </Ui::DownloadLink>
+        </li>
+        <li class="small-margin-bottom">
+          Massing diagrams&nbsp;
+          <small>
+            (if the future With-Action Scenario does not maximize all available bulk and/or FAR)
+          </small>
+        </li>
+      </ul>
+      <h5>
+        A map of the directly affected area can aid the review of the proposed actions. If maps are provided, they should not exceed 11x17”, and each map must clearly include:
+      </h5>
+      <ol class="text-small">
+        <li class="small-margin-bottom">
+          The boundaries of the directly affected area or areas
+        </li>
+        <li class="small-margin-bottom">
+          A 400-foot radius drawn from the outer boundaries of the project site
+        </li>
+        <li class="small-margin-bottom">
+          A title, scale and legend
+        </li>
+        <li class="small-margin-bottom">
+          Identification/label of any applicant-owned sites and additional projected and/or potential development sites
+        </li>
+        <li class="small-margin-bottom">
+          Labeled streets and labeled tax lots, where applicable
+        </li>
+      </ol>
+      <h5>
+        Additional materials such as zoning maps, massing diagrams, illustrative drawings, etc. that help explain the proposed project may also be submitted.
+      </h5>
+    </div>
+  </div>
+
+  The size limit for each file is 50 MB. You can upload up to 1 GB of files.
+  <Packages::Attachments
+    @package={{@model.package}}
+    @fileManager={{@model.package.fileManager}}
+    data-test-section="attachments"
+  />
+</@form.Section>

--- a/client/app/components/packages/rwcds-form/edit.hbs
+++ b/client/app/components/packages/rwcds-form/edit.hbs
@@ -41,12 +41,12 @@
             Analysis
         </h2>
       </section>
-      <section class="form-section">
-        <h2 class="section-header">
-          <span id="attached-documents" class="section-anchor"></span>
-          Attached Documents
-        </h2>
-      </section>
+
+      <Packages::RwcdsForm::AttachedDocuments
+        @form={{saveableForm}}
+        @model={{@package.rwcdsForm}}
+      />
+
     </div>
      <StickySidebar
 

--- a/client/app/components/packages/rwcds-form/edit.js
+++ b/client/app/components/packages/rwcds-form/edit.js
@@ -16,5 +16,7 @@ export default class PackagesRwcdsFormEditComponent extends Component {
     } catch (error) {
       console.log('Save RWCDS package error:', error);
     }
+
+    this.args.package.refreshExistingDocuments();
   }
 }

--- a/client/app/components/ui/download-link.hbs
+++ b/client/app/components/ui/download-link.hbs
@@ -1,0 +1,4 @@
+<a href={{@href}} target="_blank" rel="noopener noreferrer" class="download" ...attributes>
+  {{yield~}}
+  <FaIcon @icon="download" @prefix="fas" @fixedWidth={{true}} />
+</a>


### PR DESCRIPTION
Creates an attached-documents component for RWCDS form, similar to the one for PAS form. Creates an "download link" component, which is similar to the "external link" component, to support the attached-documents text.