### PR TITLE
223 create syncactions method for proposed actions

### DIFF
--- a/server/src/packages/rwcds-form/affected-zoning-resolution/affected-zoning-resolution.controller.ts
+++ b/server/src/packages/rwcds-form/affected-zoning-resolution/affected-zoning-resolution.controller.ts
@@ -1,0 +1,35 @@
+import { Controller, Patch, Body, Param, UseGuards, UseInterceptors, UsePipes, Post } from '@nestjs/common';
+import { AuthenticateGuard } from '../../../authenticate.guard';
+import { JsonApiSerializeInterceptor } from '../../../json-api-serialize.interceptor';
+import { JsonApiDeserializePipe } from '../../../json-api-deserialize.pipe';
+import { pick } from 'underscore';
+import { AFFECTED_ZONING_RESOLUTION_ATTRIBUTES } from './affected-zoning-resolutions.attrs';
+import { CrmService } from '../../../crm/crm.service';
+
+@UseInterceptors(new JsonApiSerializeInterceptor('affected-zoning-resolutions', {
+  attributes: [
+    ...AFFECTED_ZONING_RESOLUTION_ATTRIBUTES,
+  ],
+}))
+@UseGuards(AuthenticateGuard)
+@UsePipes(JsonApiDeserializePipe)
+@Controller('affected-zoning-resolutions')
+export class AffectedZoningResolutionController {
+  constructor(private readonly crmService: CrmService) {}
+
+  @Patch('/:id')
+  async update(@Body() body, @Param('id') id) {
+    const allowedAttrs = pick(body, AFFECTED_ZONING_RESOLUTION_ATTRIBUTES);
+
+    await this.crmService.update(
+      'dcp_affectedzoningresolutions',
+      id,
+      allowedAttrs,
+    );
+
+    return {
+      dcp_affectedzoningresolutionid: id,
+      ...body
+    };
+  }
+}

--- a/server/src/packages/rwcds-form/affected-zoning-resolution/affected-zoning-resolutions.attrs.ts
+++ b/server/src/packages/rwcds-form/affected-zoning-resolution/affected-zoning-resolutions.attrs.ts
@@ -1,7 +1,3 @@
 export const AFFECTED_ZONING_RESOLUTION_ATTRIBUTES = [
-  // 'dcp_zoningresolutiontype',
-  // 'dcp_zrsectionnumber',
   'dcp_modifiedzrsectionnumber',
-  // '_dcp_rwcdsform_value',
-  // 'dcp_affectedzoningresolutionid',
 ];

--- a/server/src/packages/rwcds-form/affected-zoning-resolution/affected-zoning-resolutions.attrs.ts
+++ b/server/src/packages/rwcds-form/affected-zoning-resolution/affected-zoning-resolutions.attrs.ts
@@ -1,0 +1,7 @@
+export const AFFECTED_ZONING_RESOLUTION_ATTRIBUTES = [
+  // 'dcp_zoningresolutiontype',
+  // 'dcp_zrsectionnumber',
+  'dcp_modifiedzrsectionnumber',
+  // '_dcp_rwcdsform_value',
+  // 'dcp_affectedzoningresolutionid',
+];

