### PR TITLE
RWCDS show route and template

### DIFF
--- a/client/app/components/packages/pas-form/show.hbs
+++ b/client/app/components/packages/pas-form/show.hbs
@@ -22,22 +22,29 @@
       <ul class="no-bullet">
         {{#each @package.pasForm.applicants as |applicant|}}
           <li class="ruled-adjacent">
-            <strong>
+            <h4 class="no-margin">
+              {{#if applicant.dcpOrganization}}
+                {{applicant.dcpOrganization}} |
+              {{/if}}
               {{applicant.dcpFirstname}} {{applicant.dcpLastname}}
-            </strong>
-            {{#if applicant.dcpOrganization}}
-              | {{applicant.dcpOrganization}}
-            {{/if}}
+            </h4>
             {{#if applicant.dcpEmail}}
-              <br>{{applicant.dcpEmail}}
+              <div>
+                <FaIcon @icon="envelope" class="text-gray" @fixedWidth={{true}} />
+                {{applicant.dcpEmail}}
+              </div>
             {{/if}}
             {{#if applicant.dcpAddress}}
-              <br><FaIcon @icon="map-marker-alt" class="text-gray" />
-              {{applicant.dcpAddress}}, {{applicant.dcpCity}}, {{applicant.dcpState}} {{applicant.dcpZipcode}}
+              <div>
+                <FaIcon @icon="map-marker-alt" class="text-gray" @fixedWidth={{true}} />
+                {{applicant.dcpAddress}}, {{applicant.dcpCity}}, {{applicant.dcpState}} {{applicant.dcpZipcode}}
+              </div>
             {{/if}}
             {{#if applicant.dcpPhone}}
-              <br><FaIcon @icon="phone-square" class="text-gray" />
-              {{applicant.dcpPhone}}
+              <div>
+                <FaIcon @icon="phone-square" class="text-gray" @fixedWidth={{true}} />
+                {{applicant.dcpPhone}}
+              </div>
             {{/if}}
           </li>
         {{/each}}
@@ -49,48 +56,52 @@
         <span id="project-geography" class="section-anchor"></span>
         Project Geography
       </h2>
-      <h3>
-        BBLs
-      </h3>
-      <ul class="no-bullet">
-        {{#each @package.pasForm.bbls as |bbl|}}
-          <li class="ruled-adjacent tight">
-            <strong>
-              {{bbl.dcpBblnumber}}
-            </strong>
-            {{#if bbl.dcpDevelopmentsite}}
-              <span class="text-silver">|</span> part of the development site
-            {{/if}}
-            {{#if bbl.dcpPartiallot}}
-              <span class="text-silver">|</span> partial lot
-            {{/if}}
-          </li>
-        {{/each}}
-      </ul>
-      <h3>
-        Addresses
-      </h3>
-      <ul class="no-bullet">
-        {{#each @package.pasForm.projectAddresses as |address idx|}}
-          <li
-            class="ruled-adjacent tight"
-            data-test-projectAddress={{idx}}
-          >
-            <strong>
-              {{address.dcpConcatenatedaddressvalidated}}
-            </strong>
-          </li>
-        {{/each}}
-      </ul>
+
+      <Ui::Answer as |A|>
+        <A.Prompt>
+          BBLs:
+        </A.Prompt>
+        <A.Field>
+          <ul>
+            {{#each @package.pasForm.bbls as |bbl|}}
+              <li>
+                {{bbl.dcpBblnumber}}
+                {{#if bbl.dcpDevelopmentsite}}
+                  <span class="text-silver">|</span> part of the development site
+                {{/if}}
+                {{#if bbl.dcpPartiallot}}
+                  <span class="text-silver">|</span> partial lot
+                {{/if}}
+              </li>
+            {{/each}}
+          </ul>
+        </A.Field>
+      </Ui::Answer>
+
+      <Ui::Answer as |A|>
+        <A.Prompt>
+          Addresses:
+        </A.Prompt>
+        <A.Field>
+          <ul>
+            {{#each @package.pasForm.projectAddresses as |address idx|}}
+              <li data-test-projectAddress={{idx}}>
+                {{address.dcpConcatenatedaddressvalidated}}
+              </li>
+            {{/each}}
+          </ul>
+        </A.Field>
+      </Ui::Answer>
 
       {{#if @package.pasForm.dcpDescriptionofprojectareageography}}
-        <p class="ruled-top">
-          <strong>
+        <Ui::Answer as |A|>
+          <A.Prompt>
             Description of geography:
-          </strong>
-          <br />
-          {{@package.pasForm.dcpDescriptionofprojectareageography}}
-        </p>
+          </A.Prompt>
+          <A.Field>
+            {{@package.pasForm.dcpDescriptionofprojectareageography}}
+          </A.Field>
+        </Ui::Answer>
       {{/if}}
     </section>
 
@@ -100,87 +111,101 @@
         Proposed Land Use Actions
       </h2>
 
-      <ul class="no-bullet">
+      <ul>
         {{#if @package.pasForm.dcpPfacquisitionofrealproperty}}
-          <li class="ruled-adjacent">
+          <li>
             <strong>Acquisition of Real Property</strong>
             {{@package.pasForm.dcpPfacquisitionofrealproperty}}
           </li>
         {{/if}}
+
         {{#if @package.pasForm.dcpPfchangeincitymap}}
-          <li class="ruled-adjacent">
+          <li>
             <strong>Change in CityMap</strong>
             ({{@package.pasForm.dcpPfchangeincitymap}})
           </li>
         {{/if}}
+
         {{#if @package.pasForm.dcpPfconcession}}
-          <li class="ruled-adjacent">
+          <li>
             <strong>Concession</strong>
             ({{@package.pasForm.dcpPfconcession}})
           </li>
         {{/if}}
+
         {{#if @package.pasForm.dcpPfdispositionofrealproperty}}
-          <li class="ruled-adjacent">
+          <li>
             <strong>Disposition of Real Property</strong>
             ({{@package.pasForm.dcpPfdispositionofrealproperty}})
           </li>
         {{/if}}
+
         {{#if @package.pasForm.dcpPffranchise}}
-          <li class="ruled-adjacent">
+          <li>
             <strong>Franchise</strong>
             ({{@package.pasForm.dcpPffranchise}})
           </li>
         {{/if}}
+
         {{#if @package.pasForm.dcpPfhousingplanandproject}}
-          <li class="ruled-adjacent">
+          <li>
             <strong>Housing Plan & Project</strong>
             ({{@package.pasForm.dcpPfhousingplanandproject}})
           </li>
         {{/if}}
+
         {{#if @package.pasForm.dcpPflandfill}}
-          <li class="ruled-adjacent">
+          <li>
             <strong>Landfill</strong>
             ({{@package.pasForm.dcpPflandfill}})
           </li>
         {{/if}}
+
         {{#if @package.pasForm.dcpPfmodification}}
-          <li class="ruled-adjacent">
+          <li>
             <strong>Modification</strong>
             ({{@package.pasForm.dcpPfmodification}}, {{@package.pasForm.dcpPreviousulurpnumbers1}})
           </li>
         {{/if}}
+
         {{#if @package.pasForm.dcpPfrenewal}}
-          <li class="ruled-adjacent">
+          <li>
             <strong>Renewal</strong>
-            ({{@package.pasForm.dcpPfrenewal}}, {{@package.pasForm.dcpPreviousulurpnumbers2}})
+            ({{@package.pasForm.dcpPfrenewal ~}}
+            {{if @package.pasForm.dcpPreviousulurpnumbers2 (concat ', ' @package.pasForm.dcpPreviousulurpnumbers2)}})
           </li>
         {{/if}}
+
         {{#if @package.pasForm.dcpPfrevocableconsent}}
-          <li class="ruled-adjacent">
+          <li>
             <strong>Revocable Consent</strong>
             ({{@package.pasForm.dcpPfrevocableconsent}})
           </li>
         {{/if}}
+
         {{#if @package.pasForm.dcpPfsiteselectionpublicfacility}}
-          <li class="ruled-adjacent">
+          <li>
             <strong>Site Selection - Public Facility</strong>
             ({{@package.pasForm.dcpPfsiteselectionpublicfacility}})
           </li>
         {{/if}}
+
         {{#if @package.pasForm.dcpPfudaap}}
-          <li class="ruled-adjacent">
+          <li>
             <strong>UDAAP</strong>
             ({{@package.pasForm.dcpPfudaap}})
           </li>
         {{/if}}
+
         {{#if @package.pasForm.dcpPfura}}
-          <li class="ruled-adjacent">
+          <li>
             <strong>URA</strong>
             ({{@package.pasForm.dcpPfura}})
           </li>
         {{/if}}
+
         {{#if @package.pasForm.dcpPfzoningauthorization}}
-          <li class="ruled-adjacent">
+          <li>
             <strong>Zoning Authorization</strong>
             ({{@package.pasForm.dcpPfzoningauthorization}})
             {{#if @package.pasForm.dcpZoningauthorizationpursuantto}}
@@ -197,8 +222,9 @@
             {{/if}}
           </li>
         {{/if}}
+
         {{#if @package.pasForm.dcpPfzoningcertification}}
-          <li class="ruled-adjacent">
+          <li>
             <strong>Zoning Certification</strong>
             ({{@package.pasForm.dcpPfzoningcertification}})
             {{#if @package.pasForm.dcpZoningpursuantto}}
@@ -215,8 +241,9 @@
             {{/if}}
           </li>
         {{/if}}
+
         {{#if @package.pasForm.dcpPfzoningmapamendment}}
-          <li class="ruled-adjacent">
+          <li>
             <strong>Zoning Map Amendment</strong>
             ({{@package.pasForm.dcpPfzoningmapamendment}})
             {{#if @package.pasForm.dcpExistingmapamend}}
@@ -233,8 +260,9 @@
             {{/if}}
           </li>
         {{/if}}
+
         {{#if @package.pasForm.dcpPfzoningspecialpermit}}
-          <li class="ruled-adjacent">
+          <li>
             <strong>Zoning Special Permit</strong>
             ({{@package.pasForm.dcpPfzoningspecialpermit}})
             {{#if @package.pasForm.dcpZoningspecialpermitpursuantto}}
@@ -251,8 +279,9 @@
             {{/if}}
           </li>
         {{/if}}
+
         {{#if @package.pasForm.dcpPfzoningtextamendment}}
-          <li class="ruled-adjacent">
+          <li>
             <strong>Zoning Text Amendment</strong>
             ({{@package.pasForm.dcpPfzoningtextamendment}})
             {{#if @package.pasForm.dcpAffectedzrnumber}}
@@ -278,190 +307,141 @@
         Project Area
       </h2>
 
-      <p class="grid-x ruled-adjacent tight">
-        <strong class="cell auto large-padding-right">
+      <Ui::Answer @beside={{true}} as |A|>
+        <A.Prompt>
           Requires a NYC DEP Storm Water Construction Permit
-        </strong>
-        <span class="cell large-3">
-          {{if (eq @package.pasForm.dcpProposedprojectorportionconstruction 717170000) "Yes"}}
-          {{if (eq @package.pasForm.dcpProposedprojectorportionconstruction 717170001) "No" }}
-          {{if (eq @package.pasForm.dcpProposedprojectorportionconstruction 717170002) "Unsure at this time"}}
-        </span>
-      </p>
+        </A.Prompt>
+        <A.Field>
+          {{optionset 'pasForm' 'dcpProposedprojectorportionconstruction' 'label' @package.pasForm.dcpProposedprojectorportionconstruction}}
+        </A.Field>
+      </Ui::Answer>
 
-      <p class="grid-x ruled-adjacent tight">
-        <strong class="cell auto large-padding-right">
-          Located in a current or former
-          <a href="#">
-            Urban Renewal Area
-          </a>
-          {{! TODO: add link }}
-        </strong>
-        <span class="cell large-3">
-          {{if (eq @package.pasForm.dcpUrbanrenewalarea 717170000) "Yes"}}
-          {{if (eq @package.pasForm.dcpUrbanrenewalarea 717170001) "No"}}
-          {{if (eq @package.pasForm.dcpUrbanrenewalarea 717170002) "Unsure at this time"}}
-        </span>
-      </p>
+      <Ui::Answer @beside={{true}} as |A|>
+        <A.Prompt>
+          Located in a current or former Urban Renewal Area
+        </A.Prompt>
+        <A.Field>
+          {{optionset 'pasForm' 'dcpUrbanrenewalarea' 'label' @package.pasForm.dcpUrbanrenewalarea}}
+        </A.Field>
+      </Ui::Answer>
 
-      <p class="grid-x ruled-adjacent tight">
-        <strong class="cell auto large-padding-right">
-          <a href="#">
-            Legal Street Frontage Status
-          </a>
-          {{! TODO: add link }}
-        </strong>
-        <span class="cell large-3">
-          {{if (eq @package.pasForm.dcpLegalstreetfrontage 717170000) "Mapped and Built"}}
-          {{if (eq @package.pasForm.dcpLegalstreetfrontage 717170001) "Private Road"}}
-          {{if (eq @package.pasForm.dcpLegalstreetfrontage 717170002) "Record Street"}}
-          {{if (eq @package.pasForm.dcpLegalstreetfrontage 717170003) "Corporation Counsel Opinion"}}
-          {{if (eq @package.pasForm.dcpLegalstreetfrontage 717170004) "Mapped but not Built"}}
-        </span>
-      </p>
+      <Ui::Answer @beside={{true}} as |A|>
+        <A.Prompt>
+          Legal Street Frontage Status
+        </A.Prompt>
+        <A.Field>
+          {{optionset 'pasForm' 'dcpLegalstreetfrontage' 'label' @package.pasForm.dcpLegalstreetfrontage}}
+        </A.Field>
+      </Ui::Answer>
 
-      <p class="grid-x ruled-adjacent tight">
-        <strong class="cell auto large-padding-right">
-          Meets
-          <a href="#">
-            SEQRA or CEQR criteria
-          </a>
-          for Type II status
-          {{! TODO: add link }}
-        </strong>
-        <span class="cell large-3">
-          {{if (eq @package.pasForm.dcpLanduseactiontype2 717170000) "Yes"}}
-          {{if (eq @package.pasForm.dcpLanduseactiontype2 717170001) "No"}}
-          {{if (eq @package.pasForm.dcpLanduseactiontype2 717170002) "Unsure at this time"}}
-        </span>
-      </p>
+      <Ui::Answer @beside={{true}} as |A|>
+        <A.Prompt>
+          Meets SEQRA or CEQR criteria for Type II status
+        </A.Prompt>
+        <A.Field>
+          {{optionset 'pasForm' 'dcpLanduseactiontype2' 'label' @package.pasForm.dcpLanduseactiontype2}}
+        </A.Field>
+      </Ui::Answer>
 
-      {{#if @package.pasForm.dcpPleaseexplaintypeiienvreview}}
-        <p class="grid-x ruled-adjacent tight">
-          <strong class="cell auto large-padding-right">
-            SEQRA or CEQR category each action fulfills:
-          </strong>
-          <span class="cell large-3">
-            {{@package.pasForm.dcpPleaseexplaintypeiienvreview}}
-          </span>
-        </p>
-      {{/if}}
+      <Ui::Answer @beside={{true}} as |A|>
+        <A.Prompt>
+          SEQRA or CEQR category each action fulfills:
+        </A.Prompt>
+        <A.Field>
+          {{@package.pasForm.dcpPleaseexplaintypeiienvreview}}
+        </A.Field>
+      </Ui::Answer>
 
-      <p class="grid-x ruled-adjacent tight">
-        <strong class="cell auto large-padding-right">
-          In an
-          <a href="#">
-            Industrial Business Zone
-          </a>
-          {{! TODO: add link }}
-        </strong>
-        <span class="cell large-3">
+      <Ui::Answer @beside={{true}} as |A|>
+        <A.Prompt>
+          In an Industrial Business Zone
+        </A.Prompt>
+        <A.Field>
           {{if (eq @package.pasForm.dcpProjectareaindustrialbusinesszone true) "Yes"}}
           {{if (eq @package.pasForm.dcpProjectareaindustrialbusinesszone false) "No"}}
-        </span>
-      </p>
+        </A.Field>
+      </Ui::Answer>
 
       {{#if @package.pasForm.dcpProjectareaindutrialzonename}}
-        <p class="grid-x ruled-adjacent tight">
-          <strong class="cell auto large-padding-right">
+        <Ui::Answer @beside={{true}} as |A|>
+          <A.Prompt>
             Name of Industrial Business Zone:
-          </strong>
-          <span class="cell large-3">
+          </A.Prompt>
+          <A.Field>
             {{@package.pasForm.dcpProjectareaindutrialzonename}}
-          </span>
-        </p>
+          </A.Field>
+        </Ui::Answer>
       {{/if}}
 
-      <p class="grid-x ruled-adjacent tight">
-        <strong class="cell auto large-padding-right">
-          Within or adjacent to a designated (City or State)
-          <a href="#">
-            Landmark or Historic District
-          </a>
-          {{! TODO: add link }}
-        </strong>
-        <span class="cell large-3">
+      <Ui::Answer @beside={{true}} as |A|>
+        <A.Prompt>
+          Within or adjacent to a designated (City or State) Landmark or Historic District
+        </A.Prompt>
+        <A.Field>
           {{if (eq @package.pasForm.dcpIsprojectarealandmark true) "Yes"}}
           {{if (eq @package.pasForm.dcpIsprojectarealandmark false) "No"}}
-        </span>
-      </p>
+        </A.Field>
+      </Ui::Answer>
 
       {{#if @package.pasForm.dcpProjectarealandmarkname}}
-        <p class="grid-x ruled-adjacent tight">
-          <strong class="cell auto large-padding-right">
+        <Ui::Answer @beside={{true}} as |A|>
+          <A.Prompt>
             Name of Landmark or Historic District:
-          </strong>
-          <span class="cell large-3">
+          </A.Prompt>
+          <A.Field>
             {{@package.pasForm.dcpProjectarealandmarkname}}
-          </span>
-        </p>
+          </A.Field>
+        </Ui::Answer>
       {{/if}}
 
-      <p class="grid-x ruled-adjacent tight">
-        <strong class="cell auto large-padding-right">
-          Located within the
-          <a href="#">
-            NYC Coastal Zone
-          </a>
-          {{! TODO: add link }}
-        </strong>
-        <span class="cell large-3">
+      <Ui::Answer @beside={{true}} as |A|>
+        <A.Prompt>
+          Located within the NYC Coastal Zone
+        </A.Prompt>
+        <A.Field>
           {{if (eq @package.pasForm.dcpProjectareacoastalzonelocatedin true) "Yes"}}
           {{if (eq @package.pasForm.dcpProjectareacoastalzonelocatedin false) "No"}}
-        </span>
-      </p>
+        </A.Field>
+      </Ui::Answer>
 
-      <p class="grid-x ruled-adjacent tight">
-        <strong class="cell auto large-padding-right">
-          Located within the
-          <a href="#">
-            1% annual chance floodplain
-          </a>
-          {{! TODO: add link }}
-        </strong>
-        <span class="cell large-3">
-          {{if (eq @package.pasForm.dcpProjectareaischancefloodplain 717170000) "Yes"}}
-          {{if (eq @package.pasForm.dcpProjectareaischancefloodplain 717170001) "No"}}
-          {{if (eq @package.pasForm.dcpProjectareaischancefloodplain 717170002) "Unsure at this time"}}
-        </span>
-      </p>
+      <Ui::Answer @beside={{true}} as |A|>
+        <A.Prompt>
+          Located within the 1% annual chance floodplain
+        </A.Prompt>
+        <A.Field>
+          {{optionset 'pasForm' 'dcpProjectareaischancefloodplain' 'label' @package.pasForm.dcpProjectareaischancefloodplain}}
+        </A.Field>
+      </Ui::Answer>
 
-      <p class="grid-x ruled-adjacent tight">
-        <strong class="cell auto large-padding-right">
-          A
-          <a href="#">
-            legal instrument
-          </a>
-          is associated with a previous CPC or CPC Chair action recorded against the project site
-          {{! TODO: add link }}
-        </strong>
-        <span class="cell large-3">
+      <Ui::Answer @beside={{true}} as |A|>
+        <A.Prompt>
+          A legal instrument is associated with a previous CPC or CPC Chair action recorded against the project site
+        </A.Prompt>
+        <A.Field>
           {{if (eq @package.pasForm.dcpRestrictivedeclaration true) "Yes"}}
           {{if (eq @package.pasForm.dcpRestrictivedeclaration false) "No"}}
-        </span>
-      </p>
+        </A.Field>
+      </Ui::Answer>
 
       {{#if @package.pasForm.dcpCityregisterfilenumber}}
-        <p class="grid-x ruled-adjacent tight">
-          <strong class="cell auto large-padding-right">
+        <Ui::Answer @beside={{true}} as |A|>
+          <A.Prompt>
             City Register File Number:
-          </strong>
-          <span class="cell large-3">
+          </A.Prompt>
+          <A.Field>
             {{@package.pasForm.dcpCityregisterfilenumber}}
-          </span>
-        </p>
+          </A.Field>
+        </Ui::Answer>
       {{/if}}
 
-      <p class="grid-x ruled-adjacent tight">
-        <strong class="cell auto large-padding-right">
+      <Ui::Answer @beside={{true}} as |A|>
+        <A.Prompt>
           Requires new legal instrument or modification of a current legal instrument
-        </strong>
-        <span class="cell large-3">
-          {{if (eq @package.pasForm.dcpRestrictivedeclarationrequired 717170000) "Yes"}}
-          {{if (eq @package.pasForm.dcpRestrictivedeclarationrequired 717170001) "No"}}
-          {{if (eq @package.pasForm.dcpRestrictivedeclarationrequired 717170002) "Unsure at this time"}}
-        </span>
-      </p>
+        </A.Prompt>
+        <A.Field>
+          {{optionset 'pasForm' 'dcpRestrictivedeclarationrequired' 'label' @package.pasForm.dcpRestrictivedeclarationrequired}}
+        </A.Field>
+      </Ui::Answer>
     </section>
 
     <section class="form-section">
@@ -470,77 +450,65 @@
         Proposed Development Site
       </h2>
 
-      <p class="grid-x ruled-adjacent tight">
-        <strong class="cell auto large-padding-right">
+      <Ui::Answer @beside={{true}} as |A|>
+        <A.Prompt>
           Estimated development completion year
-        </strong>
-        <span class="cell large-3">
+        </A.Prompt>
+        <A.Field>
           {{@package.pasForm.dcpEstimatedcompletiondate}}
-        </span>
-      </p>
+        </A.Field>
+      </Ui::Answer>
 
-      <p class="grid-x ruled-adjacent tight">
-        <strong class="cell auto large-padding-right">
+      <Ui::Answer @beside={{true}} as |A|>
+        <A.Prompt>
           Proposed development type
-        </strong>
-        <span
-          class="cell large-3"
-          data-test-proposedDevelopmentTypes
-        >
-          <ProposedDevelopmentTypesList
-            @pasForm={{@package.pasForm}}
-          />
-        </span>
-      </p>
+        </A.Prompt>
+        <A.Field>
+          <span data-test-proposedDevelopmentTypes>
+            <ProposedDevelopmentTypesList @pasForm={{@package.pasForm}} />
+          </span>
+        </A.Field>
+      </Ui::Answer>
 
-      <p class="grid-x ruled-adjacent tight">
-        <strong class="cell auto large-padding-right">
-          In an
-          <a href="#">
-            Inclusionary Housing Designated Area/Mandatory Inclusionary Housing Area
-          </a>
-          {{! TODO: add link }}
-        </strong>
-        <span class="cell large-3">
+      <Ui::Answer @beside={{true}} as |A|>
+        <A.Prompt>
+          In an Inclusionary Housing Designated Area/Mandatory Inclusionary Housing Area
+        </A.Prompt>
+        <A.Field>
           {{if (eq @package.pasForm.dcpIsinclusionaryhousingdesignatedarea true) "Yes"}}
           {{if (eq @package.pasForm.dcpIsinclusionaryhousingdesignatedarea false) "No"}}
-        </span>
-      </p>
+        </A.Field>
+      </Ui::Answer>
 
       {{#if @package.pasForm.dcpInclusionaryhousingdesignatedareaname}}
-        <p class="grid-x ruled-adjacent tight">
-          <strong class="cell auto large-padding-right">
+        <Ui::Answer @beside={{true}} as |A|>
+          <A.Prompt>
             Name of Inclusionary Housing Designated Area/Mandatory Inclusionary Housing Area
-          </strong>
-          <span class="cell large-3">
+          </A.Prompt>
+          <A.Field>
             {{@package.pasForm.dcpInclusionaryhousingdesignatedareaname}}
-          </span>
-        </p>
+          </A.Field>
+        </Ui::Answer>
       {{/if}}
 
-      <p class="grid-x ruled-adjacent tight">
-        <strong class="cell auto large-padding-right">
+      <Ui::Answer @beside={{true}} as |A|>
+        <A.Prompt>
           Involves discretionary funding for Affordable Housing Units
-        </strong>
-        <span class="cell large-3">
-          {{if (eq @package.pasForm.dcpDiscressionaryfundingforffordablehousing 717170000) "Yes"}}
-          {{if (eq @package.pasForm.dcpDiscressionaryfundingforffordablehousing 717170001) "No"}}
-          {{if (eq @package.pasForm.dcpDiscressionaryfundingforffordablehousing 717170002) "Unsure at this time"}}
-        </span>
-      </p>
+        </A.Prompt>
+        <A.Field>
+          {{optionset 'pasForm' 'dcpDiscressionaryfundingforffordablehousing' 'label' @package.pasForm.dcpDiscressionaryfundingforffordablehousing}}
+        </A.Field>
+      </Ui::Answer>
 
       {{#if @package.pasForm.dcpHousingunittype}}
-        <p class="grid-x ruled-adjacent tight">
-          <strong class="cell auto large-padding-right">
+        <Ui::Answer @beside={{true}} as |A|>
+          <A.Prompt>
             Funding source
-          </strong>
-          <span class="cell large-3">
-            {{if (eq @package.pasForm.dcpHousingunittype 717170000) "City"}}
-            {{if (eq @package.pasForm.dcpHousingunittype 717170001) "State"}}
-            {{if (eq @package.pasForm.dcpHousingunittype 717170002) "Federal"}}
-            {{if (eq @package.pasForm.dcpHousingunittype 717170003) "Other"}}
-          </span>
-        </p>
+          </A.Prompt>
+          <A.Field>
+            {{optionset 'pasForm' 'dcpHousingunittype' 'label' @package.pasForm.dcpHousingunittype}}
+          </A.Field>
+        </Ui::Answer>
       {{/if}}
     </section>
 
@@ -550,53 +518,60 @@
         Project Description
       </h2>
 
-      <p class="ruled-adjacent">
-        <strong>
-          Description of the proposed development being facilitated by the land use actions
-        </strong>
-        <br />
-        {{@package.pasForm.dcpProjectdescriptionproposeddevelopment}}
-      </p>
+      <Ui::Answer as |A|>
+        <A.Prompt>
+          Description of the proposed development being facilitated by the land use actions:
+        </A.Prompt>
+        <A.Field>
+          {{@package.pasForm.dcpProjectdescriptionproposeddevelopment}}
+        </A.Field>
+      </Ui::Answer>
 
-      <p class="ruled-adjacent">
-        <strong>
-          Why is this application being proposed? What is the legal, environmental, or land use background?
-        </strong>
-        <br />
-        {{@package.pasForm.dcpProjectdescriptionbackground}}
-      </p>
+      <Ui::Answer as |A|>
+        <A.Prompt>
+          Why is this application being proposed?
+          <br>What is the legal, environmental, or land use background?
+        </A.Prompt>
+        <A.Field>
+          {{@package.pasForm.dcpProjectdescriptionbackground}}
+        </A.Field>
+      </Ui::Answer>
 
-      <p class="ruled-adjacent">
-        <strong>
+      <Ui::Answer as |A|>
+        <A.Prompt>
           What is the land use rationale for all the proposed actions?
-        </strong>
-        <br />
-        {{@package.pasForm.dcpProjectdescriptionproposedactions}}
-      </p>
+        </A.Prompt>
+        <A.Field>
+          {{@package.pasForm.dcpProjectdescriptionproposedactions}}
+        </A.Field>
+      </Ui::Answer>
 
-      <p class="ruled-adjacent">
-        <strong>
+      <Ui::Answer as |A|>
+        <A.Prompt>
           Description of existing land uses and structures in the proposed Project Area and Development Site
-        </strong>
-        <br />
-        {{@package.pasForm.dcpProjectdescriptionproposedarea}}
-      </p>
+        </A.Prompt>
+        <A.Field>
+          {{@package.pasForm.dcpProjectdescriptionproposedarea}}
+        </A.Field>
+      </Ui::Answer>
 
-      <p class="ruled-adjacent">
-        <strong>
+      <Ui::Answer as |A|>
+        <A.Prompt>
           Description of land uses and built context in surrounding area (within 1000 ft)
-        </strong>
-        <br />
-        {{@package.pasForm.dcpProjectdescriptionsurroundingarea}}
-      </p>
+        </A.Prompt>
+        <A.Field>
+          {{@package.pasForm.dcpProjectdescriptionsurroundingarea}}
+        </A.Field>
+      </Ui::Answer>
 
-      <p class="ruled-adjacent">
-        <strong>
+      <Ui::Answer as |A|>
+        <A.Prompt>
           Description of proposed CEQR scope
-        </strong>
-        <br />
-        {{@package.pasForm.dcpProjectattachmentsotherinformation}}
-      </p>
+        </A.Prompt>
+        <A.Field>
+          {{@package.pasForm.dcpProjectattachmentsotherinformation}}
+        </A.Field>
+      </Ui::Answer>
     </section>
 
     <section class="form-section" id="attached-documents">

--- a/client/app/components/packages/rwcds-form/show.hbs
+++ b/client/app/components/packages/rwcds-form/show.hbs
@@ -223,7 +223,6 @@
         Attachments
       </h2>
 
-      {{log @package.rwcdsForm}}
     </section>
 
   </div>{{! end left/main column }}

--- a/client/app/components/packages/rwcds-form/show.hbs
+++ b/client/app/components/packages/rwcds-form/show.hbs
@@ -1,0 +1,250 @@
+<div class="grid-x grid-margin-x">
+  <div class="cell large-8">
+
+    <section class="form-section">
+      <h1 class="no-margin header-large">
+        <span id="project-info" class="section-anchor"></span>
+        Reasonable Worst Case Development Scenario
+      </h1>
+
+      <h2 class="section-header header-xxlarge"
+        data-test-show="dcpProjectname">
+        {{@package.rwcdsForm.dcpProjectname}}
+      </h2>
+    </section>
+
+    <section class="form-section">
+      <h2 class="section-header">
+        <span id="" class="section-anchor"></span>
+        Description
+      </h2>
+
+      <p class="grid-x">
+        <strong class="cell auto large-padding-right">
+          Has the project changed since submission of the Pre-Application Statement (PAS)?
+        </strong>
+        <span class="cell large-3">
+          {{if @package.pasForm.dcpHasprojectchangedsincesubmissionofthepas "Yes" "No"}}
+        </span>
+      </p>
+
+      <p class="ruled-top">
+        <strong>
+          Project site description:
+        </strong>
+        <br />
+        {{@package.rwcdsForm.dcpProjectsitedescription}}
+      </p>
+
+      <p class="ruled-top">
+        <strong>
+          Proposed development description:
+        </strong>
+        <br />
+        {{@package.rwcdsForm.dcpProposedprojectdevelopmentdescription}}
+      </p>
+
+      <p class="grid-x ruled-top">
+        <strong class="cell auto large-padding-right">
+          Will construction be done in multiple phases?
+        </strong>
+        <span class="cell large-3">
+          {{#if (eq @package.rwcdsForm.dcpConstructionphasing 717170000)}}
+            Single
+          {{else if (eq @package.rwcdsForm.dcpConstructionphasing 717170001)}}
+            Multiple
+          {{else}}
+            Not Applicable
+          {{/if}}
+        </span>
+      </p>
+
+      <p class="grid-x ruled-top">
+        <strong class="cell auto large-padding-right">
+          What is the proposed analysis year of the proposed action?
+        </strong>
+        <span class="cell large-3">
+          {{@package.rwcdsForm.dcpBuildyear}}
+        </span>
+      </p>
+
+      <p class="ruled-top">
+        <strong>
+          Analysis year rationale:
+        </strong>
+        <br />
+        {{@package.rwcdsForm.dcpRationalbehindthebuildyear}}
+      </p>
+
+      <p class="ruled-top">
+        <strong>
+          History of sites within the Project Area:
+        </strong>
+        <br />
+        {{@package.rwcdsForm.dcpSitehistory}}
+      </p>
+    </section>
+
+    <section class="form-section">
+      <h2 class="section-header">
+        <span id="" class="section-anchor"></span>
+        Proposed Actions
+      </h2>
+
+      {{!-- TODO: add list of actions --}}
+
+      <p class="ruled-top">
+        <strong>
+          Purpose and need for all proposed actions:
+        </strong>
+        <br />
+        {{@package.rwcdsForm.dcpPurposeandneedfortheproposedaction}}
+      </p>
+
+      <p class="grid-x ruled-top">
+        <strong class="cell auto large-padding-right">
+          Does the applicant plan to develop a 100% affordable housing development?
+        </strong>
+        <span class="cell large-3">
+          {{if @package.pasForm.dcpIsplannigondevelopingaffordablehousing "Yes" "No"}}
+        </span>
+      </p>
+
+      <p class="grid-x ruled-top">
+        <strong class="cell auto large-padding-right">
+          Is the applicant seeking actions from other City/State/Federal agencies?
+        </strong>
+        <span class="cell large-3">
+          {{if (eq @package.rwcdsForm.dcpIsapplicantseekingaction 717170000) "Yes"}}
+          {{if (eq @package.rwcdsForm.dcpIsapplicantseekingaction 717170001) "No" }}
+          {{if (eq @package.rwcdsForm.dcpIsapplicantseekingaction 717170002) "Unsure at this time"}}
+        </span>
+      </p>
+
+      {{#if (eq @package.rwcdsForm.dcpIsapplicantseekingaction 717170000)}}
+        <p class="ruled-top">
+          <strong>
+            Actions sought from other agencies:
+          </strong>
+          <br />
+          {{@package.rwcdsForm.dcpWhichactionsfromotheragenciesaresought}}
+        </p>
+      {{/if}}
+    </section>
+
+    <section class="form-section">
+      <h2 class="section-header">
+        <span id="" class="section-anchor"></span>
+        Analysis
+      </h2>
+
+      <p class="">
+        <strong>
+          Description of development assumptions:
+        </strong>
+        <br />
+        {{@package.rwcdsForm.dcpDevelopmentsiteassumptions}}
+      </p>
+
+      <h3>
+        No-Action Scenario
+      </h3>
+
+      <p class="grid-x">
+        <strong class="cell auto large-padding-right">
+          Is the No-Action scenario the same as the Existing Conditions?
+        </strong>
+        <span class="cell large-3">
+          {{if @package.rwcdsForm.dcpExistingconditions "Yes" "No" }}
+        </span>
+      </p>
+
+      {{#if @package.rwcdsForm.dcpDescribethenoactionscenario}}
+        <p class="ruled-top">
+          <strong>
+            Description of No-Action scenario:
+          </strong>
+          <br />
+          {{@package.rwcdsForm.dcpDescribethenoactionscenario}}
+        </p>
+      {{/if}}
+
+      {{#if @package.rwcdsForm.dcpHowdidyoudeterminethenoactionscenario}}
+        <p class="ruled-top">
+          <strong>
+            How No-Action scenario was determined:
+          </strong>
+          <br />
+          {{@package.rwcdsForm.dcpHowdidyoudeterminethenoactionscenario}}
+        </p>
+      {{/if}}
+
+      <h3>
+        With-Action Scenario
+      </h3>
+
+      <p class="grid-x">
+        <strong class="cell auto large-padding-right">
+          Is the proposed project the same as the proposed With-Action scenario?
+        </strong>
+        <span class="cell large-3">
+          {{if @package.rwcdsForm.dcpIsrwcdsscenario "Yes" "No" }}
+        </span>
+      </p>
+
+      <p class="ruled-top">
+        <strong>
+          Why the project is the same as the propsed With-Action scenario:
+        </strong>
+        <br />
+        {{@package.rwcdsForm.dcpRwcdsexplanation}}
+      </p>
+
+      <p class="ruled-top">
+        <strong>
+          Description of With-Action scenario:
+        </strong>
+        <br />
+        {{@package.rwcdsForm.dcpDescribethewithactionscenario}}
+      </p>
+
+      <p class="ruled-top">
+        <strong>
+          How With-Action scenario was determines:
+        </strong>
+        <br />
+        {{@package.rwcdsForm.dcpHowdidyoudeterminethiswithactionscena}}
+      </p>
+    </section>
+
+    <section class="form-section">
+      <h2 class="section-header">
+        <span id="" class="section-anchor"></span>
+        Attachments
+      </h2>
+
+      {{log @package.rwcdsForm}}
+    </section>
+
+  </div>{{! end left/main column }}
+  <div class="cell large-4">
+
+    <StickySidebar
+      @navItems={{array
+        (hash anchorId="project-info"
+          label="Project Information")
+        (hash anchorId="project-description"
+          label="Description")
+        (hash anchorId="proposed-actions"
+          label="Proposed Actions")
+        (hash anchorId="analysis"
+          label="Analysis")
+        (hash anchorId="attachments"
+          label="Attachments")
+        }}
+    />
+
+  </div>{{! end right/sidebar column }}
+</div>
+
+{{yield}}

--- a/client/app/components/packages/rwcds-form/show.hbs
+++ b/client/app/components/packages/rwcds-form/show.hbs
@@ -19,70 +19,68 @@
         Description
       </h2>
 
-      <p class="grid-x">
-        <strong class="cell auto large-padding-right">
+      <Ui::Answer @beside={{true}} as |A|>
+        <A.Prompt>
           Has the project changed since submission of the Pre-Application Statement (PAS)?
-        </strong>
-        <span class="cell large-3">
-          {{if @package.pasForm.dcpHasprojectchangedsincesubmissionofthepas "Yes" "No"}}
-        </span>
-      </p>
+        </A.Prompt>
+        <A.Field>
+          {{optionset 'rwcdsForm' 'dcpHasprojectchangedsincesubmissionofthepas' 'label' @package.rwcdsForm.dcpHasprojectchangedsincesubmissionofthepas}}
+        </A.Field>
+      </Ui::Answer>
 
-      <p class="ruled-top">
-        <strong>
+      <Ui::Answer as |A|>
+        <A.Prompt>
           Project site description:
-        </strong>
-        <br />
-        {{@package.rwcdsForm.dcpProjectsitedescription}}
-      </p>
+        </A.Prompt>
+        <A.Field>
+          {{@package.rwcdsForm.dcpProjectsitedescription}}
+        </A.Field>
+      </Ui::Answer>
 
-      <p class="ruled-top">
-        <strong>
+      <Ui::Answer as |A|>
+        <A.Prompt>
           Proposed development description:
-        </strong>
-        <br />
-        {{@package.rwcdsForm.dcpProposedprojectdevelopmentdescription}}
-      </p>
+        </A.Prompt>
+        <A.Field>
+          {{@package.rwcdsForm.dcpProposedprojectdevelopmentdescription}}
+        </A.Field>
+      </Ui::Answer>
 
-      <p class="grid-x ruled-top">
-        <strong class="cell auto large-padding-right">
+      <Ui::Answer @beside={{true}} as |A|>
+        <A.Prompt>
           Will construction be done in multiple phases?
-        </strong>
-        <span class="cell large-3">
-          {{#if (eq @package.rwcdsForm.dcpConstructionphasing 717170000)}}
-            Single
-          {{else if (eq @package.rwcdsForm.dcpConstructionphasing 717170001)}}
-            Multiple
-          {{else}}
-            Not Applicable
-          {{/if}}
-        </span>
-      </p>
+        </A.Prompt>
+        <A.Field>
+          {{optionset 'rwcdsForm' 'dcpConstructionphasing' 'label' @package.rwcdsForm.dcpConstructionphasing}}
+        </A.Field>
+      </Ui::Answer>
 
-      <p class="grid-x ruled-top">
-        <strong class="cell auto large-padding-right">
+      <Ui::Answer @beside={{true}} as |A|>
+        <A.Prompt>
           What is the proposed analysis year of the proposed action?
-        </strong>
-        <span class="cell large-3">
+        </A.Prompt>
+        <A.Field>
           {{@package.rwcdsForm.dcpBuildyear}}
-        </span>
-      </p>
+        </A.Field>
+      </Ui::Answer>
 
-      <p class="ruled-top">
-        <strong>
+      <Ui::Answer as |A|>
+        <A.Prompt>
           Analysis year rationale:
-        </strong>
-        <br />
-        {{@package.rwcdsForm.dcpRationalbehindthebuildyear}}
-      </p>
+        </A.Prompt>
+        <A.Field>
+          {{@package.rwcdsForm.dcpRationalbehindthebuildyear}}
+        </A.Field>
+      </Ui::Answer>
 
-      <p class="ruled-top">
-        <strong>
+      <Ui::Answer as |A|>
+        <A.Prompt>
           History of sites within the Project Area:
-        </strong>
-        <br />
-        {{@package.rwcdsForm.dcpSitehistory}}
-      </p>
+        </A.Prompt>
+        <A.Field>
+          {{@package.rwcdsForm.dcpSitehistory}}
+        </A.Field>
+      </Ui::Answer>
     </section>
 
     <section class="form-section">
@@ -93,42 +91,44 @@
 
       {{!-- TODO: add list of actions --}}
 
-      <p class="ruled-top">
-        <strong>
+      <Ui::Answer as |A|>
+        <A.Prompt>
           Purpose and need for all proposed actions:
-        </strong>
-        <br />
-        {{@package.rwcdsForm.dcpPurposeandneedfortheproposedaction}}
-      </p>
+        </A.Prompt>
+        <A.Field>
+          {{@package.rwcdsForm.dcpPurposeandneedfortheproposedaction}}
+        </A.Field>
+      </Ui::Answer>
 
-      <p class="grid-x ruled-top">
-        <strong class="cell auto large-padding-right">
+      <Ui::Answer @beside={{true}} as |A|>
+        <A.Prompt>
           Does the applicant plan to develop a 100% affordable housing development?
-        </strong>
-        <span class="cell large-3">
+        </A.Prompt>
+        <A.Field>
           {{if @package.pasForm.dcpIsplannigondevelopingaffordablehousing "Yes" "No"}}
-        </span>
-      </p>
+        </A.Field>
+      </Ui::Answer>
 
-      <p class="grid-x ruled-top">
-        <strong class="cell auto large-padding-right">
+      <Ui::Answer @beside={{true}} as |A|>
+        <A.Prompt>
           Is the applicant seeking actions from other City/State/Federal agencies?
-        </strong>
-        <span class="cell large-3">
+        </A.Prompt>
+        <A.Field>
           {{if (eq @package.rwcdsForm.dcpIsapplicantseekingaction 717170000) "Yes"}}
           {{if (eq @package.rwcdsForm.dcpIsapplicantseekingaction 717170001) "No" }}
           {{if (eq @package.rwcdsForm.dcpIsapplicantseekingaction 717170002) "Unsure at this time"}}
-        </span>
-      </p>
+        </A.Field>
+      </Ui::Answer>
 
       {{#if (eq @package.rwcdsForm.dcpIsapplicantseekingaction 717170000)}}
-        <p class="ruled-top">
-          <strong>
+        <Ui::Answer as |A|>
+          <A.Prompt>
             Actions sought from other agencies:
-          </strong>
-          <br />
-          {{@package.rwcdsForm.dcpWhichactionsfromotheragenciesaresought}}
-        </p>
+          </A.Prompt>
+          <A.Field>
+            {{@package.rwcdsForm.dcpWhichactionsfromotheragenciesaresought}}
+          </A.Field>
+        </Ui::Answer>
       {{/if}}
     </section>
 
@@ -138,83 +138,89 @@
         Analysis
       </h2>
 
-      <p class="">
-        <strong>
+      <Ui::Answer as |A|>
+        <A.Prompt>
           Description of development assumptions:
-        </strong>
-        <br />
-        {{@package.rwcdsForm.dcpDevelopmentsiteassumptions}}
-      </p>
+        </A.Prompt>
+        <A.Field>
+          {{@package.rwcdsForm.dcpDevelopmentsiteassumptions}}
+        </A.Field>
+      </Ui::Answer>
 
       <h3>
         No-Action Scenario
       </h3>
 
-      <p class="grid-x">
-        <strong class="cell auto large-padding-right">
+      <Ui::Answer @beside={{true}} as |A|>
+        <A.Prompt>
           Is the No-Action scenario the same as the Existing Conditions?
-        </strong>
-        <span class="cell large-3">
-          {{if @package.rwcdsForm.dcpExistingconditions "Yes" "No" }}
-        </span>
-      </p>
+        </A.Prompt>
+        <A.Field>
+          {{optionset 'rwcdsForm' 'dcpExistingconditions' 'label' @package.rwcdsForm.dcpExistingconditions}}
+        </A.Field>
+      </Ui::Answer>
 
       {{#if @package.rwcdsForm.dcpDescribethenoactionscenario}}
-        <p class="ruled-top">
-          <strong>
+        <Ui::Answer as |A|>
+          <A.Prompt>
             Description of No-Action scenario:
-          </strong>
-          <br />
-          {{@package.rwcdsForm.dcpDescribethenoactionscenario}}
-        </p>
+          </A.Prompt>
+          <A.Field>
+            {{@package.rwcdsForm.dcpDescribethenoactionscenario}}
+          </A.Field>
+        </Ui::Answer>
       {{/if}}
 
       {{#if @package.rwcdsForm.dcpHowdidyoudeterminethenoactionscenario}}
-        <p class="ruled-top">
-          <strong>
+        <Ui::Answer as |A|>
+          <A.Prompt>
             How No-Action scenario was determined:
-          </strong>
-          <br />
-          {{@package.rwcdsForm.dcpHowdidyoudeterminethenoactionscenario}}
-        </p>
+          </A.Prompt>
+          <A.Field>
+            {{@package.rwcdsForm.dcpHowdidyoudeterminethenoactionscenario}}
+          </A.Field>
+        </Ui::Answer>
       {{/if}}
 
       <h3>
         With-Action Scenario
       </h3>
 
-      <p class="grid-x">
-        <strong class="cell auto large-padding-right">
+      <Ui::Answer @beside={{true}} as |A|>
+        <A.Prompt>
           Is the proposed project the same as the proposed With-Action scenario?
-        </strong>
-        <span class="cell large-3">
-          {{if @package.rwcdsForm.dcpIsrwcdsscenario "Yes" "No" }}
-        </span>
-      </p>
+        </A.Prompt>
+        <A.Field>
+          {{optionset 'rwcdsForm' 'dcpIsrwcdsscenario' 'label' @package.rwcdsForm.dcpIsrwcdsscenario}}
+        </A.Field>
+      </Ui::Answer>
 
-      <p class="ruled-top">
-        <strong>
+      <Ui::Answer as |A|>
+        <A.Prompt>
           Why the project is the same as the propsed With-Action scenario:
-        </strong>
-        <br />
-        {{@package.rwcdsForm.dcpRwcdsexplanation}}
-      </p>
+        </A.Prompt>
+        <A.Field>
+          {{@package.rwcdsForm.dcpRwcdsexplanation}}
+        </A.Field>
+      </Ui::Answer>
 
-      <p class="ruled-top">
-        <strong>
+      <Ui::Answer as |A|>
+        <A.Prompt>
           Description of With-Action scenario:
-        </strong>
-        <br />
-        {{@package.rwcdsForm.dcpDescribethewithactionscenario}}
-      </p>
+        </A.Prompt>
+        <A.Field>
+          {{@package.rwcdsForm.dcpDescribethewithactionscenario}}
+        </A.Field>
+      </Ui::Answer>
 
-      <p class="ruled-top">
-        <strong>
+      <Ui::Answer as |A|>
+        <A.Prompt>
           How With-Action scenario was determines:
-        </strong>
-        <br />
-        {{@package.rwcdsForm.dcpHowdidyoudeterminethiswithactionscena}}
-      </p>
+        </A.Prompt>
+        <A.Field>
+          {{@package.rwcdsForm.dcpHowdidyoudeterminethiswithactionscena}}
+        </A.Field>
+      </Ui::Answer>
     </section>
 
     <section class="form-section">
@@ -222,6 +228,8 @@
         <span id="" class="section-anchor"></span>
         Attachments
       </h2>
+
+      {{!-- TODO: add list of attachments --}}
 
     </section>
 

--- a/client/app/components/ui/answer-field.hbs
+++ b/client/app/components/ui/answer-field.hbs
@@ -1,0 +1,6 @@
+<div
+  class="{{if @beside 'cell large-3'}}"
+  ...attributes
+>
+  {{yield}}
+</div>

--- a/client/app/components/ui/answer-prompt.hbs
+++ b/client/app/components/ui/answer-prompt.hbs
@@ -1,0 +1,6 @@
+<div
+  class="text-weight-bold {{if @beside 'cell auto large-padding-right'}}"
+  ...attributes
+>
+  {{yield}}
+</div>

--- a/client/app/components/ui/answer.hbs
+++ b/client/app/components/ui/answer.hbs
@@ -1,0 +1,9 @@
+<div
+  class="ruled-adjacent {{if @beside 'grid-x'}}"
+  ...attributes
+>
+  {{yield (hash
+    Prompt=(component 'ui/answer-prompt' beside=@beside)
+    Field=(component 'ui/answer-field' beside=@beside)
+  )}}
+</div>

--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -68,7 +68,7 @@ const OPTIONSET_LOOKUP = {
  * @return     {string, number, array or Object}
  */
 export function optionset([model, optionsetId, returnType, lookupToken]) {
-  const optionset = OPTIONSET_LOOKUP[model][optionsetId]; // eslint-disable-line
+  const optionset = OPTIONSET_LOOKUP[model][optionsetId];
   const optionById = optionset[lookupToken];
   let option;
 

--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -17,6 +17,11 @@ import {
   DCPHASPROJECTCHANGEDSINCESUBMISSIONOFTHEPAS_OPTIONSET,
   DCPCONSTRUCTIONPHASING_OPTIONSET,
 } from '../models/rwcds-form';
+import {
+  YES_NO_UNSURE_OPTIONSET,
+  DCPLEGALSTREETFRONTAGE_OPTIONSET,
+  DCPHOUSINGUNITTYPE_OPTIONSET,
+} from '../models/pas-form';
 
 const OPTIONSET_LOOKUP = {
   applicant: {
@@ -35,8 +40,17 @@ const OPTIONSET_LOOKUP = {
     dcpHasprojectchangedsincesubmissionofthepas: DCPHASPROJECTCHANGEDSINCESUBMISSIONOFTHEPAS_OPTIONSET,
     dcpConstructionphasing: DCPCONSTRUCTIONPHASING_OPTIONSET,
   },
+  pasForm: {
+    dcpProposedprojectorportionconstruction: YES_NO_UNSURE_OPTIONSET,
+    dcpUrbanrenewalarea: YES_NO_UNSURE_OPTIONSET,
+    dcpLegalstreetfrontage: DCPLEGALSTREETFRONTAGE_OPTIONSET,
+    dcpLanduseactiontype2: YES_NO_UNSURE_OPTIONSET,
+    dcpProjectareaischancefloodplain: YES_NO_UNSURE_OPTIONSET,
+    dcpRestrictivedeclarationrequired: YES_NO_UNSURE_OPTIONSET,
+    dcpDiscressionaryfundingforffordablehousing: YES_NO_UNSURE_OPTIONSET,
+    dcpHousingunittype: DCPHOUSINGUNITTYPE_OPTIONSET,
+  },
 };
-
 
 /**
  * Use this helper in templates to retrieve optionsets and their values.
@@ -54,40 +68,34 @@ const OPTIONSET_LOOKUP = {
  * @return     {string, number, array or Object}
  */
 export function optionset([model, optionsetId, returnType, lookupToken]) {
-  const optionset = OPTIONSET_LOOKUP[model][optionsetId];
+  const optionset = OPTIONSET_LOOKUP[model][optionsetId]; // eslint-disable-line
+  const optionById = optionset[lookupToken];
+  let option;
 
   switch (returnType) {
     case 'list':
       return Object.values(optionset);
     case 'code':
-      if (lookupToken) {
-        const optionById = optionset[lookupToken];
+      if (optionById) {
+        return optionById.code;
+      }
 
-        if (optionById) {
-          return optionById.code;
-        }
+      option = Object.values(optionset).findBy('label', lookupToken);
 
-        const optionByLabel = Object.values(optionset).findBy('label', lookupToken);
-
-        if (optionByLabel) {
-          return optionByLabel.code;
-        }
+      if (option) {
+        return option.code;
       }
       console.assert(false, 'Invalid call to optionset helper: must provide a valid identifier or label to look up a code.'); // eslint-disable-line
       break;
     case 'label':
-      if (lookupToken) {
-        const optionById = optionset[lookupToken];
+      if (optionById) {
+        return optionById.label;
+      }
 
-        if (optionById) {
-          return optionById.label;
-        }
+      option = Object.values(optionset).findBy('code', lookupToken);
 
-        const optionByCode = Object.values(optionset).findBy('code', lookupToken);
-
-        if (optionByCode) {
-          return optionByCode.label;
-        }
+      if (option) {
+        return option.label;
       }
       console.assert(false, `Invalid call to optionset helper with identifier ${lookupToken}: must provide a valid identifier or code to look up a label.`); // eslint-disable-line
       break;

--- a/client/app/models/pas-form.js
+++ b/client/app/models/pas-form.js
@@ -1,5 +1,62 @@
 import Model, { belongsTo, hasMany, attr } from '@ember-data/model';
 
+export const YES_NO_UNSURE_OPTIONSET = {
+  YES: {
+    code: 717170000,
+    label: 'Yes',
+  },
+  NO: {
+    code: 717170001,
+    label: 'No',
+  },
+  UNSURE: {
+    code: 717170002,
+    label: 'Unsure at this time',
+  },
+};
+
+export const DCPLEGALSTREETFRONTAGE_OPTIONSET = {
+  MAPPED_AND_BUILT: {
+    code: 717170000,
+    label: 'Mapped and Built',
+  },
+  PRIVATE_ROAD: {
+    code: 717170001,
+    label: 'Private Road',
+  },
+  RECORD_STREET: {
+    code: 717170002,
+    label: 'Record Street',
+  },
+  CORPORATION_COUNSEL_OPINION: {
+    code: 717170003,
+    label: 'Corporation Counsel Opinion',
+  },
+  MAPPED_BUT_NOT_BUILT: {
+    code: 717170004,
+    label: 'Mapped but not Built',
+  },
+};
+
+export const DCPHOUSINGUNITTYPE_OPTIONSET = {
+  CITY: {
+    code: 717170000,
+    label: 'City',
+  },
+  STATE: {
+    code: 717170000,
+    label: 'State',
+  },
+  FEDERAL: {
+    code: 717170000,
+    label: 'Federal',
+  },
+  OTHER: {
+    code: 717170000,
+    label: 'Other',
+  },
+};
+
 export default class PasFormModel extends Model {
   @belongsTo('package', { async: false })
   package;

--- a/client/app/routes/rwcds-form/edit.js
+++ b/client/app/routes/rwcds-form/edit.js
@@ -1,4 +1,0 @@
-import Route from '@ember/routing/route';
-
-export default class RwcdsFormEditRoute extends Route {
-}

--- a/client/app/templates/rwcds-form/show.hbs
+++ b/client/app/templates/rwcds-form/show.hbs
@@ -1,0 +1,9 @@
+<Breadcrumbs as |Crumb|>
+  <Crumb @text="My Projects" @route='projects' />
+  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb @text="RWCDS" @current={{true}} />
+</Breadcrumbs>
+
+<Packages::RwcdsForm::Show @package={{@model}} />
+
+{{outlet}}

--- a/client/tests/integration/components/ui/answer-field-test.js
+++ b/client/tests/integration/components/ui/answer-field-test.js
@@ -6,21 +6,13 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Component | ui/answer-field', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
-
+  test('it’s not a grid cell', async function(assert) {
     await render(hbs`<Ui::AnswerField />`);
+    assert.dom('.cell.large-3').doesNotExist();
+  });
 
-    assert.equal(this.element.textContent.trim(), '');
-
-    // Template block usage:
-    await render(hbs`
-      <Ui::AnswerField>
-        template block text
-      </Ui::AnswerField>
-    `);
-
-    assert.equal(this.element.textContent.trim(), 'template block text');
+  test('it’s a grid cell', async function(assert) {
+    await render(hbs`<Ui::AnswerField @beside={{true}} />`);
+    assert.dom('.cell.large-3').exists();
   });
 });

--- a/client/tests/integration/components/ui/answer-field-test.js
+++ b/client/tests/integration/components/ui/answer-field-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | ui/answer-field', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<Ui::AnswerField />`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      <Ui::AnswerField>
+        template block text
+      </Ui::AnswerField>
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});

--- a/client/tests/integration/components/ui/answer-prompt-test.js
+++ b/client/tests/integration/components/ui/answer-prompt-test.js
@@ -6,21 +6,13 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Component | ui/answer-prompt', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
-
+  test('it’s not a grid cell', async function(assert) {
     await render(hbs`<Ui::AnswerPrompt />`);
+    assert.dom('.cell.auto.large-padding-right').doesNotExist();
+  });
 
-    assert.equal(this.element.textContent.trim(), '');
-
-    // Template block usage:
-    await render(hbs`
-      <Ui::AnswerPrompt>
-        template block text
-      </Ui::AnswerPrompt>
-    `);
-
-    assert.equal(this.element.textContent.trim(), 'template block text');
+  test('it’s a grid cell', async function(assert) {
+    await render(hbs`<Ui::AnswerPrompt @beside={{true}} />`);
+    assert.dom('.cell.auto.large-padding-right').exists();
   });
 });

--- a/client/tests/integration/components/ui/answer-prompt-test.js
+++ b/client/tests/integration/components/ui/answer-prompt-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | ui/answer-prompt', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<Ui::AnswerPrompt />`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      <Ui::AnswerPrompt>
+        template block text
+      </Ui::AnswerPrompt>
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});

--- a/client/tests/integration/components/ui/answer-test.js
+++ b/client/tests/integration/components/ui/answer-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | ui/answer', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<Ui::Answer />`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      <Ui::Answer>
+        template block text
+      </Ui::Answer>
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});

--- a/client/tests/integration/components/ui/answer-test.js
+++ b/client/tests/integration/components/ui/answer-test.js
@@ -6,21 +6,13 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Component | ui/answer', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
-
+  test('it’s not a grid cell', async function(assert) {
     await render(hbs`<Ui::Answer />`);
+    assert.dom('.grid-x').doesNotExist();
+  });
 
-    assert.equal(this.element.textContent.trim(), '');
-
-    // Template block usage:
-    await render(hbs`
-      <Ui::Answer>
-        template block text
-      </Ui::Answer>
-    `);
-
-    assert.equal(this.element.textContent.trim(), 'template block text');
+  test('it’s a grid cell', async function(assert) {
+    await render(hbs`<Ui::Answer @beside={{true}} />`);
+    assert.dom('.grid-x').exists();
   });
 });


### PR DESCRIPTION
This PR…
- Add the RWCDS show route and template
- Adds a `<Ui:Answer>` component that reduces the repetition and brittle markup of the PAS and RWCDS show routes — which works much like the `<Ui:Question>` component for the edit routes
  ```
  <Ui::Answer [@beside={{true}}] as |A|>
    <A.Prompt>
      ...
    </A.Prompt>
    <A.Field>
      ...
    </A.Field>
  </Ui::Answer>
  ```
  (Passing the optional `@beside={{true}}` will put the prompt and field in a grid so that they're beside each other. Without it, the prompt appears above the filed.) 
- Updates the `{{optionset}}` helper so that it can be passed falsey args

NOTE: Still need to get the list of actions and attachments in the RWCDS show template
