### PR TITLE
Updated the "Official Zoning Map" hyperlink

### DIFF
--- a/client/app/components/packages/pas-form/attached-documents.hbs
+++ b/client/app/components/packages/pas-form/attached-documents.hbs
@@ -11,7 +11,7 @@
           <Ui::ExternalLink @href="http://gis.nyc.gov/taxmap/map.htm">Tax Map(s)</Ui::ExternalLink> — if project area has more than one tax block submit a separate map for each tax block
         </li>
         <li class="small-margin-bottom">
-          <Ui::ExternalLink @href="https://www1.nyc.gov/site/planning/zoning/index- map.page">Official Zoning Map</Ui::ExternalLink> — circle the project area
+          <Ui::ExternalLink @href="https://www1.nyc.gov/site/planning/zoning/index-map.page">Official Zoning Map</Ui::ExternalLink> — circle the project area
         </li>
         <li class="small-margin-bottom">
           <Ui::ExternalLink @href="https://applicantmaps.planning.nyc.gov/">Land Use Map</Ui::ExternalLink>


### PR DESCRIPTION
Changed the Official Zoning Map link to 

https://www1.nyc.gov/site/planning/zoning/index-map.page