### PR TITLE
500 Fix character counter rendering

### DIFF
--- a/client/app/components/saveable-form/field.hbs
+++ b/client/app/components/saveable-form/field.hbs
@@ -15,17 +15,11 @@
     {{!-- We invoke as angle brackets so we can spread attributes --}}
     <CurriedFieldComponent
       data-test-input={{@attribute}}
+      @maxlength={{@maxlength}}
       ...attributes
     />
   {{/if}}
 {{/let}}
-
-{{#if @showCounter}}
-  <SaveableForm::CharacterCounter
-    @string={{this.value}}
-    @maxlength={{if @maxlength @maxlength '250'}}
-  />
-{{/if}}
 
 {{#if (and this.error (not @hideError))}}
   <span

--- a/client/app/components/saveable-form/field/text-input.hbs
+++ b/client/app/components/saveable-form/field/text-input.hbs
@@ -3,3 +3,10 @@
   @value={{@value}}
   ...attributes
 />
+
+{{#if @showCounter}}
+  <SaveableForm::CharacterCounter
+    @string={{this.value}}
+    @maxlength={{if @maxlength @maxlength '250'}}
+  />
+{{/if}}


### PR DESCRIPTION
Render Character Counter for just text input and
text area fields. Ensure that the maxlength
property is passed to the text input/area fields.

Addresses #500 