### PR TITLE
479 Add field for build year rational

### DIFF
--- a/client/app/components/packages/rwcds-form/project-description.hbs
+++ b/client/app/components/packages/rwcds-form/project-description.hbs
@@ -93,16 +93,45 @@
         Explain the rationale behind the analysis year
       </strong>
       <small class="help-text display-block">
+        Please explain how the Analysis Year was determined while factoring in the following information:
+        <ul>
+          <li>Intended construction duration and phasing</li>
+          <li>Consider the Application review period (and ULURP process, if applicable)</li>
+          <li>All of the Projected Development Sites</li>
+        </ul>
+      </small>
+      <form.Field
+        @type="text-area"
+        @attribute="dcpRationalbehindthebuildyear"
+        @maxlength="300"
+      />
+    </label>
+    <label>
+      <strong>
+        History of sites within the Project Area
+      </strong>
+      <small class="help-text display-block">
         Providing history allows NYC Planning to analyze potential CEQR analysis&nbsp;
         sections/chapters, as well as development trends and previous environment&nbsp;
         review assumptions.
         <br>
-        Summarize any prior rezonings or discretionary City Planning Commission&nbsp;
-        approvals. Provide ULURP and CEQR Application numbers, if available.&nbsp;
-        Describe any context that is relevant to development on the site (e.g.&nbsp;
-        former uses, large scale development plans, urban renewal plans,&nbsp;
-        Mitchell Lama site plans, or other site controls, easements, restrictive&nbsp;
-        declarations, (E) designations, historic or other designations, etc.).
+        <Ui::CollapsibleText
+          @buttonText="Additional Guidance"
+        >
+          Summarize any prior rezonings or discretionary City Planning Commission&nbsp;
+          approvals providing the following information. You can paste links to&nbsp;
+          supporting documents in the text box below.
+          <ul>
+            <li>ULURP and CEQR Application numbers, if available</li>
+            <li>Former site uses</li>
+            <li>Large scale development plans</li>
+            <li>Urban renewal plans</li>
+            <li>Mitchell Lama site plans, or other site controls</li>
+            <li>Easements</li>
+            <li>Restrictive declarations</li>
+            <li>(E) designations, historic or other designations, etc.</li>
+          </ul>
+        </Ui::CollapsibleText>
       </small>
       <form.Field
         @type="text-area"

--- a/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
@@ -83,6 +83,9 @@ module('Acceptance | user can click rwcds edit', function(hooks) {
     await fillIn('[data-test-input="dcpBuildyear"]', exceedMaximum(4, 'Number'));
     assert.dom('[data-test-validation-message="dcpBuildyear"').hasText('Number is too long (max 4 characters)');
 
+    await fillIn('[data-test-input="dcpRationalbehindthebuildyear"]', exceedMaximum(300, 'String'));
+    assert.dom('[data-test-validation-message="dcpRationalbehindthebuildyear"').hasText('Text is too long (max 300 characters)');
+
     await fillIn('[data-test-textarea="dcpSitehistory"]', exceedMaximum(600, 'String'));
     assert.dom('[data-test-validation-message="dcpSitehistory"').hasText('Text is too long (max 600 characters)');
   });


### PR DESCRIPTION
Also update copy based on updates to wireframe

Addresses #479  
The issue was not that the input for `dcpSitehistory` was missing. It was that it was accidentally associated with the question for build year rational, and there was no input for `dcpRationalbehindthebuildyear`