### PR TITLE
335: include ura name on pas how template

### DIFF
--- a/client/app/components/packages/pas-form/show.hbs
+++ b/client/app/components/packages/pas-form/show.hbs
@@ -325,6 +325,17 @@
         </A.Field>
       </Ui::Answer>
 
+      {{#if @package.pasForm.dcpUrbanareaname}}
+        <Ui::Answer @beside={{true}} as |A|>
+          <A.Prompt>
+            Name of Urban Renewal Area:
+          </A.Prompt>
+          <A.Field>
+            {{@package.pasForm.dcpUrbanareaname}}
+          </A.Field>
+        </Ui::Answer>
+      {{/if}}
+
       <Ui::Answer @beside={{true}} as |A|>
         <A.Prompt>
           Legal Street Frontage Status


### PR DESCRIPTION
Addresses #335. The Urban Renewal Area name `dcpUrbanareaname` was missing in the pas/show template.