### PR TITLE
470: add dcp_publicstatus as new attribute on projects endpoint

### DIFF
--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -28,6 +28,7 @@ import {
   DCPLEGALSTREETFRONTAGE_OPTIONSET,
   DCPHOUSINGUNITTYPE_OPTIONSET,
 } from '../models/pas-form';
+import { DCPPUBLICSTATUS_OPTIONSET } from '../optionset-lookups/project-optionset-lookup';
 
 const OPTIONSET_LOOKUP = {
   applicant: {
@@ -41,6 +42,9 @@ const OPTIONSET_LOOKUP = {
     status: PACKAGE_STATUS_OPTIONSET,
     visibility: PACKAGE_VISIBILITY_OPTIONSET,
     type: PACKAGE_TYPE_OPTIONSET,
+  },
+  project: {
+    dcpPublicstatus: DCPPUBLICSTATUS_OPTIONSET,
   },
   rwcdsForm: {
     dcpHasprojectchangedsincesubmissionofthepas: DCPHASPROJECTCHANGEDSINCESUBMISSIONOFTHEPAS_OPTIONSET,

--- a/client/app/models/project.js
+++ b/client/app/models/project.js
@@ -15,6 +15,9 @@ export default class ProjectModel extends Model {
 
   @attr statuscode;
 
+  // e.g. 'Prefiled', 'Filed', 'In Public Review', 'Completed'
+  @attr dcpPublicstatus;
+
   @attr dcpApplicantCustomerValue;
 
   @hasMany('package', { async: false })

--- a/client/app/optionset-lookups/project-optionset-lookup.js
+++ b/client/app/optionset-lookups/project-optionset-lookup.js
@@ -1,0 +1,18 @@
+export const DCPPUBLICSTATUS_OPTIONSET = {
+  PREFILED: {
+    code: 717170005,
+    label: 'Prefiled',
+  },
+  FILED: {
+    code: 717170000,
+    label: 'Filed',
+  },
+  IN_PUBLIC_REVIEW: {
+    code: 717170001,
+    label: 'In Public Review',
+  },
+  COMPLETED: {
+    code: 717170002,
+    label: 'Completed',
+  },
+};

--- a/server/src/projects/projects.attrs.ts
+++ b/server/src/projects/projects.attrs.ts
@@ -7,4 +7,5 @@ export const PROJECT_ATTRS = [
   'dcp_visibility',
   '_dcp_applicant_customer_value',
   'dcp_dcp_project_dcp_projectapplicant_Project',
+  'dcp_publicstatus',
 ];


### PR DESCRIPTION
- Add `dcp_publicstatus` as new attribute on projects endpoint in server.
- Add `dcp_publicstatus` to frontend model
- Add a new optionset lookup

**NOTE**: fixing weird linting error and then will mark ready for review

Addresses #470 