### PR TITLE
add RequiredAsterisk component and call it in prompts

### DIFF
--- a/client/app/components/packages/applicant-fieldset.hbs
+++ b/client/app/components/packages/applicant-fieldset.hbs
@@ -53,6 +53,7 @@
         <Ui::Question as |Q|>
           <Q.Prompt>
             <span class="text-weight-normal">First Name</span>
+            <Ui::RequiredAsterisk />
           </Q.Prompt>
 
           <Form.Field @attribute="dcpFirstname"/>
@@ -63,6 +64,7 @@
         <Ui::Question as |Q|>
           <Q.Prompt>
             <span class="text-weight-normal">Last Name</span>
+            <Ui::RequiredAsterisk />
           </Q.Prompt>
 
           <Form.Field @attribute="dcpLastname"/>
@@ -84,6 +86,7 @@
     <Ui::Question as |Q|>
       <Q.Prompt>
         <span class="text-weight-normal">Email Address</span>
+        <Ui::RequiredAsterisk />
       </Q.Prompt>
 
       <Form.Field @attribute="dcpEmail"/>

--- a/client/app/components/packages/land-use-action.hbs
+++ b/client/app/components/packages/land-use-action.hbs
@@ -44,6 +44,7 @@
               --}}
               <label class="middle">
                 <strong>How many {{landUseAction.name}} actions?</strong>
+                <Ui::RequiredAsterisk />
               </label>
             </div>
             <div class="auto cell">
@@ -63,6 +64,7 @@
           <Ui::Question as |Q|>
             <Q.Prompt>
               Where in the Zoning Resolution can this action be found?
+              <Ui::RequiredAsterisk />
             </Q.Prompt>
 
             <Form.Field
@@ -81,6 +83,7 @@
           <Ui::Question as |Q|>
             <Q.Prompt>
               Which sections of the Zoning Resolution does this modify?
+              <Ui::RequiredAsterisk />
             </Q.Prompt>
 
             <Form.Field
@@ -101,6 +104,7 @@
           <Ui::Question as |Q|>
             <Q.Prompt>
               Existing Zoning Districts:
+              <Ui::RequiredAsterisk />
             </Q.Prompt>
 
             <Form.Field
@@ -119,6 +123,7 @@
           <Ui::Question as |Q|>
             <Q.Prompt>
               Proposed Zoning Districts:
+              <Ui::RequiredAsterisk />
             </Q.Prompt>
 
             <Form.Field
@@ -139,6 +144,7 @@
           <Ui::Question as |Q|>
             <Q.Prompt>
               Affected ZR Section Number:
+              <Ui::RequiredAsterisk />
             </Q.Prompt>
 
             <Form.Field
@@ -157,6 +163,7 @@
           <Ui::Question as |Q|>
             <Q.Prompt>
               Affected ZR Section Title:
+              <Ui::RequiredAsterisk />
             </Q.Prompt>
 
             <Form.Field
@@ -177,6 +184,7 @@
           <Ui::Question as |Q|>
             <Q.Prompt>
               Previous ULURP Numbers:
+              <Ui::RequiredAsterisk />
             </Q.Prompt>
 
             <Form.Field

--- a/client/app/components/packages/pas-form/project-area.hbs
+++ b/client/app/components/packages/pas-form/project-area.hbs
@@ -46,6 +46,7 @@
             <Ui::Question as |Q|>
               <Q.Prompt>
                 What is the name of the Urban Renewal Area?
+                <Ui::RequiredAsterisk />
               </Q.Prompt>
 
               <Form.Field
@@ -104,6 +105,7 @@
             <Ui::Question as |Q|>
               <Q.Prompt>
                 Indicate which SEQRA or CEQR category each action fulfills
+                <Ui::RequiredAsterisk />
                 <small class="help-text display-block text-weight-normal">
                   Ex: 617.5(c)(9)
                 </small>
@@ -140,6 +142,7 @@
             <Ui::Question as |Q|>
               <Q.Prompt>
                 Name of Industrial Business Zone
+                <Ui::RequiredAsterisk />
               </Q.Prompt>
 
               <Form.Field
@@ -173,6 +176,7 @@
             <Ui::Question as |Q|>
               <Q.Prompt>
                 Name of Landmark or Historic District
+                <Ui::RequiredAsterisk />
               </Q.Prompt>
 
               <Form.Field

