### PR TITLE
509: fix save button on rwcds form to save nested model affected-zoning-resolutions

### DIFF
--- a/client/app/components/packages/rwcds-form/edit.hbs
+++ b/client/app/components/packages/rwcds-form/edit.hbs
@@ -53,7 +53,7 @@
 
       <saveableForm.PageNav>
         <saveableForm.SaveButton
-          @isEnabled={{or @package.isDirty (and saveableForm.saveableChanges.isDirty saveableForm.saveableChanges.isValid)}}
+          @isEnabled={{or @package.isDirty saveableForm.isSaveable}}
           @onClick={{this.savePackage}}
           data-test-save-button
         />

--- a/client/app/models/package.js
+++ b/client/app/models/package.js
@@ -222,7 +222,8 @@ export default class PackageModel extends Model {
     }
     if (this.dcpPackagetype === PACKAGE_TYPE_OPTIONSET.RWCDS.code) {
       return isPackageDirty
-        || this.rwcdsForm.hasDirtyAttributes;
+        || this.rwcdsForm.hasDirtyAttributes
+        || this.rwcdsForm.isAffectedZoningResolutionsDirty;
     }
 
     return isPackageDirty;

--- a/client/app/models/rwcds-form.js
+++ b/client/app/models/rwcds-form.js
@@ -133,4 +133,23 @@ export default class RwcdsFormModel extends Model {
   @attr('date') overriddencreatedon;
 
   @attr('number') utcconversiontimezonecode;
+
+  async save() {
+    await this.saveDirtyAffectedZoningResolutions();
+    await super.save();
+  }
+
+  async saveDirtyAffectedZoningResolutions() {
+    return Promise.all(
+      this.affectedZoningResolutions
+        .filter((zoningResolution) => zoningResolution.hasDirtyAttributes)
+        .map((zoningResolution) => zoningResolution.save()),
+    );
+  }
+
+  get isAffectedZoningResolutionsDirty() {
+    const dirtyZrs = this.affectedZoningResolutions.filter((zr) => zr.hasDirtyAttributes);
+
+    return dirtyZrs.length > 0;
+  }
 }

--- a/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
@@ -42,6 +42,27 @@ module('Acceptance | user can click rwcds edit', function(hooks) {
     assert.equal(this.server.db.rwcdsForms.firstObject.dcpProjectsitedescription, 'Whatever affects one directly, affects all indirectly.');
   });
 
+  test('User can save proposed actions information on rwcds form', async function(assert) {
+    this.server.create('project', 1, {
+      packages: [this.server.create('package', 'applicant', 'rwcdsForm')],
+    });
+
+    await visit('/rwcds-form/1/edit');
+
+    assert.equal(currentURL(), '/rwcds-form/1/edit');
+
+    assert.dom('[data-test-input="dcpModifiedzrsectionnumber"]').hasNoValue();
+    await fillIn('[data-test-input="dcpModifiedzrsectionnumber"]', 'blah blah blah');
+
+    await click('[data-test-save-button]');
+
+    await settled();
+
+    assert.dom('[data-test-input="dcpModifiedzrsectionnumber"]').hasValue('blah blah blah');
+
+    assert.equal(this.server.db.affectedZoningResolutions.firstObject.dcpModifiedzrsectionnumber, 'blah blah blah');
+  });
+
   test('User can visit, edit, save, and submit rwcds-form route', async function(assert) {
     this.server.create('project', 1, {
       packages: [this.server.create('package', 'applicant', 'rwcdsForm')],


### PR DESCRIPTION
Update save action on rwcds form to include affected-zoning-resolution model.

Update enable/disabled save button functionality to include dirty attributes for affected-zoning-resolution model.

Addresses #509 