### PR TITLE
Include default object for destructuring

### DIFF
--- a/server/src/packages/pas-form/pas-form.service.ts
+++ b/server/src/packages/pas-form/pas-form.service.ts
@@ -23,7 +23,7 @@ export class PasFormService {
 
     // dcp_projectname is the name of the CRM navigation link.
     // then dcp_projectname is the real project name
-    const { dcp_projectname } = pasForm.dcp_projectname;
+    const { dcp_projectname } = pasForm.dcp_projectname || {};
 
     return {
       ...pasForm,


### PR DESCRIPTION
Although the default behavior of CRM for 0 related entities is to return a blank array, this isn’t true for a single related entity (a has one). If there is no association, it returns null.

This fix accounts for that.