--- a/client/app/components/packages/pas-form/project-information.hbs
+++ b/client/app/components/packages/pas-form/project-information.hbs
@@ -2,7 +2,8 @@
   <Form.Section @title="Project Information">
     <Ui::Question as |Q|>
       <Q.Prompt>
-        Project Name <Ui::RequiredAsterisk />
+        Project Name
+        <Ui::RequiredAsterisk />
       </Q.Prompt>
 
       <Form.Field @attribute="dcpRevisedprojectname" />

--- a/client/app/components/packages/pas-form/project-information.hbs
+++ b/client/app/components/packages/pas-form/project-information.hbs
@@ -2,7 +2,7 @@
   <Form.Section @title="Project Information">
     <Ui::Question as |Q|>
       <Q.Prompt>
-        Project Name
+        Project Name <Ui::RequiredAsterisk />
       </Q.Prompt>
 
       <Form.Field @attribute="dcpRevisedprojectname" />

--- a/client/app/components/packages/pas-form/proposed-development-site.hbs
+++ b/client/app/components/packages/pas-form/proposed-development-site.hbs
@@ -59,7 +59,7 @@
       {{#if @form.saveableChanges.dcpProposeddevelopmentsiteinfoother}}
         <Ui::Question as |Q|>
           <Q.Prompt>
-            Explain:
+            Explain: <Ui::RequiredAsterisk />
           </Q.Prompt>
           <Form.Field @attribute="dcpProposeddevelopmentsiteotherexplanation"/>
         </Ui::Question>
@@ -70,6 +70,7 @@
       <Q.Prompt>
         Is the Development Site in an
         <Ui::ExternalLink @href="https://zola.planning.nyc.gov/">Inclusionary Housing Designated Area/Mandatory Inclusionary Housing Area</Ui::ExternalLink>?
+        <Ui::RequiredAsterisk />
       </Q.Prompt>
 
       <p class="text-small">
@@ -102,6 +103,7 @@
     <Ui::Question @fieldset={{true}} as |Q|>
       <Q.Prompt>
         Does the proposed development involve discretionary funding for Affordable Housing Units?
+        <Ui::RequiredAsterisk />
       </Q.Prompt>
 
       <Form.Field

--- a/client/app/components/packages/pas-form/proposed-development-site.hbs
+++ b/client/app/components/packages/pas-form/proposed-development-site.hbs
@@ -59,7 +59,8 @@
       {{#if @form.saveableChanges.dcpProposeddevelopmentsiteinfoother}}
         <Ui::Question as |Q|>
           <Q.Prompt>
-            Explain: <Ui::RequiredAsterisk />
+            Explain:
+            <Ui::RequiredAsterisk />
           </Q.Prompt>
           <Form.Field @attribute="dcpProposeddevelopmentsiteotherexplanation"/>
         </Ui::Question>

--- a/client/app/components/packages/rwcds-form/project-description.hbs
+++ b/client/app/components/packages/rwcds-form/project-description.hbs
@@ -30,6 +30,7 @@
     <label>
       <strong>
         Identify and describe the existing conditions of all areas affected by the proposed actions
+        <Ui::RequiredAsterisk />
       </strong>
       <form.Field
         @type="text-area"
@@ -41,6 +42,7 @@
     <label>
       <strong>
         Describe the proposed project facilitated by the proposed actions
+        <Ui::RequiredAsterisk />
       </strong>
       <form.Field
         @type="text-area"

--- a/client/app/components/packages/rwcds-form/proposed-project-actions.hbs
+++ b/client/app/components/packages/rwcds-form/proposed-project-actions.hbs
@@ -68,6 +68,7 @@
             {{#if (eq value 717170000)}}
               <Q.Prompt>
                 Which actions from other agencies are sought?
+                <Ui::RequiredAsterisk />
               </Q.Prompt>
               <br>
               <Form.Field

--- a/client/app/components/packages/rwcds-form/with-action-no-action.hbs
+++ b/client/app/components/packages/rwcds-form/with-action-no-action.hbs
@@ -17,7 +17,7 @@
             <li>Rationale for selecting Projected Development Sites and Potential Development Sites</li>
             <li>Possible use conversions</li>
             <li>Expansions or sites with bulk or uses that would be legalized in the future with the Proposed Actions</li>
-            <li>Other Sites that may be excluded from the analysis, if applicable (e.g., rent stabilized    residential buildings, which are difficult to legally demolish due to tenant relocation requirements). Please note that dwelling unit sizes typically range between 850 – 1,000 gsf.</li>
+            <li>Other Sites that may be excluded from the analysis, if applicable (e.g., rent stabilized   residential buildings, which are difficult to legally demolish due to tenant relocation requirements). Please note that dwelling unit sizes typically range between 850 – 1,000 gsf.</li>
           </ul>
         <p>
           Please note that dwelling unit sizes typically range between 850 – 1,000 gsf.
@@ -92,7 +92,7 @@
                   If a prior environmental review was conducted on the Project/Development Site, and the Projected or Potential Development Sites were assumed as soft sites in the prior environmental review materials, it may be appropriate to assume that the prior project’s With-Action Scenario is this Project’s/Development’s future No-Action Scenario.
                 </p>
               </Ui::CollapsibleText>
-              <form.Field 
+              <form.Field
                 @attribute="dcpDescribethenoactionscenario"
                 @type="text-area"
                 @maxlength="1500"
@@ -127,6 +127,7 @@
             <Ui::Question as |Q|>
               <Q.Prompt>
                 Explain why the project is the same as the proposed With-Action Scenario.
+                <Ui::RequiredAsterisk />
               </Q.Prompt>
               <form.Field
                 @attribute="dcpRwcdsexplanation"
@@ -143,7 +144,7 @@
                 @buttonText="Additional Guidance"
               >
                 <p>
-                Describe a future development scenario that is likely and would reasonably occur with the approval of the Proposed Action(s) by the Analysis Year, including: 
+                Describe a future development scenario that is likely and would reasonably occur with the approval of the Proposed Action(s) by the Analysis Year, including:
                 </p>
                   <ul>
                     <li>How all of the Development Sites(s) in question could reasonably be developed with regard to the underlying zoning district and any other applicable site controls</li>
@@ -158,7 +159,7 @@
                     <li>Site ownership, etc</li>
                   </ul>
                 <p>
-                  Describe the future development expected to occur on all of the Projected Development Sites (and in a separate paragraph, the Potential Development Sites, if any). 
+                  Describe the future development expected to occur on all of the Projected Development Sites (and in a separate paragraph, the Potential Development Sites, if any).
                 </p>
               </Ui::CollapsibleText>
               <form.Field

--- a/client/app/components/ui/required-asterisk.hbs
+++ b/client/app/components/ui/required-asterisk.hbs
@@ -1,6 +1,9 @@
-<sup>
-  <FaIcon @icon="asterisk" class="text-red text-weight-normal" @transform="shrink-4" />
-  <EmberTooltip>
-    Required
-  </EmberTooltip>
+<sup class="text-red">
+  <LabsUi::IconTooltip
+    @tip="This field is required"
+    @icon="asterisk"
+    @side="top"
+    @transform="shrink-4"
+    @fixedWidth={{false}}
+  />
 </sup>

--- a/client/app/components/ui/required-asterisk.hbs
+++ b/client/app/components/ui/required-asterisk.hbs
@@ -1,0 +1,6 @@
+<sup>
+  <FaIcon @icon="asterisk" class="text-red text-weight-normal" @transform="shrink-4" />
+  <EmberTooltip>
+    Required
+  </EmberTooltip>
+</sup>


### PR DESCRIPTION
This PR adds a `<Ui::RequiredAsterisk />` component which is called within prompts to indicate that its field is required. 

```
<Ui::Question as |Q|>
  <Q.Prompt>
    What's your name?
    <Ui::RequiredAsterisk />
  </Q.Prompt>
  ...
</Ui::Question>
```

It inserts a FontAwesome asterisk icon with a tooltip. 

![image](https://user-images.githubusercontent.com/409279/86840593-e63f4e00-c070-11ea-9931-f45a8d36ba6c.png)

-----

NOTE: As is, the `<Ui::Question>` component is not aware of the `<Form.Field>` and this PR is more evidence that they could be refactored as one component that generates both the prompt and the field(s), auto generating `for=""` attributes. We're already flagging in the "saveable" validations which fields are required, and this PR flags the labels separately. It would be nice if we could easily keep the prompt asterisk in sync with the validation. 