### PR TITLE
480: update backend for proposed actions

### DIFF
--- a/client/app/components/packages/rwcds-form/proposed-project-actions-editor.hbs
+++ b/client/app/components/packages/rwcds-form/proposed-project-actions-editor.hbs
@@ -2,10 +2,10 @@
   <fieldset class="fieldset">
     <Ui::Legend>
       <span class="label">
-        {{~zrForm.saveableChanges.dcpZoningresolutiontype~}}
-        {{#if (lookup-action-type zrForm.saveableChanges.dcpZoningresolutiontype)}}
+        {{~this.zrTypeLabel~}}
+        {{#if (lookup-action-type this.zrTypeLabel)}}
           <LabsUi::IconTooltip
-            @tip={{lookup-action-type zrForm.saveableChanges.dcpZoningresolutiontype}}
+            @tip={{lookup-action-type this.zrTypeLabel}}
             @icon="info-circle"
             @side="bottom"
             @transform="shrink-4 up-2"

--- a/client/app/components/packages/rwcds-form/proposed-project-actions-editor.js
+++ b/client/app/components/packages/rwcds-form/proposed-project-actions-editor.js
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import { optionset } from '../../../helpers/optionset';
 
 export default class ProposedActionsComponent extends Component {
   actionsWithSectionNumberAndSectionTitle = [
@@ -9,32 +10,33 @@ export default class ProposedActionsComponent extends Component {
     'ZA', 'ZS', 'SD', 'SA', 'RA', 'RS',
   ];
 
-  get zrAppendixF() {
-    const zrType = this.args.zrForm.saveableChanges.dcpZoningresolutiontype;
-    const zrSectionNumber = this.args.zrForm.saveableChanges.dcpZrsectionnumber;
+  get zrTypeLabel() {
+    const zrTypeCode = this.args.zrForm.saveableChanges.dcpZoningresolutiontype;
 
-    return zrType === 'ZR' && zrSectionNumber === 'Appendix F';
+    return optionset(['affectedZoningResolution', 'actions', 'label', zrTypeCode]);
+  }
+
+  get zrAppendixF() {
+    const zrSectionNumber = this.args.zrForm.saveableChanges.dcpZrsectionnumber;
+    return this.zrTypeLabel === 'ZR' && zrSectionNumber === 'Appendix F';
   }
 
   get zrSectionNumber() {
-    const zrType = this.args.zrForm.saveableChanges.dcpZoningresolutiontype;
     const zrSectionNumber = this.args.zrForm.saveableChanges.dcpZrsectionnumber;
 
-    const zrTypeInArray = this.actionsWithSectionNumberAndSectionTitle.includes(zrType);
+    const zrTypeInArray = this.actionsWithSectionNumberAndSectionTitle.includes(this.zrTypeLabel);
     if (zrTypeInArray || this.zrAppendixF) {
       return zrSectionNumber;
     } return null;
   }
 
   get hasModifiedZrSectionNumberQuestion() {
-    const zrType = this.args.zrForm.saveableChanges.dcpZoningresolutiontype;
-    const zrTypeInArray = this.actionsWithModifiedZrSectionNumberQuestion.includes(zrType);
+    const zrTypeInArray = this.actionsWithModifiedZrSectionNumberQuestion.includes(this.zrTypeLabel);
     return zrTypeInArray;
   }
 
   get hasZrSectionTitleQuestion() {
-    const zrType = this.args.zrForm.saveableChanges.dcpZoningresolutiontype;
-    const zrTypeInArray = this.actionsWithSectionNumberAndSectionTitle.includes(zrType);
+    const zrTypeInArray = this.actionsWithSectionNumberAndSectionTitle.includes(this.zrTypeLabel);
     return zrTypeInArray || this.zrAppendixF;
   }
 }

--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -8,6 +8,9 @@ import {
   BOROUGHS_OPTIONSET,
 } from '../models/bbl';
 import {
+  AFFECTED_ZONING_RESOLUTION_ACTION_OPTIONSET,
+} from '../models/affected-zoning-resolution';
+import {
   PACKAGE_STATE_OPTIONSET,
   PACKAGE_STATUS_OPTIONSET,
   PACKAGE_VISIBILITY_OPTIONSET,
@@ -49,6 +52,9 @@ const OPTIONSET_LOOKUP = {
     dcpRestrictivedeclarationrequired: YES_NO_UNSURE_OPTIONSET,
     dcpDiscressionaryfundingforffordablehousing: YES_NO_UNSURE_OPTIONSET,
     dcpHousingunittype: DCPHOUSINGUNITTYPE_OPTIONSET,
+  },
+  affectedZoningResolution: {
+    actions: AFFECTED_ZONING_RESOLUTION_ACTION_OPTIONSET,
   },
 };
 

--- a/client/app/models/affected-zoning-resolution.js
+++ b/client/app/models/affected-zoning-resolution.js
@@ -1,5 +1,148 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
+export const AFFECTED_ZONING_RESOLUTION_ACTION_OPTIONSET = {
+  ZA: {
+    code: 717170000,
+    label: 'ZA',
+  },
+  ZC: {
+    code: 717170001,
+    label: 'ZC',
+  },
+  ZS: {
+    code: 717170002,
+    label: 'ZS',
+  },
+  ZR: {
+    code: 717170003,
+    label: 'ZR',
+  },
+  ZM: {
+    code: 717170008,
+    label: 'ZM',
+  },
+  SD: {
+    code: 717170009,
+    label: 'SD',
+  },
+  SC: {
+    code: 717170010,
+    label: 'SC',
+  },
+  SA: {
+    code: 717170011,
+    label: 'SA',
+  },
+  RS: {
+    code: 717170012,
+    label: 'RS',
+  },
+  RC: {
+    code: 717170013,
+    label: 'RC',
+  },
+  RA: {
+    code: 717170014,
+    label: 'RA',
+  },
+  PS: {
+    code: 717170015,
+    label: 'PS',
+  },
+  PQ: {
+    code: 717170016,
+    label: 'PQ',
+  },
+  PP: {
+    code: 717170017,
+    label: 'PP',
+  },
+  PE: {
+    code: 717170018,
+    label: 'PE',
+  },
+  PC: {
+    code: 717170019,
+    label: 'PC',
+  },
+  NP: {
+    code: 717170020,
+    label: 'NP',
+  },
+  MY: {
+    code: 717170021,
+    label: 'MY',
+  },
+  MM: {
+    code: 717170022,
+    label: 'MM',
+  },
+  ML: {
+    code: 717170023,
+    label: 'ML',
+  },
+  ME: {
+    code: 717170024,
+    label: 'ME',
+  },
+  MC: {
+    code: 717170025,
+    label: 'MC',
+  },
+  LD: {
+    code: 717170026,
+    label: 'LD',
+  },
+  HU: {
+    code: 717170027,
+    label: 'HU',
+  },
+  HP: {
+    code: 717170028,
+    label: 'HP',
+  },
+  HO: {
+    code: 717170029,
+    label: 'HO',
+  },
+  HN: {
+    code: 717170030,
+    label: 'HN',
+  },
+  HG: {
+    code: 717170031,
+    label: 'HG',
+  },
+  HD: {
+    code: 717170032,
+    label: 'HD',
+  },
+  HC: {
+    code: 717170033,
+    label: 'HC',
+  },
+  HA: {
+    code: 717170034,
+    label: 'HA',
+  },
+  GF: {
+    code: 717170035,
+    label: 'GF',
+  },
+  CM: {
+    code: 717170036,
+    label: 'CM',
+  },
+  BF: {
+    code: 717170037,
+    label: 'BF',
+  },
+  BD: {
+    code: 717170038,
+    label: 'BD',
+  },
+};
+
 export default class AffectedZoningResolutionModel extends Model {
   @belongsTo('rwcds-form')
   rwcdsForm;

--- a/server/src/packages/packages.controller.ts
+++ b/server/src/packages/packages.controller.ts
@@ -9,6 +9,7 @@ import { PAS_FORM_ATTRS, PAS_FORM_PROJECTADDRESS_ATTRS } from './pas-form/pas-fo
 import { PACKAGE_ATTRS } from './packages.attrs';
 import { PROJECT_ATTRS } from '../projects/projects.attrs';
 import { BBL_ATTRS } from './pas-form/bbls/bbls.attrs';
+import { AFFECTEDZONINGRESOLUTION_ATTRS } from './rwcds-form/affected-zoning-resolution/affected-zoning-resolutions.attrs';
 import { APPLICANT_ATTRS } from './pas-form/applicants/applicants.attrs';
 
 @UseInterceptors(new JsonApiSerializeInterceptor('packages', {
@@ -65,7 +66,14 @@ import { APPLICANT_ATTRS } from './pas-form/applicants/applicants.attrs';
     ref: 'dcp_rwcdsformid',
     attributes: [
       ...RWCDS_FORM_ATTRS,
+      'affected-zoning-resolutions',
     ],
+    'affected-zoning-resolutions': {
+      ref: 'dcp_affectedzoningresolutionid',
+      attributes: [
+        ...AFFECTEDZONINGRESOLUTION_ATTRS,
+      ],
+    },
   },
 
   // Transform here should only be used for remapping
@@ -112,6 +120,7 @@ import { APPLICANT_ATTRS } from './pas-form/applicants/applicants.attrs';
         ...projectPackage,
         'rwcds-form': {
           ...rwcdsForm,
+          'affected-zoning-resolutions': rwcdsForm.dcp_rwcdsform_dcp_affectedzoningresolution_rwcdsform,
         }
       }
     } else {

--- a/server/src/packages/packages.module.ts
+++ b/server/src/packages/packages.module.ts
@@ -5,6 +5,7 @@ import { CrmModule } from '../crm/crm.module';
 import { PasFormController } from './pas-form/pas-form.controller';
 import { ApplicantsController } from './pas-form/applicants/applicants.controller';
 import { BblsController } from './pas-form/bbls/bbls.controller';
+import { AffectedZoningResolutionsController } from './rwcds-form/affected-zoning-resolution/affected-zoning-resolutions.controller';
 import { RwcdsFormController } from './rwcds-form/rwcds-form.controller';
 import { PasFormService } from './pas-form/pas-form.service';
 import { RwcdsFormService } from './rwcds-form/rwcds-form.service';
@@ -13,6 +14,6 @@ import { RwcdsFormService } from './rwcds-form/rwcds-form.service';
   imports: [CrmModule],
   exports: [PackagesService],
   providers: [PackagesService, PasFormService, RwcdsFormService],
-  controllers: [PackagesController, PasFormController, RwcdsFormController, ApplicantsController, BblsController],
+  controllers: [PackagesController, PasFormController, RwcdsFormController, ApplicantsController, BblsController, AffectedZoningResolutionsController],
 })
 export class PackagesModule {}

--- a/server/src/packages/rwcds-form/affected-zoning-resolution/affected-zoning-resolutions.attrs.ts
+++ b/server/src/packages/rwcds-form/affected-zoning-resolution/affected-zoning-resolutions.attrs.ts
@@ -1,3 +1,6 @@
-export const AFFECTED_ZONING_RESOLUTION_ATTRIBUTES = [
+export const AFFECTEDZONINGRESOLUTION_ATTRS = [
   'dcp_modifiedzrsectionnumber',
+  'dcp_zoningresolutiontype',
+  'dcp_zrserctionnumber',
+  'dcp_zrsectiontitle',
 ];

--- a/server/src/packages/rwcds-form/affected-zoning-resolution/affected-zoning-resolutions.controller.ts
+++ b/server/src/packages/rwcds-form/affected-zoning-resolution/affected-zoning-resolutions.controller.ts
@@ -3,12 +3,12 @@ import { AuthenticateGuard } from '../../../authenticate.guard';
 import { JsonApiSerializeInterceptor } from '../../../json-api-serialize.interceptor';
 import { JsonApiDeserializePipe } from '../../../json-api-deserialize.pipe';
 import { pick } from 'underscore';
-import { AFFECTED_ZONING_RESOLUTION_ATTRIBUTES } from './affected-zoning-resolutions.attrs';
+import { AFFECTEDZONINGRESOLUTION_ATTRS } from './affected-zoning-resolutions.attrs';
 import { CrmService } from '../../../crm/crm.service';
 
 @UseInterceptors(new JsonApiSerializeInterceptor('affected-zoning-resolutions', {
   attributes: [
-    ...AFFECTED_ZONING_RESOLUTION_ATTRIBUTES,
+    ...AFFECTEDZONINGRESOLUTION_ATTRS,
   ],
 }))
 @UseGuards(AuthenticateGuard)
@@ -19,7 +19,7 @@ export class AffectedZoningResolutionsController {
 
   @Patch('/:id')
   async update(@Body() body, @Param('id') id) {
-    const allowedAttrs = pick(body, AFFECTED_ZONING_RESOLUTION_ATTRIBUTES);
+    const allowedAttrs = pick(body, AFFECTEDZONINGRESOLUTION_ATTRS);
 
     await this.crmService.update(
       'dcp_affectedzoningresolutions',

--- a/server/src/packages/rwcds-form/rwcds-form.service.ts
+++ b/server/src/packages/rwcds-form/rwcds-form.service.ts
@@ -6,41 +6,41 @@ import { RWCDS_FORM_ATTRS } from './rwcds-form.attrs';
 import { PACKAGE_ATTRS } from '../packages.attrs';
 
 const ZONING_RESOLUTION_TYPES = [
-  ["ZA", 717170000],
-  ["ZC", 717170001],
-  ["ZS", 717170002],
-  ["ZR", 717170003],
-  ["ZM", 717170008],
-  ["SD", 717170009],
-  ["SC", 717170010],
-  ["SA", 717170011],
-  ["RS", 717170012],
-  ["RC", 717170013],
-  ["RA", 717170014],
-  ["PS", 717170015],
-  ["PQ", 717170016],
-  ["PP", 717170017],
-  ["PE", 717170018],
-  ["PC", 717170019],
-  ["NP", 717170020],
-  ["MY", 717170021],
-  ["MM", 717170022],
-  ["ML", 717170023],
-  ["ME", 717170024],
-  ["MC", 717170025],
-  ["LD", 717170026],
-  ["HU", 717170027],
-  ["HP", 717170028],
-  ["HO", 717170029],
-  ["HN", 717170030],
-  ["HG", 717170031],
-  ["HD", 717170032],
-  ["HC", 717170033],
-  ["HA", 717170034],
-  ["GF", 717170035],
-  ["CM", 717170036],
-  ["BF", 717170037],
-  ["BD", 717170038],
+  { label: "ZA", code: 717170000 },
+  { label: "ZC", code: 717170001 },
+  { label: "ZS", code: 717170002 },
+  { label: "ZR", code: 717170003 },
+  { label: "ZM", code: 717170008 },
+  { label: "SD", code: 717170009 },
+  { label: "SC", code: 717170010 },
+  { label: "SA", code: 717170011 },
+  { label: "RS", code: 717170012 },
+  { label: "RC", code: 717170013 },
+  { label: "RA", code: 717170014 },
+  { label: "PS", code: 717170015 },
+  { label: "PQ", code: 717170016 },
+  { label: "PP", code: 717170017 },
+  { label: "PE", code: 717170018 },
+  { label: "PC", code: 717170019 },
+  { label: "NP", code: 717170020 },
+  { label: "MY", code: 717170021 },
+  { label: "MM", code: 717170022 },
+  { label: "ML", code: 717170023 },
+  { label: "ME", code: 717170024 },
+  { label: "MC", code: 717170025 },
+  { label: "LD", code: 717170026 },
+  { label: "HU", code: 717170027 },
+  { label: "HP", code: 717170028 },
+  { label: "HO", code: 717170029 },
+  { label: "HN", code: 717170030 },
+  { label: "HG", code: 717170031 },
+  { label: "HD", code: 717170032 },
+  { label: "HC", code: 717170033 },
+  { label: "HA", code: 717170034 },
+  { label: "GF", code: 717170035 },
+  { label: "CM", code: 717170036 },
+  { label: "BF", code: 717170037 },
+  { label: "BD", code: 717170038 },
 ];
 
 @Injectable()
@@ -140,25 +140,24 @@ export class RwcdsFormService {
     const zrTypes = affectedZoningResolutions.map(zr => zr['dcp_zoningresolutiontype@OData.Community.Display.V1.FormattedValue']);
     const { records: projectActions } = await this.crmService.get(`dcp_projectactions`, `
       $filter=_dcp_project_value eq ${_dcp_projectid_value}
+      &$expand=dcp_ZoningResolution
     `);
 
     await Promise.all(projectActions.map(action => {
       const projectActionLabel = action['_dcp_action_value@OData.Community.Display.V1.FormattedValue'];
 
       // Lookup: dcp_affectedzoningresolutions asks for a ZR type,
-      const [actionLabel, actionCode] = ZONING_RESOLUTION_TYPES.find((label) => label === projectActionLabel) || ['ZA', 717170000];
+      const { label, code } = ZONING_RESOLUTION_TYPES.filter((zr) => zr.label === projectActionLabel)[0] || { label: '', code: null };
 
-      if (!actionLabel) console.log(`Could not find Affected ZR Type for ${projectActionLabel}`);
+      if (!label) console.log(`Could not find Affected ZR Type for ${projectActionLabel}`);
 
-      if (!zrTypes.includes(actionLabel)) {
+      if (!zrTypes.includes(label) && label) {
         return this.crmService.create(`dcp_affectedzoningresolutions`, {
-          'dcp_zoningresolutiontype': actionCode, // this is a coded value
-          'dcp_zrsectionnumber': action.dcp_zrsectionnumber,
+          'dcp_zoningresolutiontype': code, // this is a coded value
+          'dcp_zrsectionnumber': action.dcp_ZoningResolution ? action.dcp_ZoningResolution.dcp_zoningresolution : null,
           'dcp_modifiedzrsectionnumber': action.dcp_zrmodifyingzrtxt,
           'dcp_rwcdsform@odata.bind': `/dcp_pasforms(${dcp_rwcdsformid})`,
         });
-      } else {
-        console.log(`zoning resolution with id ${projectActionLabel} already exists`);
       }
     }));
   }


### PR DESCRIPTION
Fixing the backend/frontend synchronization of proposed actions. 

- Provide optionset in frontend to convert codes to zoning resolution labels
- updating component logic in `proposed-project-action-editor.js` in order to better display relevant info on template
- update backend field mapping to accurately reflect the relevant attributes. This included expanding on `dcp_projectaction` entity to grab `dcp_ZoningResolution.dcp_zoningresolution` which maps to `dcp_zrsectionnumber` on `dcp_affectedzoningresolution` entity
- update logic for which rows we post from `dcp_projectaction` to `dcp_affectedzoningresolution` -- there were a couple bugs in this approach, so this was refactored

Addresses #480 