### PR TITLE
499: fix submit on rwcds form

### DIFF
--- a/client/app/components/packages/rwcds-form/edit.js
+++ b/client/app/components/packages/rwcds-form/edit.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 import SaveableRwcdsFormValidations from '../../../validations/saveable-rwcds-form';
 import SubmittableRwcdsFormValidations from '../../../validations/submittable-rwcds-form';
 import SaveableAffectedZoningResolutionFormValidations from '../../../validations/saveable-affected-zoning-resolution-form';
@@ -13,6 +14,9 @@ export default class PackagesRwcdsFormEditComponent extends Component {
     SubmittableAffectedZoningResolutionFormValidations,
   };
 
+  @service
+  router;
+
   @action
   async savePackage() {
     try {
@@ -23,5 +27,12 @@ export default class PackagesRwcdsFormEditComponent extends Component {
     }
 
     this.args.package.refreshExistingDocuments();
+  }
+
+  @action
+  async submitPackage() {
+    await this.args.package.submit();
+
+    this.router.transitionTo('rwcds-form.show', this.args.package.id);
   }
 }

--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -19,6 +19,9 @@ import {
 import {
   DCPHASPROJECTCHANGEDSINCESUBMISSIONOFTHEPAS_OPTIONSET,
   DCPCONSTRUCTIONPHASING_OPTIONSET,
+  DCPEXISTINGCONDITIONS_OPTIONSET,
+  DCPISRWCDSSCENARIO_OPTIONSET,
+
 } from '../models/rwcds-form';
 import {
   YES_NO_UNSURE_OPTIONSET,
@@ -42,6 +45,8 @@ const OPTIONSET_LOOKUP = {
   rwcdsForm: {
     dcpHasprojectchangedsincesubmissionofthepas: DCPHASPROJECTCHANGEDSINCESUBMISSIONOFTHEPAS_OPTIONSET,
     dcpConstructionphasing: DCPCONSTRUCTIONPHASING_OPTIONSET,
+    dcpExistingconditions: DCPEXISTINGCONDITIONS_OPTIONSET,
+    dcpIsrwcdsscenario: DCPISRWCDSSCENARIO_OPTIONSET,
   },
   pasForm: {
     dcpProposedprojectorportionconstruction: YES_NO_UNSURE_OPTIONSET,

--- a/client/app/models/rwcds-form.js
+++ b/client/app/models/rwcds-form.js
@@ -26,6 +26,28 @@ export const DCPCONSTRUCTIONPHASING_OPTIONSET = {
   },
 };
 
+export const DCPEXISTINGCONDITIONS_OPTIONSET = {
+  YES: {
+    code: true,
+    label: 'Yes',
+  },
+  NO: {
+    code: false,
+    label: 'No',
+  },
+};
+
+export const DCPISRWCDSSCENARIO_OPTIONSET = {
+  YES: {
+    code: true,
+    label: 'Yes',
+  },
+  NO: {
+    code: false,
+    label: 'No',
+  },
+};
+
 export default class RwcdsFormModel extends Model {
   @belongsTo('package', { async: false })
   package;

--- a/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
@@ -42,6 +42,30 @@ module('Acceptance | user can click rwcds edit', function(hooks) {
     assert.equal(this.server.db.rwcdsForms.firstObject.dcpProjectsitedescription, 'Whatever affects one directly, affects all indirectly.');
   });
 
+  test('User can visit, edit, save, and submit rwcds-form route', async function(assert) {
+    this.server.create('project', 1, {
+      packages: [this.server.create('package', 'applicant', 'rwcdsForm')],
+    });
+
+    await visit('/rwcds-form/1/edit');
+
+    assert.equal(currentURL(), '/rwcds-form/1/edit');
+
+    assert.dom('[data-test-textarea="dcpProjectsitedescription"]').hasNoValue();
+    await fillIn('[data-test-textarea="dcpProjectsitedescription"]', 'Whatever affects one directly, affects all indirectly.');
+
+    await fillIn('[data-test-textarea="dcpProposedprojectdevelopmentdescription"]', 'bananas');
+
+    await click('[data-test-save-button]');
+
+    await settled();
+
+    await click('[data-test-submit-button]');
+    await click('[data-test-confirm-submit-button]');
+
+    assert.equal(currentURL(), '/rwcds-form/1');
+  });
+
   test('User can view existing values in Project Description section', async function(assert) {
     this.server.create('project', 1, {
       packages: [this.server.create('package', 'applicant', {


### PR DESCRIPTION
Add `submitPackage` action to rwcds-form edit.js so that it is accessible in the template.

Add optionsets to rwcds-form for use on show page.

Addresses #499 