### PR TITLE
490 Display default and nested props in error resp

### DIFF
--- a/client/app/components/packages/pas-form/pas-form-error.hbs
+++ b/client/app/components/packages/pas-form/pas-form-error.hbs
@@ -9,10 +9,32 @@
         There was a problem saving your information.
     </h5>
       {{#each @package.pasForm.adapterError.errors as |error|}}
-        <p class="font-mono text-red-dark bg-red-white small-padding text-small" data-test-error-message>{{error.detail}}</p>
+        <p class="font-mono text-red-dark bg-red-white small-padding text-small" data-test-error-message>
+          Message: {{error.message}} <br>
+          Status: {{error.status}} <br>
+          Response: <br>
+          <ul>
+            {{#each-in error.response as |key value|}}
+              <li class="display-block">
+                {{key}}: {{value}}
+              </li>
+            {{/each-in}}
+          </ul>
+        </p>
       {{/each}}
       {{#each @package.adapterError.errors as |error|}}
-        <p class="font-mono text-red-dark bg-red-white small-padding text-small" data-test-error-message>{{error.detail}}</p>
+        <p class="font-mono text-red-dark bg-red-white small-padding text-small" data-test-error-message>
+          Message: {{error.message}} <br>
+          Status: {{error.status}} <br>
+          Response:
+          <ul>
+            {{#each-in error.response as |key value|}}
+              <li class="display-block">
+                {{key}}: {{value}}
+              </li>
+            {{/each-in}}
+          </ul>
+        </p>
       {{/each}}
       <p class="text-red-dark text-small">
         Please try again. If the problem persists, please contact NYC Planning at <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or <a href="tel:212-720-3300" class="nowrap">212-720-3300</a>.

--- a/client/app/components/packages/rwcds-form/rwcds-form-error.hbs
+++ b/client/app/components/packages/rwcds-form/rwcds-form-error.hbs
@@ -9,10 +9,32 @@
         There was a problem saving your information.
     </h5>
       {{#each @package.rwcdsForm.adapterError.errors as |error|}}
-        <p class="font-mono text-red-dark bg-red-white small-padding text-small" data-test-error-message>{{error.detail}}</p>
+        <p class="font-mono text-red-dark bg-red-white small-padding text-small" data-test-error-message>
+          Message: {{error.message}} <br>
+          Status: {{error.status}} <br>
+          Response:
+          <ul>
+            {{#each-in error.response as |key value|}}
+              <li class="display-block">
+                {{key}}: {{value}}
+              </li>
+            {{/each-in}}
+          </ul>
+        </p>
       {{/each}}
       {{#each @package.adapterError.errors as |error|}}
-        <p class="font-mono text-red-dark bg-red-white small-padding text-small" data-test-error-message>{{error.detail}}</p>
+        <p class="font-mono text-red-dark bg-red-white small-padding text-small" data-test-error-message>
+          Message: {{error.message}} <br>
+          Status: {{error.status}} <br>
+          Response:
+          <ul>
+            {{#each-in error.response as |key value|}}
+              <li class="display-block">
+                {{key}}: {{value}}
+              </li>
+            {{/each-in}}
+          </ul>
+        </p>
       {{/each}}
       <p class="text-red-dark text-small">
         Please try again. If the problem persists, please contact City Planning at <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or <a href="tel:212-720-3300" class="nowrap">212-720-3300</a>.

--- a/client/tests/acceptance/error-message-appears-when-save-fails-test.js
+++ b/client/tests/acceptance/error-message-appears-when-save-fails-test.js
@@ -27,7 +27,7 @@ module('Acceptance | error message appears when save fails', function(hooks) {
       project: this.server.create('project'),
     });
 
-    this.server.patch('/pas-forms/:id', { errors: [{ detail: 'server problem with pasForm' }] }, 500); // force mirage to error
+    this.server.patch('/pas-forms/:id', { errors: [{ message: 'server problem with pasForm' }] }, 500); // force mirage to error
 
     await visit('/pas-form/1/edit');
 
@@ -53,7 +53,7 @@ module('Acceptance | error message appears when save fails', function(hooks) {
       project: this.server.create('project'),
     });
 
-    this.server.patch('/rwcds-forms/:id', { errors: [{ detail: 'server problem with rwcdsForm' }] }, 500); // force mirage to error
+    this.server.patch('/rwcds-forms/:id', { errors: [{ message: 'server problem with rwcdsForm' }] }, 500); // force mirage to error
 
     await visit('/rwcds-form/1/edit');
 
@@ -83,7 +83,7 @@ module('Acceptance | error message appears when save fails', function(hooks) {
       }),
     });
 
-    this.server.patch('/packages/:id', { errors: [{ detail: 'server problem with package' }] }, 500); // force mirage to error
+    this.server.patch('/packages/:id', { errors: [{ message: 'server problem with package' }] }, 500); // force mirage to error
 
     await visit('/pas-form/2/edit');
 
@@ -123,7 +123,7 @@ module('Acceptance | error message appears when save fails', function(hooks) {
       }),
     });
 
-    this.server.patch('/pas-forms/:id', { errors: [{ detail: 'server problem with pasForm' }] }, 500); // force mirage to error
+    this.server.patch('/pas-forms/:id', { errors: [{ message: 'server problem with pasForm' }] }, 500); // force mirage to error
 
     await visit('/pas-form/1/edit');
 


### PR DESCRIPTION
In the PAS Form and RWCDS Form adapter error components,
display the default status and message propoerties for each
error. Also iterate through and list properties nested
within the erorr.response property.

Addresses #490  

We still need to unify the two adapter error components, which is captured in Issue #515 