### PR TITLE
Remove legacy use of data-test-textarea

### DIFF
--- a/client/app/components/saveable-form/field/text-area.hbs
+++ b/client/app/components/saveable-form/field/text-area.hbs
@@ -1,6 +1,5 @@
 <Textarea
   @value={{@value}}
-  data-test-textarea={{@attribute}}
   rows="5"
   ...attributes
 />

--- a/client/tests/acceptance/error-message-appears-when-save-fails-test.js
+++ b/client/tests/acceptance/error-message-appears-when-save-fails-test.js
@@ -59,7 +59,7 @@ module('Acceptance | error message appears when save fails', function(hooks) {
 
     assert.dom('[data-test-error-message]').doesNotExist();
 
-    await fillIn('[data-test-textarea="dcpProjectsitedescription"]', 'Whatever affects one directly, affects all indirectly.');
+    await fillIn('[data-test-input="dcpProjectsitedescription"]', 'Whatever affects one directly, affects all indirectly.');
 
     // save it
     await click('[data-test-save-button]');

--- a/client/tests/acceptance/pas-form-validation-messages-display-test.js
+++ b/client/tests/acceptance/pas-form-validation-messages-display-test.js
@@ -42,9 +42,9 @@ module('Acceptance | pas form validation messages display', function(hooks) {
 
     // dcpDescriptionofprojectareageography (length limits)
     assert.dom('[data-test-validation-message="dcpDescriptionofprojectareageography"]').doesNotExist();
-    await fillIn('[data-test-textarea="dcpDescriptionofprojectareageography"]', exceedMaximum(2000, 'String'));
+    await fillIn('[data-test-input="dcpDescriptionofprojectareageography"]', exceedMaximum(2000, 'String'));
     assert.dom('[data-test-validation-message="dcpDescriptionofprojectareageography"]').exists();
-    await fillIn('[data-test-textarea="dcpDescriptionofprojectareageography"]', 'my short description');
+    await fillIn('[data-test-input="dcpDescriptionofprojectareageography"]', 'my short description');
     assert.dom('[data-test-validation-message="dcpDescriptionofprojectareageography"]').doesNotExist();
 
     // dcpUrbanareaname (length limits and presence required in certain conditions)
@@ -115,44 +115,44 @@ module('Acceptance | pas form validation messages display', function(hooks) {
 
     // dcpProjectdescriptionproposeddevelopment (length limits)
     assert.dom('[data-test-validation-message="dcpEstimatedcompletiondate"]').doesNotExist();
-    await fillIn('[data-test-textarea="dcpProjectdescriptionproposeddevelopment"]', exceedMaximum(3000, 'String'));
+    await fillIn('[data-test-input="dcpProjectdescriptionproposeddevelopment"]', exceedMaximum(3000, 'String'));
     assert.dom('[data-test-validation-message="dcpProjectdescriptionproposeddevelopment"]').exists('Text is too long (max 3000 characters)');
-    await fillIn('[data-test-textarea="dcpProjectdescriptionproposeddevelopment"]', 'abc');
+    await fillIn('[data-test-input="dcpProjectdescriptionproposeddevelopment"]', 'abc');
     assert.dom('[data-test-validation-message="dcpProjectdescriptionproposeddevelopment"]').doesNotExist();
 
     // dcpProjectdescriptionbackground (length limits)
     assert.dom('[data-test-validation-message="dcpProjectdescriptionbackground"]').doesNotExist();
-    await fillIn('[data-test-textarea="dcpProjectdescriptionbackground"]', exceedMaximum(2000, 'String'));
+    await fillIn('[data-test-input="dcpProjectdescriptionbackground"]', exceedMaximum(2000, 'String'));
     assert.dom('[data-test-validation-message="dcpProjectdescriptionbackground"]').hasText('Text is too long (max 2000 characters)');
-    await fillIn('[data-test-textarea="dcpProjectdescriptionbackground"]', 'abc');
+    await fillIn('[data-test-input="dcpProjectdescriptionbackground"]', 'abc');
     assert.dom('[data-test-validation-message="dcpProjectdescriptionproposeddevelopment"]').doesNotExist();
 
     // dcpProjectdescriptionproposedactions (length limits)
     assert.dom('[data-test-validation-message="dcpProjectdescriptionproposedactions"]').doesNotExist();
-    await fillIn('[data-test-textarea="dcpProjectdescriptionproposedactions"]', exceedMaximum(2000, 'String'));
+    await fillIn('[data-test-input="dcpProjectdescriptionproposedactions"]', exceedMaximum(2000, 'String'));
     assert.dom('[data-test-validation-message="dcpProjectdescriptionproposedactions"]').hasText('Text is too long (max 2000 characters)');
-    await fillIn('[data-test-textarea="dcpProjectdescriptionproposedactions"]', 'abc');
+    await fillIn('[data-test-input="dcpProjectdescriptionproposedactions"]', 'abc');
     assert.dom('[data-test-validation-message="dcpProjectdescriptionproposedactions"]').doesNotExist();
 
     // dcpProjectdescriptionproposedarea (length limits)
     assert.dom('[data-test-validation-message="dcpProjectdescriptionproposedarea"]').doesNotExist();
-    await fillIn('[data-test-textarea="dcpProjectdescriptionproposedarea"]', exceedMaximum(3000, 'String'));
+    await fillIn('[data-test-input="dcpProjectdescriptionproposedarea"]', exceedMaximum(3000, 'String'));
     assert.dom('[data-test-validation-message="dcpProjectdescriptionproposedarea"]').hasText('Text is too long (max 3000 characters)');
-    await fillIn('[data-test-textarea="dcpProjectdescriptionproposedarea"]', 'abc');
+    await fillIn('[data-test-input="dcpProjectdescriptionproposedarea"]', 'abc');
     assert.dom('[data-test-validation-message="dcpProjectdescriptionproposedarea"]').doesNotExist();
 
     // dcpProjectdescriptionsurroundingarea (length limits)
     assert.dom('[data-test-validation-message="dcpProjectdescriptionsurroundingarea"]').doesNotExist();
-    await fillIn('[data-test-textarea="dcpProjectdescriptionsurroundingarea"]', exceedMaximum(3000, 'String'));
+    await fillIn('[data-test-input="dcpProjectdescriptionsurroundingarea"]', exceedMaximum(3000, 'String'));
     assert.dom('[data-test-validation-message="dcpProjectdescriptionsurroundingarea"]').hasText('Text is too long (max 3000 characters)');
-    await fillIn('[data-test-textarea="dcpProjectdescriptionsurroundingarea"]', 'abc');
+    await fillIn('[data-test-input="dcpProjectdescriptionsurroundingarea"]', 'abc');
     assert.dom('[data-test-validation-message="dcpProjectdescriptionsurroundingarea"]').doesNotExist();
 
     // dcpProjectattachmentsotherinformation (length limits)
     assert.dom('[data-test-validation-message="dcpProjectattachmentsotherinformation"]').doesNotExist();
-    await fillIn('[data-test-textarea="dcpProjectattachmentsotherinformation"]', exceedMaximum(2000, 'String'));
+    await fillIn('[data-test-input="dcpProjectattachmentsotherinformation"]', exceedMaximum(2000, 'String'));
     assert.dom('[data-test-validation-message="dcpProjectattachmentsotherinformation"]').hasText('Text is too long (max 2000 characters)');
-    await fillIn('[data-test-textarea="dcpProjectattachmentsotherinformation"]', 'abc');
+    await fillIn('[data-test-input="dcpProjectattachmentsotherinformation"]', 'abc');
     assert.dom('[data-test-validation-message="dcpProjectattachmentsotherinformation"]').doesNotExist();
   });
 

--- a/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
@@ -30,14 +30,14 @@ module('Acceptance | user can click rwcds edit', function(hooks) {
 
     assert.equal(currentURL(), '/rwcds-form/1/edit');
 
-    assert.dom('[data-test-textarea="dcpProjectsitedescription"]').hasNoValue();
-    await fillIn('[data-test-textarea="dcpProjectsitedescription"]', 'Whatever affects one directly, affects all indirectly.');
+    assert.dom('[data-test-input="dcpProjectsitedescription"]').hasNoValue();
+    await fillIn('[data-test-input="dcpProjectsitedescription"]', 'Whatever affects one directly, affects all indirectly.');
 
     await click('[data-test-save-button]');
 
     await settled();
 
-    assert.dom('[data-test-textarea="dcpProjectsitedescription"]').hasValue('Whatever affects one directly, affects all indirectly.');
+    assert.dom('[data-test-input="dcpProjectsitedescription"]').hasValue('Whatever affects one directly, affects all indirectly.');
 
     assert.equal(this.server.db.rwcdsForms.firstObject.dcpProjectsitedescription, 'Whatever affects one directly, affects all indirectly.');
   });
@@ -72,10 +72,10 @@ module('Acceptance | user can click rwcds edit', function(hooks) {
 
     assert.equal(currentURL(), '/rwcds-form/1/edit');
 
-    assert.dom('[data-test-textarea="dcpProjectsitedescription"]').hasNoValue();
-    await fillIn('[data-test-textarea="dcpProjectsitedescription"]', 'Whatever affects one directly, affects all indirectly.');
+    assert.dom('[data-test-input="dcpProjectsitedescription"]').hasNoValue();
+    await fillIn('[data-test-input="dcpProjectsitedescription"]', 'Whatever affects one directly, affects all indirectly.');
 
-    await fillIn('[data-test-textarea="dcpProposedprojectdevelopmentdescription"]', 'bananas');
+    await fillIn('[data-test-input="dcpProposedprojectdevelopmentdescription"]', 'bananas');
 
     await click('[data-test-save-button]');
 
@@ -104,10 +104,10 @@ module('Acceptance | user can click rwcds edit', function(hooks) {
 
     assert.equal(currentURL(), '/rwcds-form/1/edit');
 
-    assert.dom('[data-test-textarea="dcpProjectsitedescription"]').hasValue('Mixed use');
-    assert.dom('[data-test-textarea="dcpProposedprojectdevelopmentdescription"]').hasValue('Increase equity');
+    assert.dom('[data-test-input="dcpProjectsitedescription"]').hasValue('Mixed use');
+    assert.dom('[data-test-input="dcpProposedprojectdevelopmentdescription"]').hasValue('Increase equity');
     assert.dom('[data-test-input="dcpBuildyear"]').hasValue('1990');
-    assert.dom('[data-test-textarea="dcpSitehistory"]').hasValue('Some history');
+    assert.dom('[data-test-input="dcpSitehistory"]').hasValue('Some history');
   });
 
   test('Validation messages display for Project Description', async function(assert) {
@@ -119,10 +119,10 @@ module('Acceptance | user can click rwcds edit', function(hooks) {
 
     assert.equal(currentURL(), '/rwcds-form/1/edit');
 
-    await fillIn('[data-test-textarea="dcpProjectsitedescription"]', exceedMaximum(2400, 'String'));
+    await fillIn('[data-test-input="dcpProjectsitedescription"]', exceedMaximum(2400, 'String'));
     assert.dom('[data-test-validation-message="dcpProjectsitedescription"').hasText('Text is too long (max 2400 characters)');
 
-    await fillIn('[data-test-textarea="dcpProposedprojectdevelopmentdescription"]', exceedMaximum(1800, 'String'));
+    await fillIn('[data-test-input="dcpProposedprojectdevelopmentdescription"]', exceedMaximum(1800, 'String'));
     assert.dom('[data-test-validation-message="dcpProposedprojectdevelopmentdescription"').hasText('Text is too long (max 1800 characters)');
 
     await fillIn('[data-test-input="dcpBuildyear"]', exceedMaximum(4, 'Number'));
@@ -131,7 +131,7 @@ module('Acceptance | user can click rwcds edit', function(hooks) {
     await fillIn('[data-test-input="dcpRationalbehindthebuildyear"]', exceedMaximum(300, 'String'));
     assert.dom('[data-test-validation-message="dcpRationalbehindthebuildyear"').hasText('Text is too long (max 300 characters)');
 
-    await fillIn('[data-test-textarea="dcpSitehistory"]', exceedMaximum(600, 'String'));
+    await fillIn('[data-test-input="dcpSitehistory"]', exceedMaximum(600, 'String'));
     assert.dom('[data-test-validation-message="dcpSitehistory"').hasText('Text is too long (max 600 characters)');
   });
 
@@ -175,29 +175,29 @@ module('Acceptance | user can click rwcds edit', function(hooks) {
     assert.equal(currentURL(), '/rwcds-form/1/edit');
 
     // no-action
-    await fillIn('[data-test-textarea="dcpDevelopmentsiteassumptions"]', exceedMaximum(2400, 'String'));
+    await fillIn('[data-test-input="dcpDevelopmentsiteassumptions"]', exceedMaximum(2400, 'String'));
     assert.dom('[data-test-validation-message="dcpDevelopmentsiteassumptions"').hasText('Text is too long (max 2400 characters)');
 
-    await fillIn('[data-test-textarea="dcpDescribethenoactionscenario"]', exceedMaximum(1500, 'String'));
+    await fillIn('[data-test-input="dcpDescribethenoactionscenario"]', exceedMaximum(1500, 'String'));
     assert.dom('[data-test-validation-message="dcpDescribethenoactionscenario"').hasText('Text is too long (max 1500 characters)');
 
     await click('[data-test-radio="dcpExistingconditions"][data-test-radio-option="No"]');
 
-    await fillIn('[data-test-textarea="dcpHowdidyoudeterminethenoactionscenario"]', exceedMaximum(1500, 'String'));
+    await fillIn('[data-test-input="dcpHowdidyoudeterminethenoactionscenario"]', exceedMaximum(1500, 'String'));
     assert.dom('[data-test-validation-message="dcpHowdidyoudeterminethenoactionscenario"').hasText('Text is too long (max 1500 characters)');
 
     // with-action
-    await fillIn('[data-test-textarea="dcpDescribethewithactionscenario"]', exceedMaximum(1500, 'String'));
+    await fillIn('[data-test-input="dcpDescribethewithactionscenario"]', exceedMaximum(1500, 'String'));
     assert.dom('[data-test-validation-message="dcpDescribethewithactionscenario"').hasText('Text is too long (max 1500 characters)');
 
-    await fillIn('[data-test-textarea="dcpHowdidyoudeterminethiswithactionscena"]', exceedMaximum(600, 'String'));
+    await fillIn('[data-test-input="dcpHowdidyoudeterminethiswithactionscena"]', exceedMaximum(600, 'String'));
     assert.dom('[data-test-validation-message="dcpHowdidyoudeterminethiswithactionscena"').hasText('Text is too long (max 600 characters)');
 
     await click('[data-test-radio="dcpIsrwcdsscenario"][data-test-radio-option="Yes"]');
 
     assert.dom('[data-test-validation-message="dcpRwcdsexplanation"]').hasText('This field is required');
 
-    await fillIn('[data-test-textarea="dcpRwcdsexplanation"]', exceedMaximum(50, 'String'));
+    await fillIn('[data-test-input="dcpRwcdsexplanation"]', exceedMaximum(50, 'String'));
     assert.dom('[data-test-validation-message="dcpRwcdsexplanation"').hasText('Text is too long (max 50 characters)');
   });
 });


### PR DESCRIPTION
🧹🧹🧹 
Previously, we had two different test selectors, data-test-textinput
and data-test-textarea, for single-line inputs and text areas respectively.

However the new Field component assigns data-test-input as the selector
for all input types, even radio inputs. Thus we no longer need
data-test-textarea selectors on text areas. In fact, prior to this
commit, text areas had both data-test-textarea and data-test-input
selectors attached to the element.