--- a/server/src/packages/rwcds-form/affected-zoning-resolution/affected-zoning-resolutions.controller.spec.ts
+++ b/server/src/packages/rwcds-form/affected-zoning-resolution/affected-zoning-resolutions.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AffectedZoningResolutionsController } from './affected-zoning-resolutions.controller';
+import { CrmModule } from '../../../crm/crm.module';
+
+describe('AffectedZoningResolutions Controller', () => {
+  let controller: AffectedZoningResolutionsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [CrmModule],
+      controllers: [AffectedZoningResolutionsController],
+    }).compile();
+
+    controller = module.get<AffectedZoningResolutionsController>(AffectedZoningResolutionsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/server/src/packages/rwcds-form/affected-zoning-resolution/affected-zoning-resolutions.controller.ts
+++ b/server/src/packages/rwcds-form/affected-zoning-resolution/affected-zoning-resolutions.controller.ts
@@ -14,7 +14,7 @@ import { CrmService } from '../../../crm/crm.service';
 @UseGuards(AuthenticateGuard)
 @UsePipes(JsonApiDeserializePipe)
 @Controller('affected-zoning-resolutions')
-export class AffectedZoningResolutionController {
+export class AffectedZoningResolutionsController {
   constructor(private readonly crmService: CrmService) {}
 
   @Patch('/:id')

--- a/server/src/packages/rwcds-form/rwcds-form.service.ts
+++ b/server/src/packages/rwcds-form/rwcds-form.service.ts
@@ -5,6 +5,44 @@ import { pick } from 'underscore';
 import { RWCDS_FORM_ATTRS } from './rwcds-form.attrs';
 import { PACKAGE_ATTRS } from '../packages.attrs';
 
+const ZONING_RESOLUTION_TYPES = [
+  ["ZA", 717170000],
+  ["ZC", 717170001],
+  ["ZS", 717170002],
+  ["ZR", 717170003],
+  ["ZM", 717170008],
+  ["SD", 717170009],
+  ["SC", 717170010],
+  ["SA", 717170011],
+  ["RS", 717170012],
+  ["RC", 717170013],
+  ["RA", 717170014],
+  ["PS", 717170015],
+  ["PQ", 717170016],
+  ["PP", 717170017],
+  ["PE", 717170018],
+  ["PC", 717170019],
+  ["NP", 717170020],
+  ["MY", 717170021],
+  ["MM", 717170022],
+  ["ML", 717170023],
+  ["ME", 717170024],
+  ["MC", 717170025],
+  ["LD", 717170026],
+  ["HU", 717170027],
+  ["HP", 717170028],
+  ["HO", 717170029],
+  ["HN", 717170030],
+  ["HG", 717170031],
+  ["HD", 717170032],
+  ["HC", 717170033],
+  ["HA", 717170034],
+  ["GF", 717170035],
+  ["CM", 717170036],
+  ["BF", 717170037],
+  ["BD", 717170038],
+];
+
 @Injectable()
 export class RwcdsFormService {
   constructor(
@@ -55,8 +93,7 @@ export class RwcdsFormService {
     const { _dcp_projectid_value } = rwcdsForm;
 
     // run syncActions to synchronize dcp_projectaction and dcp_affectedzoningresolution entities
-    const affectedZoningResolutions = rwcdsForm.dcp_rwcdsform_dcp_affectedzoningresolution_rwcdsform;
-    this.syncActions(_dcp_projectid_value, id, affectedZoningResolutions);
+    await this.syncActions(rwcdsForm);
 
     // requires info from adjacent latest pasForm
     if (
@@ -84,33 +121,36 @@ export class RwcdsFormService {
   // with the rwcds form's related project. 
   // Then, it posts each of the project actions to dcp_affectedzoningresolution.
   // This occurs every time that the rwcds-form endpoint is hit
-  async syncActions(projectId, rwcdsFormId, affectedZoningResolutions) {
-    const { records: [currentProjectWithActions] } = await this.crmService.get(`dcp_projects`, `
-      $select=dcp_projectid
-      &$filter=_dcp_projectid_value eq ${projectId}
-      &$expand=dcp_dcp_project_dcp_projectaction_project($filter=statuscode eq 1)
+  async syncActions(rwcdsForm) {
+    const {
+      dcp_rwcdsform_dcp_affectedzoningresolution_rwcdsform: affectedZoningResolutions,
+      _dcp_projectid_value,
+      dcp_rwcdsformid,
+    } = rwcdsForm;
+    const zrTypes = affectedZoningResolutions.map(zr => zr['dcp_zoningresolutiontype@OData.Community.Display.V1.FormattedValue']);
+    console.log(zrTypes);
+    const { records: projectActions } = await this.crmService.get(`dcp_projectactions`, `
+      $filter=_dcp_project_value eq ${_dcp_projectid_value}
     `);
 
-    const projectActions = currentProjectWithActions.dcp_dcp_project_dcp_projectaction_project;
+    await Promise.all(projectActions.map(action => {
+      const projectActionLabel = action['_dcp_action_value@OData.Community.Display.V1.FormattedValue'];
 
-    const regexFirstWord = /^(\w+)/g;
+      // Lookup: dcp_affectedzoningresolutions asks for a ZR type,
+      const [actionLabel, actionCode] = ZONING_RESOLUTION_TYPES.find((label) => label === projectActionLabel) || ['ZA', 717170000];
 
-    console.log('bananas', affectedZoningResolutions[0]);
+      if (!actionLabel) console.log(`Could not find Affected ZR Type for ${projectActionLabel}`);
 
-    const zrIds = affectedZoningResolutions.map(zr => zr.dcp_affectedzoningresolutionid);
-
-    projectActions.forEach(action => !zrIds.includes(action.dcp_projectactionid) ? this.crmService.create(
-      `dcp_affectedzoningresolution`, 
-        {
-          'dcp_zoningresolutiontype': action.dcp_name.match(regexFirstWord),
+      if (!zrTypes.includes(actionLabel)) {
+        return this.crmService.create(`dcp_affectedzoningresolutions`, {
+          'dcp_zoningresolutiontype': actionCode, // this is a coded value
           'dcp_zrsectionnumber': action.dcp_zrsectionnumber,
-          'dcp_modifiedzrsectoinnumber': action.dcp_zrmodifyingzrtxt,
-          '_dcp_rwcdsform_value': rwcdsFormId,
-          'dcp_affectedzoningresolutionid': action.dcp_projectactionid, 
-          // how is this generated?? With the projectaction id?
-          // e.g. b6d22b11-4502-ea11-b862-00155da05478
-        },
-      ) : console.log(`zoning resolution with id ${action.dcp_projectactionid} already exists`),
-    );
+          'dcp_modifiedzrsectionnumber': action.dcp_zrmodifyingzrtxt,
+          'dcp_rwcdsform@odata.bind': `/dcp_pasforms(${dcp_rwcdsformid})`,
+        });
+      } else {
+        console.log(`zoning resolution with id ${projectActionLabel} already exists`);
+      }
+    }));
   }
 }


### PR DESCRIPTION
- set up backend patch for updating `dcp_affectedzoningresolution` entity
- when rwcds' `find` method is run, a new method `syncActions` will copy `dcp_projectaction` entity associated with current project to `dcp_affectedzoningresolution`. The frontend then only interacts with `dcp_affectedzoningresolution`

Addreses issue #223 (reference this issue for scope of problem).