### PR TITLE
improve markup in attachments component

### DIFF
--- a/client/app/components/packages/attachments.hbs
+++ b/client/app/components/packages/attachments.hbs
@@ -1,130 +1,126 @@
-<div class="site-main grid-x grid-margin-x" ...attributes>
-  <div class="cell">
-    <Ui::Question class="fieldset" as |Q|>
-      <Q.Prompt>
-        Attachments
-      </Q.Prompt>
+<div ...attributes>
+  <Ui::Question @fieldset={{true}} class="fieldset" as |Q|>
+    <Q.Prompt>
+      Attachments
+    </Q.Prompt>
 
-      <ul class="no-bullet">
-        {{#each @fileManager.existingFiles as |file idx|}}
-          <li class="slide-in-bottom">
-            <div class="grid-x">
-              <div class="cell auto">
-                <a
-                  href={{concat (get-env-variable 'host') '/documents' file.serverRelativeUrl}}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  data-test-document-name={{idx}}
-                >
-                  {{file.name}}
-                </a>
-              </div>
-              <div class="cell shrink medium-padding-left">
-                <small>
-                  {{file.timeCreated}}
-                </small>
-              </div>
-              <div class="cell shrink medium-padding-left">
-                <button
-                  type="button"
-                  class="text-red-dark"
-                  {{on "click" (fn this.markFileForDeletion file)}}
-                  data-test-delete-file-button={{idx}}
-                >
-                  <FaIcon @icon="times" @prefix="fas" @fixedWidth={{true}} />
-                </button>
-              </div>
+    <ul class="no-bullet">
+      {{#each @fileManager.existingFiles as |file idx|}}
+        <li class="slide-in-bottom">
+          <div class="grid-x">
+            <div class="cell auto">
+              <a
+                href={{concat (get-env-variable 'host') '/documents' file.serverRelativeUrl}}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-test-document-name={{idx}}
+              >
+                {{file.name}}
+              </a>
             </div>
-          </li>
-        {{/each}}
-      </ul>
+            <div class="cell shrink medium-padding-left">
+              <small>
+                {{file.timeCreated}}
+              </small>
+            </div>
+            <div class="cell shrink medium-padding-left">
+              <button
+                type="button"
+                class="text-red-dark"
+                {{on "click" (fn this.markFileForDeletion file)}}
+                data-test-delete-file-button={{idx}}
+              >
+                <FaIcon @icon="times" @prefix="fas" @fixedWidth={{true}} />
+              </button>
+            </div>
+          </div>
+        </li>
+      {{/each}}
+    </ul>
 
+    {{#if (or @fileManager.filesToDelete @fileManager.filesToUpload.files)}}
       <hr>
 
-      {{#if (or @fileManager.filesToDelete @fileManager.filesToUpload.files)}}
-        <h6 class="medium-margin-bottom slide-in-top">
-          To be
-          {{if @fileManager.filesToUpload.files 'uploaded'}}
-          {{if (and @fileManager.filesToDelete @fileManager.filesToUpload.files) '/'}}
-          {{if @fileManager.filesToDelete 'deleted'}}
-          when you save the project:
-        </h6>
-      {{/if}}
+      <h6 class="medium-margin-bottom slide-in-top">
+        To be
+        {{if @fileManager.filesToUpload.files 'uploaded'}}
+        {{if (and @fileManager.filesToDelete @fileManager.filesToUpload.files) '/'}}
+        {{if @fileManager.filesToDelete 'deleted'}}
+        when you save the project:
+      </h6>
+    {{/if}}
 
-      <ul class="no-bullet">
-        {{#each @fileManager.filesToDelete as |file idx|}}
-          <li class="slide-in-top">
-            <div class="grid-x">
-              <div class="cell auto">
-                <b
-                  data-test-document-to-be-deleted-name={{idx}}
-                >
-                  {{file.name}}
-                </b>
-              </div>
-              <div class="cell shrink medium-padding-left">
-                <small>
-                  TO BE DELETED
-                </small>
-              </div>
-              <div class="cell shrink medium-padding-left">
-                <button
-                  type="button"
-                  {{on "click" (fn this.unmarkFileForDeletion file)}}
-                  data-test-undo-delete-file-button={{idx}}
-                >
-                  <FaIcon @icon="undo" @prefix="fas" @fixedWidth={{true}} />
-                </button>
-              </div>
+    <ul class="no-bullet">
+      {{#each @fileManager.filesToDelete as |file idx|}}
+        <li class="slide-in-top">
+          <div class="grid-x">
+            <div class="cell auto">
+              <b
+                data-test-document-to-be-deleted-name={{idx}}
+              >
+                {{file.name}}
+              </b>
             </div>
-          </li>
-        {{/each}}
-      </ul>
-
-      <ul class="no-bullet">
-        {{#each @fileManager.filesToUpload.files as |file idx|}}
-          <li class="slide-in-top">
-            <div class="grid-x">
-              <div class="cell auto">
-                <b
-                  data-test-document-to-be-uploaded-name={{idx}}
-                >
-                  {{file.name}}
-                </b>
-              </div>
-              <div class="cell shrink medium-padding-left">
-                <small>
-                  TO BE ADDED
-                </small>
-              </div>
-              <div class="cell shrink medium-padding-left">
-                <button
-                  type="button"
-                  class="text-red-dark"
-                  {{on "click" (fn this.deselectFileForUpload file)}}
-                  data-test-deselect-file-button={{idx}}
-                >
-                  <FaIcon @icon="times" @prefix="fas" @fixedWidth={{true}} />
-                </button>
-              </div>
+            <div class="cell shrink medium-padding-left">
+              <small>
+                TO BE DELETED
+              </small>
             </div>
-          </li>
-        {{/each}}
-      </ul>
+            <div class="cell shrink medium-padding-left">
+              <button
+                type="button"
+                {{on "click" (fn this.unmarkFileForDeletion file)}}
+                data-test-undo-delete-file-button={{idx}}
+              >
+                <FaIcon @icon="undo" @prefix="fas" @fixedWidth={{true}} />
+              </button>
+            </div>
+          </div>
+        </li>
+      {{/each}}
+    </ul>
 
-      <div class="cell large-auto">
-        <FileUpload
-          id={{concat "FileUploader" @package.id}}
-          @name={{@package.id}}
-          @accept='*/*'
-          @multiple={{true}}
-          @onfileadd={{this.trackFileForUpload}}
-          class="button secondary expanded"
-        >
-          <FaIcon @icon="upload" @prefix="fas" />
-          Choose Files
-        </FileUpload>
-      </div>
-    </Ui::Question>
-  </div>
+    <ul class="no-bullet">
+      {{#each @fileManager.filesToUpload.files as |file idx|}}
+        <li class="slide-in-top">
+          <div class="grid-x">
+            <div class="cell auto">
+              <b
+                data-test-document-to-be-uploaded-name={{idx}}
+              >
+                {{file.name}}
+              </b>
+            </div>
+            <div class="cell shrink medium-padding-left">
+              <small>
+                TO BE ADDED
+              </small>
+            </div>
+            <div class="cell shrink medium-padding-left">
+              <button
+                type="button"
+                class="text-red-dark"
+                {{on "click" (fn this.deselectFileForUpload file)}}
+                data-test-deselect-file-button={{idx}}
+              >
+                <FaIcon @icon="times" @prefix="fas" @fixedWidth={{true}} />
+              </button>
+            </div>
+          </div>
+        </li>
+      {{/each}}
+    </ul>
+
+    <FileUpload
+      id={{concat "FileUploader" @package.id}}
+      @name={{@package.id}}
+      @accept='*/*'
+      @multiple={{true}}
+      @onfileadd={{this.trackFileForUpload}}
+      class="button secondary expanded"
+    >
+      <FaIcon @icon="upload" @prefix="fas" />
+      Choose Files
+    </FileUpload>
+  </Ui::Question>
 </div>


### PR DESCRIPTION
This PR fixes some bad markup in the attachments component. 
- Call prompt poperly w/ `@fieldset={{true}}` — this was causing the whole component to be wrapped in a `<label>` tag
- Remove `.site-main.grid-x.grid-margin-x` class
- Remove unnecessary grid cells
- Only show hr if there's content to separate 