### PR TITLE
358 Require at least one applicant to submit PAS

### DIFF
--- a/client/app/components/packages/pas-form/applicant-team.hbs
+++ b/client/app/components/packages/pas-form/applicant-team.hbs
@@ -54,5 +54,13 @@
         </div>
       </div>
     </div>
+    {{#unless @pasForm.hasApplicants}}
+      <span
+        class="form-error is-visible"
+        data-test-validation-message="has-applicants"
+      >
+        One or more applicant team members is required.
+      </span>
+    {{/unless}}
   </Form.Section>
 {{/let}}

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -31,6 +31,7 @@
 
       <Packages::PasForm::ApplicantTeam
         @form={{pasForm}}
+        @pasForm={{this.pasForm}}
         @addApplicant={{this.addApplicant}}
         @removeApplicant={{this.removeApplicant}}
         @validations={{this.validations}}
@@ -63,7 +64,7 @@
 
         <Packages::PasForm::PasFormError @package={{@package}} />
         <pasForm.SubmitButton
-          @isEnabled={{pasForm.isSubmittable}}
+          @isEnabled={{and @package.isValid  pasForm.isSubmittable}}
           class="secondary"
           data-test-submit-button
         />

--- a/client/app/models/package.js
+++ b/client/app/models/package.js
@@ -227,4 +227,11 @@ export default class PackageModel extends Model {
 
     return isPackageDirty;
   }
+
+  get isValid() {
+    if (this.dcpPackagetype === PACKAGE_TYPE_OPTIONSET.PAS_PACKAGE.code) {
+      return this.pasForm.hasApplicants;
+    }
+    return true;
+  }
 }

--- a/client/app/models/pas-form.js
+++ b/client/app/models/pas-form.js
@@ -883,4 +883,8 @@ export default class PasFormModel extends Model {
 
     return dirtyApplicants.length > 0;
   }
+
+  get hasApplicants() {
+    return this.applicants.length > 0;
+  }
 }

--- a/client/tests/acceptance/pas-form-validation-messages-display-test.js
+++ b/client/tests/acceptance/pas-form-validation-messages-display-test.js
@@ -3,6 +3,7 @@ import {
   visit,
   fillIn,
   click,
+  waitFor,
 } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -223,5 +224,32 @@ module('Acceptance | pas form validation messages display', function(hooks) {
     await fillIn('[data-test-input="dcpZipcode"]', '10022');
 
     assert.dom('[data-test-input="dcpZipcode"]').hasValue('10022');
+  });
+
+  test('User is required to add at least one Applicant member in order to submit PAS', async function(assert) {
+    this.server.create('project', 1, 'applicant');
+    await visit('/pas-form/1/edit');
+
+    await fillIn('[data-test-input="dcpRevisedprojectname"]', 'my project name');
+
+    assert.dom('[data-test-submit-button]').hasAttribute('disabled');
+
+    assert.dom('[data-test-validation-message="has-applicants"]').hasText('One or more applicant team members is required.');
+
+    await click('[data-test-add-applicant-button]');
+
+    await fillIn('[data-test-input="dcpFirstname"]', 'Tess');
+
+    await fillIn('[data-test-input="dcpLastname"]', 'Ter');
+
+    assert.dom('[data-test-submit-button]').hasAttribute('disabled');
+
+    await fillIn('[data-test-input="dcpEmail"]', 'tesster@planning.nyc.gov');
+
+    await waitFor('[data-test-submit-button]:not([disabled])');
+    await click('[data-test-submit-button]');
+
+    assert.dom('[data-test-reveal-modal]').exists();
+    assert.dom('[data-test-confirm-submit-button]').exists();
   });
 });

--- a/client/tests/acceptance/user-can-click-pas-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-pas-form-edit-test.js
@@ -44,6 +44,10 @@ module('Acceptance | user can click pas-form edit', function(hooks) {
     await visit('/projects');
     await click('[data-test-project="edit-pas"]');
     await fillIn('[data-test-input="dcpRevisedprojectname"]', 'my project name');
+    await click('[data-test-add-applicant-button]');
+    await fillIn('[data-test-input="dcpFirstname"]', 'Tess');
+    await fillIn('[data-test-input="dcpLastname"]', 'Ter');
+    await fillIn('[data-test-input="dcpEmail"]', 'tesster@planning.nyc.gov');
     await click('[data-test-save-button]');
 
     await waitFor('[data-test-submit-button]:not([disabled])');
@@ -221,6 +225,11 @@ module('Acceptance | user can click pas-form edit', function(hooks) {
     await visit('/pas-form/1/edit');
 
     await fillIn('[data-test-input="dcpRevisedprojectname"]', 'my project name');
+
+    await click('[data-test-add-applicant-button]');
+    await fillIn('[data-test-input="dcpFirstname"]', 'Tess');
+    await fillIn('[data-test-input="dcpLastname"]', 'Ter');
+    await fillIn('[data-test-input="dcpEmail"]', 'tesster@planning.nyc.gov');
 
     // modal doesn't exist to start
     assert.dom('[data-test-reveal-modal]').doesNotExist();


### PR DESCRIPTION
Addresses #358 

The way we've designed our form architecture, there are two types of validations: 
  1. **Field-specific** Those sitting within validators (like `validators/submittable-pas-form.js` and `validators/saveable-rwcds-form.js`, etc.)
  2. **Entity/Macro-level** Those sitting within our package logic, namely the isDirty and isValid getters. These usually deal with macro-level validations. Validations which span across fields and entities (e.g. validating one or more attachment or applicant has been added) 

![image](https://user-images.githubusercontent.com/3311663/87601434-f4612000-c6a9-11ea-9173-e5ff08a11b51.png)

The Save and Submit buttons depend on both types of validations to determine if they are enabled.
![image](https://user-images.githubusercontent.com/3311663/87601566-2ecabd00-c6aa-11ea-8f61-dd6be79e08ff.png)

![image](https://user-images.githubusercontent.com/3311663/87601573-325e4400-c6aa-11ea-8615-ea6889a021cc.png)

For this issue, I added the isValid() getter to the package in order to add an "entity/macro-level validation" to support the Save enabled logic. This follows the pattern for the Submit button. (In the screenshot above, pasForm.isSubmittable is the field-level validation)

Note that I have a PR #513   to standardize and improve the variable names in the `pas-form/edit.hbs` file. Namely, renaming the SaveableForm block parameter from `|pasForm|` to `|saveableForm|` (like how we do it for `rwcds-form/edit.hbs`.  This will remove the potential confusion here as to the difference between `this.pasForm` and `pasForm`
![image](https://user-images.githubusercontent.com/3311663/87601051-2920a780-c6a9-11ea-9b78-e73398c2e03d.png)

However it's an extensive change, so needed to do it in a separate PR to keep this one clear and focused.