### PR TITLE
504 rename the pasForm block param to saveableForm

### DIFF
--- a/client/app/components/packages/applicant-fieldset.hbs
+++ b/client/app/components/packages/applicant-fieldset.hbs
@@ -1,4 +1,4 @@
-{{#let @form as |Form|}}
+{{#let @form as |form|}}
   <Ui::Question
     class="fieldset relative"
     ...attributes
@@ -19,7 +19,7 @@
           Type of applicant
         </Q.Legend>
 
-        <Form.Field
+        <form.Field
           @attribute="dcpType"
           @type="radio-group"
           as |RadioGroup|
@@ -30,7 +30,7 @@
               (hash label='Organization' code=717170001)
             }}
           />
-        </Form.Field>
+        </form.Field>
       </Ui::Question>
     {{/if}}
 
@@ -38,7 +38,7 @@
     {{#if (eq @applicant.dcpType 717170001)}}
       <label data-test-applicant-organization>
         Organization Name <Ui::RequiredAsterisk />
-        <Form.Field @attribute="dcpOrganization" />
+        <form.Field @attribute="dcpOrganization" />
       </label>
 
       <hr/>
@@ -50,13 +50,13 @@
       <div class="cell medium-6">
         <label>
           First Name <Ui::RequiredAsterisk />
-          <Form.Field @attribute="dcpFirstname" />
+          <form.Field @attribute="dcpFirstname" />
         </label>
       </div>
       <div class="cell medium-6">
         <label>
           Last Name <Ui::RequiredAsterisk />
-          <Form.Field @attribute="dcpLastname" />
+          <form.Field @attribute="dcpLastname" />
         </label>
       </div>
     </div>
@@ -65,25 +65,25 @@
     {{#if (eq @applicant.friendlyEntityName "Other Team Member")}}
       <label>
         Organization
-        <Form.Field @attribute="dcpOrganization" />
+        <form.Field @attribute="dcpOrganization" />
       </label>
     {{/if}}
 
     <label>
       Email Address <Ui::RequiredAsterisk />
-      <Form.Field @attribute="dcpEmail" />
+      <form.Field @attribute="dcpEmail" />
     </label>
 
     <label>
       Address
-      <Form.Field @attribute="dcpAddress" />
+      <form.Field @attribute="dcpAddress" />
     </label>
 
     <div class="grid-x grid-margin-x">
       <div class="cell medium-auto">
         <label>
           City
-          <Form.Field @attribute="dcpCity" />
+          <form.Field @attribute="dcpCity" />
         </label>
       </div>
 
@@ -107,7 +107,7 @@
       <div class="cell auto medium-4">
         <label>
           ZIP
-          <Form.Field
+          <form.Field
             @attribute="dcpZipcode"
             type="number"
           />
@@ -117,7 +117,7 @@
 
     <label>
       Phone
-      <Form.Field
+      <form.Field
         @attribute="dcpPhone"
         type="number"
       />

--- a/client/app/components/packages/land-use-action.hbs
+++ b/client/app/components/packages/land-use-action.hbs
@@ -1,4 +1,4 @@
-{{#let @form as |Form|}}
+{{#let @form as |form|}}
   <div class="fieldset-adder">
     <h5 class="small-margin-bottom">
       Add a Proposed Action:
@@ -52,7 +52,7 @@
                 </Q.Label>
               </div>
               <div class="auto cell">
-                <Form.Field
+                <form.Field
                   @attribute={{landUseAction.countField}}
                   as |TextInput|
                 >
@@ -62,7 +62,7 @@
                     id={{Q.questionId}}
                     data-test-input={{landUseAction.countField}}
                   />
-                </Form.Field>
+                </form.Field>
               </div>
             </div>
           </Ui::Question>
@@ -76,7 +76,7 @@
               Provide the Zoning Resolution section number. Ex. ZR Sec. 74-711
             </p>
 
-            <Form.Field
+            <form.Field
               @attribute={{landUseAction.attr1}}
               as |TextInput|
             >
@@ -86,7 +86,7 @@
                 id={{Q.questionId}}
                 data-test-input={{landUseAction.attr1}}
               />
-            </Form.Field>
+            </form.Field>
           </Ui::Question>
 
           <Ui::Question @required={{true}} as |Q|>
@@ -98,7 +98,7 @@
               Provide the Zoning Resolution section number(s). Ex. ZR Sec. 42-10 and 43-17
             </p>
 
-            <Form.Field
+            <form.Field
               @attribute={{landUseAction.attr2}}
               as |TextInput|
             >
@@ -108,7 +108,7 @@
                 id={{Q.questionId}}
                 data-test-input={{landUseAction.attr2}}
               />
-            </Form.Field>
+            </form.Field>
           </Ui::Question>
         {{/if}}
 
@@ -122,7 +122,7 @@
               ex. R7-1/C2-4
             </p>
 
-            <Form.Field
+            <form.Field
               @attribute={{landUseAction.attr1}}
               as |TextInput|
             >
@@ -132,7 +132,7 @@
                 id={{Q.questionId}}
                 data-test-input={{landUseAction.attr1}}
               />
-            </Form.Field>
+            </form.Field>
           </Ui::Question>
 
           <Ui::Question @required={{true}} as |Q|>
@@ -144,7 +144,7 @@
               ex. C4-5X
             </p>
 
-            <Form.Field
+            <form.Field
               @attribute={{landUseAction.attr2}}
               as |TextInput|
             >
@@ -154,7 +154,7 @@
                 id={{Q.questionId}}
                 data-test-input={{landUseAction.attr2}}
               />
-            </Form.Field>
+            </form.Field>
           </Ui::Question>
         {{/if}}
 
@@ -168,7 +168,7 @@
               Provide the Zoning Resolution section number. Ex. ZR Sec. 74-711
             </p>
 
-            <Form.Field
+            <form.Field
               @attribute={{landUseAction.attr1}}
               as |TextInput|
             >
@@ -178,7 +178,7 @@
                 id={{Q.questionId}}
                 data-test-input={{landUseAction.attr1}}
               />
-            </Form.Field>
+            </form.Field>
           </Ui::Question>
 
           <Ui::Question @required={{true}} as |Q|>
@@ -190,7 +190,7 @@
               Provide the Zoning Resolution section Title. Ex. EXAMPLE
             </p>
 
-            <Form.Field
+            <form.Field
               @attribute={{landUseAction.attr2}}
               as |TextInput|
             >
@@ -200,7 +200,7 @@
                 id={{Q.questionId}}
                 data-test-input={{landUseAction.attr2}}
               />
-            </Form.Field>
+            </form.Field>
           </Ui::Question>
         {{/if}}
 
@@ -217,7 +217,7 @@
               ex. 200307ZRK
             </p>
 
-            <Form.Field
+            <form.Field
               @attribute={{landUseAction.attr1}}
               as |TextInput|
             >
@@ -227,7 +227,7 @@
                 id={{Q.questionId}}
                 data-test-input={{landUseAction.attr1}}
               />
-            </Form.Field>
+            </form.Field>
           </Ui::Question>
         {{/if}}
       {{else}}

--- a/client/app/components/packages/pas-form/applicant-team.hbs
+++ b/client/app/components/packages/pas-form/applicant-team.hbs
@@ -1,5 +1,5 @@
-{{#let @form as |Form|}}
-  <Form.Section @title="Applicant Team">
+{{#let @form as |form|}}
+  <form.Section @title="Applicant Team">
     <p>
       Add all Applicants (either individuals or organizations) and other Team Members (including Land Use Consultants and Environmental Consultants, agency staff, etc.).
     </p>
@@ -7,7 +7,7 @@
     <ul class="no-bullet">
       {{#each (filter-by 'isDeleted' false @form.saveableChanges.applicants) as |applicant applicantIndex|}}
         <li class="scale-fade-in">
-          <Form.SaveableForm
+          <form.SaveableForm
             @model={{applicant}}
             @validators={{array @validations.SaveableApplicantFormValidations @validations.SubmittableApplicantFormValidations}}
             as |applicantForm|
@@ -19,7 +19,7 @@
               data-test-applicant-fieldset={{applicantIndex}}
               data-test-applicant-type={{applicant.friendlyEntityName}}
             />
-          </Form.SaveableForm>
+          </form.SaveableForm>
         </li>
       {{/each}}
     </ul>
@@ -54,5 +54,5 @@
         </div>
       </div>
     </div>
-  </Form.Section>
+  </form.Section>
 {{/let}}

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -1,7 +1,7 @@
 <SaveableForm
   @model={{this.pasForm}}
   @validators={{array this.validations.SaveablePasFormValidations this.validations.SubmittablePasFormValidations}}
-  as |pasForm|
+  as |saveableForm|
 >
   <div class="grid-x grid-margin-x">
     <div class="cell large-8">
@@ -27,52 +27,53 @@
         </p>
       </section>
 
-      <Packages::PasForm::ProjectInformation @form={{pasForm}} />
+      <Packages::PasForm::ProjectInformation @form={{saveableForm}} />
 
       <Packages::PasForm::ApplicantTeam
-        @form={{pasForm}}
+        @form={{saveableForm}}
         @addApplicant={{this.addApplicant}}
         @removeApplicant={{this.removeApplicant}}
         @validations={{this.validations}}
       />
 
-      <Packages::PasForm::ProjectGeography @form={{pasForm}} />
+      <Packages::PasForm::ProjectGeography @form={{saveableForm}} />
 
-      <Packages::PasForm::ProposedLandUseActions @form={{pasForm}} />
+      <Packages::PasForm::ProposedLandUseActions @form={{saveableForm}} />
 
-      <Packages::PasForm::ProjectArea @form={{pasForm}} />
+      <Packages::PasForm::ProjectArea @form={{saveableForm}} />
 
-      <Packages::PasForm::ProposedDevelopmentSite @form={{pasForm}} />
+      <Packages::PasForm::ProposedDevelopmentSite @form={{saveableForm}} />
 
-      <Packages::PasForm::ProjectDescription @form={{pasForm}} />
+      <Packages::PasForm::ProjectDescription @form={{saveableForm}} />
 
       <Packages::PasForm::AttachedDocuments
-        @form={{pasForm}}
+        @form={{saveableForm}}
         @model={{this.pasForm}}
       />
 
     </div>{{! end left/main column }}
     <div class="cell large-4 sticky-sidebar">
 
-      <pasForm.PageNav>
-        <pasForm.SaveButton
-          @isEnabled={{or @package.isDirty pasForm.isSaveable}}
+      <saveableForm.PageNav>
+        <saveableForm.SaveButton
+          @isEnabled={{or @package.isDirty saveableForm.isSaveable}}
           @onClick={{this.savePackage}}
           data-test-save-button
         />
 
         <Packages::PasForm::PasFormError @package={{@package}} />
-        <pasForm.SubmitButton
-          @isEnabled={{pasForm.isSubmittable}}
+
+        <saveableForm.SubmitButton
+          @isEnabled={{saveableForm.isSubmittable}}
           class="secondary"
           data-test-submit-button
         />
-      </pasForm.PageNav>
+      </saveableForm.PageNav>
 
-      <pasForm.ConfirmationModal
-        @action={{component pasForm.SubmitButton
+      <saveableForm.ConfirmationModal
+        @action={{component saveableForm.SubmitButton
           onClick=this.submitPackage
-          isEnabled=pasForm.isSubmittable
+          isEnabled=saveableForm.isSubmittable
           class="no-margin"
         }}
         @footer={{component 'packages/pas-form/pas-form-error'
@@ -87,7 +88,7 @@
         <p>
           Before submitting, ensure that your answers are accurate and complete, and that necessary attachments (including the signature form) have been uploaded. If NYC Planning does not receive enough accurate information to provide guidance, the Lead Planner will notify you and request that this form be resubmitted with necessary materials, corrections, or clarifications.
         </p>
-      </pasForm.ConfirmationModal>
+      </saveableForm.ConfirmationModal>
 
       <Messages::Assistance class="large-margin-top" />
 

--- a/client/app/components/packages/pas-form/project-area.hbs
+++ b/client/app/components/packages/pas-form/project-area.hbs
@@ -1,5 +1,5 @@
-{{#let @form as |Form|}}
-  <Form.Section @title="Project Area">
+{{#let @form as |form|}}
+  <form.Section @title="Project Area">
     <p>
       Project Area refers to all property that would be subject to the Proposed Actions.
     </p>
@@ -9,7 +9,7 @@
         Does the proposed Project, or portion thereof, require a <Ui::ExternalLink @href="https://www1.nyc.gov/site/dep/water/stormwater-management.page">NYC DEP Stormwater Construction Permit</Ui::ExternalLink>?
       </Q.Legend>
 
-      <Form.Field
+      <form.Field
         @attribute="dcpProposedprojectorportionconstruction"
         @type="radio-group"
         as |GroupedRadio|
@@ -21,7 +21,7 @@
             (hash code=717170002 label='Unsure at this time')
           }}
         />
-      </Form.Field>
+      </form.Field>
     </Ui::Question>
 
     <Ui::Question as |Q|>
@@ -29,7 +29,7 @@
         Is the proposed Project Area located in a current or former <Ui::ExternalLink @href="https://www1.nyc.gov/site/hpd/services-and-information/urban-renewal.page">Urban Renewal Area</Ui::ExternalLink>?
       </Q.Legend>
 
-      <Form.Field
+      <form.Field
         @attribute="dcpUrbanrenewalarea"
         @type="radio-group"
         as |RadioGroup|
@@ -48,7 +48,7 @@
                 What is the name of the Urban Renewal Area?
               </Q.Label>
 
-              <Form.Field
+              <form.Field
                 @attribute="dcpUrbanareaname"
                 @showCounter={{true}}
                 id={{Q.questionId}}
@@ -56,7 +56,7 @@
             </Ui::Question>
           {{/if}}
         </RadioGroup>
-      </Form.Field>
+      </form.Field>
     </Ui::Question>
 
     <Ui::Question as |Q|>
@@ -64,7 +64,7 @@
         What is the <Ui::ExternalLink @href="https://streets.planning.nyc.gov/about">Legal Street Frontage Status in the Project Area</Ui::ExternalLink>?
       </Q.Legend>
 
-      <Form.Field
+      <form.Field
         @attribute="dcpLegalstreetfrontage"
         @type="radio-group"
         as |RadioGroup|
@@ -78,7 +78,7 @@
             (hash code=717170004 label='Mapped but not Built')
           }}
         />
-      </Form.Field>
+      </form.Field>
     </Ui::Question>
 
     <Ui::Question as |Q|>
@@ -86,7 +86,7 @@
         Do all Land Use Actions meet <Ui::ExternalLink @href="https://govt.westlaw.com/nycrr/Document/I4ec3a767cd1711dda432a117e6e0f345?viewType=FullText&originationContext=documenttoc&transitionType=CategoryPageItem&contextData=(sc.Default)">SEQRA or CEQR criteria</Ui::ExternalLink> for Type II status?
       </Q.Legend>
 
-      <Form.Field
+      <form.Field
         @attribute="dcpLanduseactiontype2"
         @type="radio-group"
         as |RadioGroup|
@@ -109,7 +109,7 @@
                 Ex: 617.5(c)(9)
               </p>
 
-              <Form.Field
+              <form.Field
                 @attribute="dcpPleaseexplaintypeiienvreview"
                 @showCounter={{true}}
                 maxlength="200"
@@ -118,7 +118,7 @@
             </Ui::Question>
           {{/if}}
         </RadioGroup>
-      </Form.Field>
+      </form.Field>
     </Ui::Question>
 
     <Ui::Question as |Q|>
@@ -126,7 +126,7 @@
         Is the proposed Project Area in an <Ui::ExternalLink @href="https://zola.planning.nyc.gov/">Industrial Business Zone</Ui::ExternalLink>?
       </Q.Legend>
 
-      <Form.Field
+      <form.Field
         @attribute="dcpProjectareaindustrialbusinesszone"
         @type="radio-group"
         as |RadioGroup|
@@ -143,7 +143,7 @@
                 Name of Industrial Business Zone
               </Q.Label>
 
-              <Form.Field
+              <form.Field
                 @attribute="dcpProjectareaindutrialzonename"
                 @maxlength="200"
                 @showCounter={{true}}
@@ -152,7 +152,7 @@
             </Ui::Question>
           {{/if}}
         </RadioGroup>
-      </Form.Field>
+      </form.Field>
     </Ui::Question>
 
     <Ui::Question as |Q|>
@@ -160,7 +160,7 @@
         Is the proposed Project Area within or adjacent to a designated (City or State) <Ui::ExternalLink @href="https://zola.planning.nyc.gov/">Landmark or Historic District</Ui::ExternalLink>?
       </Q.Legend>
 
-      <Form.Field
+      <form.Field
         @attribute="dcpIsprojectarealandmark"
         @type="radio-group"
         as |RadioGroup|
@@ -177,7 +177,7 @@
                 Name of Landmark or Historic District
               </Q.Label>
 
-              <Form.Field
+              <form.Field
                 @attribute="dcpProjectarealandmarkname"
                 @showCounter={{true}}
                 id={{Q.questionId}}
@@ -185,7 +185,7 @@
             </Ui::Question>
           {{/if}}
         </RadioGroup>
-      </Form.Field>
+      </form.Field>
     </Ui::Question>
 
     <Ui::Question as |Q|>
@@ -193,7 +193,7 @@
         Is the proposed Project Area located within the <Ui::ExternalLink @href="https://dcp.maps.arcgis.com/apps/View/index.html?appid=90e3a9f927c2471483631a20e8a41d8d">NYC Coastal Zone</Ui::ExternalLink>?
       </Q.Legend>
 
-      <Form.Field
+      <form.Field
         @attribute="dcpProjectareacoastalzonelocatedin"
         @type="radio-group"
         as |RadioGroup|
@@ -204,7 +204,7 @@
             (hash code=false label='No')
           }}
         />
-      </Form.Field>
+      </form.Field>
     </Ui::Question>
 
     <Ui::Question as |Q|>
@@ -212,7 +212,7 @@
         Is the Project Area located within the <Ui::ExternalLink @href="https://dcp.maps.arcgis.com/apps/webappviewer/index.html?id=1c37d271fba14163bbb520517153d6d5">1% Annual Chance Floodplain</Ui::ExternalLink>?
       </Q.Legend>
 
-      <Form.Field
+      <form.Field
         @attribute="dcpProjectareaischancefloodplain"
         @type="radio-group"
         as |RadioGroup|
@@ -224,7 +224,7 @@
             (hash code=717170002 label='Unsure at this time')
           }}
         />
-      </Form.Field>
+      </form.Field>
     </Ui::Question>
 
     <Ui::Question as |Q|>
@@ -232,7 +232,7 @@
         Is a <Ui::ExternalLink @href="https://a836-acris.nyc.gov/CP/">legal instrument</Ui::ExternalLink> associated with a previous CPC or CPC Chair action recorded against the Project Site?
       </Q.Legend>
 
-      <Form.Field
+      <form.Field
         @attribute="dcpRestrictivedeclaration"
         @type="radio-group"
         as |RadioGroup|
@@ -254,7 +254,7 @@
                 Feel free to attach a copy of the legal instrument in the Attachments section.
               </p>
 
-              <Form.Field
+              <form.Field
                 @attribute="dcpCityregisterfilenumber"
                 @maxlength="25"
                 @showCounter={{true}}
@@ -263,7 +263,7 @@
             </Ui::Question>
           {{/if}}
         </RadioGroup>
-      </Form.Field>
+      </form.Field>
     </Ui::Question>
 
     <Ui::Question as |Q|>
@@ -271,7 +271,7 @@
         Will a new legal instrument or modification of a current legal instrument be necessary to approve/implement these Actions?
       </Q.Legend>
 
-      <Form.Field
+      <form.Field
         @attribute="dcpRestrictivedeclarationrequired"
         @type="radio-group"
         as |RadioGroup|
@@ -282,7 +282,7 @@
             (hash code=717170000 label='No')
             (hash code=717170002 label='Unsure at this time')}}
         />
-      </Form.Field>
+      </form.Field>
     </Ui::Question>
-  </Form.Section>
+  </form.Section>
 {{/let}}

--- a/client/app/components/packages/pas-form/project-description.hbs
+++ b/client/app/components/packages/pas-form/project-description.hbs
@@ -1,5 +1,5 @@
-{{#let @form as |Form|}}
-  <Form.Section @title="Project Description">
+{{#let @form as |form|}}
+  <form.Section @title="Project Description">
     <p>
       For complex proposals, feel free to upload a draft document (in the Attachments section) explaining this information instead of filling out the form inputs.
     </p>
@@ -9,7 +9,7 @@
         Description of the Proposed Development being facilitated by the Land Use Actions
       </Q.Label>
 
-      <Form.Field
+      <form.Field
         @attribute="dcpProjectdescriptionproposeddevelopment"
         @type="text-area"
         id={{Q.questionId}}
@@ -21,7 +21,7 @@
         Why is this application being proposed? What is the legal, environmental, or land use background?
       </Q.Label>
 
-      <Form.Field
+      <form.Field
         @attribute="dcpProjectdescriptionbackground"
         @type="text-area"
         id={{Q.questionId}}
@@ -33,7 +33,7 @@
         What is the land use rationale for all the Proposed Actions?
       </Q.Label>
 
-      <Form.Field
+      <form.Field
         @attribute="dcpProjectdescriptionproposedactions"
         @type="text-area"
         id={{Q.questionId}}
@@ -45,7 +45,7 @@
         Description of existing land uses and structures in the proposed Project Area and Development&nbsp;Site
       </Q.Label>
 
-      <Form.Field
+      <form.Field
         @attribute="dcpProjectdescriptionproposedarea"
         @type="text-area"
         id={{Q.questionId}}
@@ -57,7 +57,7 @@
         Description of land uses and built context in surrounding area (within 1000 ft)
       </Q.Label>
 
-      <Form.Field
+      <form.Field
         @attribute="dcpProjectdescriptionsurroundingarea"
         @type="text-area"
         id={{Q.questionId}}
@@ -73,11 +73,11 @@
         Include to expedite CEQR guidance: If Proposed Actions are not approved, what is the Applicant’s as-of-right development (CEQR “No-Action”) proposal? What would be expected to occur on non-applicant-controlled sites because of the Proposed Actions (CEQR “With-Action”)?
       </p>
 
-      <Form.Field
+      <form.Field
         @attribute="dcpProjectattachmentsotherinformation"
         @type="text-area"
         id={{Q.questionId}}
       />
     </Ui::Question>
-  </Form.Section>
+  </form.Section>
 {{/let}}

--- a/client/app/components/packages/pas-form/project-geography.hbs
+++ b/client/app/components/packages/pas-form/project-geography.hbs
@@ -1,5 +1,5 @@
-{{#let @form as |Form|}}
-  <Form.Section @title="Project Geography">
+{{#let @form as |form|}}
+  <form.Section @title="Project Geography">
     <p>
       Please identify the tax lots that are included in the proposed Project Area and/or Development Site.
       If the Project's geography is irregular, especially large, or does not consist of tax lots, describe it below.
@@ -26,11 +26,11 @@
         Fill in if the Project Area and/or Development Site is irregular, especially large, or does not consist of tax lots.
       </p>
 
-      <Form.Field
+      <form.Field
         @attribute="dcpDescriptionofprojectareageography"
         @type="text-area"
         id={{Q.questionId}}
       />
     </Ui::Question>
-  </Form.Section>
+  </form.Section>
 {{/let}}

--- a/client/app/components/packages/pas-form/project-information.hbs
+++ b/client/app/components/packages/pas-form/project-information.hbs
@@ -1,14 +1,14 @@
-{{#let @form as |Form|}}
-  <Form.Section @title="Project Information">
+{{#let @form as |form|}}
+  <form.Section @title="Project Information">
     <Ui::Question @required={{true}} as |Q|>
       <Q.Label>
         Project Name
       </Q.Label>
 
-      <Form.Field
+      <form.Field
         @attribute="dcpRevisedprojectname"
         id={{Q.questionId}}
       />
     </Ui::Question>
-  </Form.Section>
+  </form.Section>
 {{/let}}

--- a/client/app/components/packages/pas-form/proposed-development-site.hbs
+++ b/client/app/components/packages/pas-form/proposed-development-site.hbs
@@ -1,5 +1,5 @@
-{{#let @form as |Form|}}
-  <Form.Section @title="Proposed Development Site">
+{{#let @form as |form|}}
+  <form.Section @title="Proposed Development Site">
     <p class="text-small">
       <b>Development Site</b> refers to all property to be developed as part of the Applicant’s specific proposal which the Land Use Actions would facilitate. Typically, the Development Site and the Project Area will comprise the same property(ies) unless the application is requesting a Zoning Map Amendment covering an area greater than an Applicant’s property to be developed or a large-scale special approval involving multiple tax lots. In these cases, the Development Site may be one or several tax lots within a broader Project Area.
     </p>
@@ -9,7 +9,7 @@
         In what year do you expect the development to complete?
       </Q.Label>
 
-      <Form.Field
+      <form.Field
         @attribute="dcpEstimatedcompletiondate"
         @maxlength="4"
         id={{Q.questionId}}
@@ -33,7 +33,7 @@
           (hash attr="dcpProposeddevelopmentsiteenlargement" label="Enlargement")) as |developmentType|
         }}
           <li>
-            <Form.Field
+            <form.Field
               @attribute={{developmentType.attr}}
               @type="checkbox"
               as |Checkbox|
@@ -41,11 +41,11 @@
               <Checkbox>
                 {{developmentType.label}}
               </Checkbox>
-            </Form.Field>
+            </form.Field>
           </li>
         {{/each}}
         <li>
-          <Form.Field
+          <form.Field
             @attribute="dcpProposeddevelopmentsiteinfoother"
             @type="checkbox"
             as |Checkbox|
@@ -55,7 +55,7 @@
             >
               Other&hellip;
             </Checkbox>
-          </Form.Field>
+          </form.Field>
         </li>
       </ul>
       {{#if @form.saveableChanges.dcpProposeddevelopmentsiteinfoother}}
@@ -64,7 +64,7 @@
             Explain:
           </Q.Label>
 
-          <Form.Field
+          <form.Field
             @attribute="dcpProposeddevelopmentsiteotherexplanation"
             id={{Q.questionId}}
           />
@@ -81,7 +81,7 @@
         Refer to <Ui::ExternalLink @href="https://zr.planning.nyc.gov/appendix-f-inclusionary-housing-designated-areas-and-mandatory-inclusionary-housing-areas">Appendix F</Ui::ExternalLink> of the Zoning Resolution for full list of all Inclusionary Housing Areas which are areas that incentivize or require affordable housing.
       </p>
 
-      <Form.Field
+      <form.Field
         @attribute="dcpIsinclusionaryhousingdesignatedarea"
         @type="radio-group"
         as |RadioGroup|
@@ -103,14 +103,14 @@
                 Refer to the "Inclusionary Housing Designated Areas" data layer in <Ui::ExternalLink @href="https://zola.planning.nyc.gov/about">ZoLa</Ui::ExternalLink> if you are unsure of the name.
               </p>
 
-              <Form.Field
+              <form.Field
                 @attribute="dcpInclusionaryhousingdesignatedareaname"
                 id={{Q.questionId}}
               />
             </Ui::Question>
           {{/if}}
         </RadioGroup>
-      </Form.Field>
+      </form.Field>
     </Ui::Question>
 
     <Ui::Question @required={{true}} as |Q|>
@@ -118,7 +118,7 @@
         Does the proposed development involve discretionary funding for Affordable Housing Units?
       </Q.Legend>
 
-      <Form.Field
+      <form.Field
         @attribute="dcpDiscressionaryfundingforffordablehousing"
         @type="radio-group"
         as |RadioGroup|
@@ -137,7 +137,7 @@
                 Funding source
               </Q.Legend>
 
-              <Form.Field
+              <form.Field
                 @attribute="dcpHousingunittype"
                 @type="radio-group"
                 as |RadioGroup|
@@ -150,11 +150,11 @@
                     (hash code=717170003 label='Other')
                   }}
                 />
-              </Form.Field>
+              </form.Field>
             </Ui::Question>
           {{/if}}
         </RadioGroup>
-      </Form.Field>
+      </form.Field>
     </Ui::Question>
-  </Form.Section>
+  </form.Section>
 {{/let}}

--- a/client/app/components/packages/pas-form/proposed-land-use-actions.hbs
+++ b/client/app/components/packages/pas-form/proposed-land-use-actions.hbs
@@ -1,5 +1,5 @@
-{{#let @form as |Form|}}
-  <Form.Section @title="Proposed Land Use Actions">
+{{#let @form as |form|}}
+  <form.Section @title="Proposed Land Use Actions">
     <p>
       What Land Use Actions does the proposed Project require? Identify all that apply and fill in the appropriate related information.
     </p>
@@ -13,5 +13,5 @@
         @pasForm={{@form.saveableChanges}}
       />
     </div>
-  </Form.Section>
+  </form.Section>
 {{/let}}

--- a/client/app/components/packages/project-geography.hbs
+++ b/client/app/components/packages/project-geography.hbs
@@ -21,8 +21,8 @@
 {{/if}}
 
 {{#each @bbls as |bbl|}}
-  {{#let @form as |Form|}}
-    <Form.SaveableForm @model={{bbl}} as |bblForm|>
+  {{#let @form as |form|}}
+    <form.SaveableForm @model={{bbl}} as |bblForm|>
       <fieldset class="fieldset relative scale-fade-in">
 
         <legend data-test-bbl-title="{{bbl.dcpBblnumber}}">
@@ -91,6 +91,6 @@
           <FaIcon @icon="times" @prefix="fas" @fixedWidth={{true}} />
         </button>
       </fieldset>
-    </Form.SaveableForm>
+    </form.SaveableForm>
   {{/let}}
 {{/each}}

--- a/client/app/components/packages/rwcds-form/proposed-project-actions.hbs
+++ b/client/app/components/packages/rwcds-form/proposed-project-actions.hbs
@@ -1,12 +1,12 @@
-{{#let @form as |Form|}}
-  <Form.Section @title="Proposed Actions">
+{{#let @form as |form|}}
+  <form.Section @title="Proposed Actions">
     <p>
       Listed below are the actions involved in this project:
     </p>
 
     <div data-test-section="proposed-project-actions">
       {{#each @form.saveableChanges.affectedZoningResolutions as |affectedZoningResolution|}}
-        <Form.SaveableForm
+        <form.SaveableForm
           @model={{affectedZoningResolution}}
           @validators={{array @validations.SaveableAffectedZoningResolutionFormValidations @validations.SubmittableAffectedZoningResolutionFormValidations}}
           as |affectedZoningResolutionForm|
@@ -15,7 +15,7 @@
             @zrForm={{affectedZoningResolutionForm}}
             @rwcdsForm={{@form}}
           />
-        </Form.SaveableForm>
+        </form.SaveableForm>
       {{/each}}
 
       <Ui::Question as |Q|>
@@ -27,7 +27,7 @@
           Refer to <strong>Chapter 2 page 2</strong> of the <Ui::ExternalLink @href="#">CEQR Technical manual</Ui::ExternalLink>. If multiple actions are sought, please address each action individually.
         </p>
 
-        <Form.Field
+        <form.Field
           @attribute="dcpPurposeandneedfortheproposedaction"
           @type="text-area"
           @maxlength="1500"
@@ -40,7 +40,7 @@
           Does the applicant plan to develop a 100% affordable housing development?
         </Q.Legend>
 
-        <Form.Field
+        <form.Field
           @attribute="dcpIsplannigondevelopingaffordablehousing"
           @type="radio-group"
           as |RadioGroup|
@@ -51,7 +51,7 @@
               (hash label='No' code=false)
             }}
           />
-        </Form.Field>
+        </form.Field>
       </Ui::Question>
 
       <Ui::Question as |Q|>
@@ -63,7 +63,7 @@
           Note that financing for affordable housing is considered an action
         </p>
 
-        <Form.Field
+        <form.Field
           @attribute="dcpIsapplicantseekingaction"
           @type="radio-group"
           as |RadioGroup|
@@ -82,7 +82,7 @@
                   Which actions from other agencies are sought?
                 </Q.Label>
 
-                <Form.Field
+                <form.Field
                   @attribute="dcpWhichactionsfromotheragenciesaresought"
                   as |TextInput|
                 >
@@ -92,12 +92,12 @@
                     data-test-input="dcpWhichactionsfromotheragenciesaresought"
                     id={{Q.questionId}}
                   />
-                </Form.Field>
+                </form.Field>
               </Ui::Question>
             {{/if}}
           </RadioGroup>
-        </Form.Field>
+        </form.Field>
       </Ui::Question>
     </div>
-  </Form.Section>
+  </form.Section>
 {{/let}}


### PR DESCRIPTION
Addresses #504 

- Commit 1: clarifies which variable refers to the form, which to the model.
 It also is consistent with rwcds-form/edit.hbs

- Commit 2: use lowercase form block params to indicate a form hash/object
Change to |form| (lowercase form) to follow community conventions.
This conveys that the variable represents the SaveableForm yielded
hash, instead of a rendered component.

