### PR TITLE
341 use optionset helper to display applicant state

### DIFF
--- a/client/app/components/packages/pas-form/show.hbs
+++ b/client/app/components/packages/pas-form/show.hbs
@@ -37,7 +37,7 @@
             {{#if applicant.dcpAddress}}
               <div>
                 <FaIcon @icon="map-marker-alt" class="text-gray" @fixedWidth={{true}} />
-                {{applicant.dcpAddress}}, {{applicant.dcpCity}}, {{applicant.dcpState}} {{applicant.dcpZipcode}}
+                {{applicant.dcpAddress}}, {{applicant.dcpCity}}, {{optionset 'applicant' 'state' 'label' applicant.dcpState}} {{applicant.dcpZipcode}}
               </div>
             {{/if}}
             {{#if applicant.dcpPhone}}


### PR DESCRIPTION
Display the applicant state label instead of code
on the view-only page.