### PR TITLE
Update saveable changes to data

### DIFF
--- a/client/app/components/packages/pas-form/applicant-team.hbs
+++ b/client/app/components/packages/pas-form/applicant-team.hbs
@@ -11,7 +11,7 @@
     {{/if}}
 
     <ul class="no-bullet">
-      {{#each (filter-by 'isDeleted' false @form.saveableChanges.applicants) as |applicant applicantIndex|}}
+      {{#each (filter-by 'isDeleted' false @form.data.applicants) as |applicant applicantIndex|}}
         <li class="scale-fade-in">
           <form.SaveableForm
             @model={{applicant}}
@@ -19,9 +19,9 @@
             as |applicantForm|
           >
             <Packages::ApplicantFieldset
-              @applicant={{applicantForm.saveableChanges}}
+              @applicant={{applicantForm.data}}
               @form={{applicantForm}}
-              @removeApplicant={{fn @removeApplicant applicant @form.saveableChanges}}
+              @removeApplicant={{fn @removeApplicant applicant @form.data}}
               data-test-applicant-fieldset={{applicantIndex}}
               data-test-applicant-type={{applicant.friendlyEntityName}}
             />
@@ -40,7 +40,7 @@
           <button
             class="button expanded secondary no-margin"
             type="button"
-            {{on "click" (fn @addApplicant "dcp_applicantinformation" @form.saveableChanges) }}
+            {{on "click" (fn @addApplicant "dcp_applicantinformation" @form.data) }}
             data-test-add-applicant-button
           >
             <strong>Add an Applicant</strong>
@@ -51,7 +51,7 @@
           <button
             class="button expanded secondary no-margin"
             type="button"
-            {{on "click" (fn @addApplicant "dcp_applicantrepresentativeinformation" @form.saveableChanges) }}
+            {{on "click" (fn @addApplicant "dcp_applicantrepresentativeinformation" @form.data) }}
             data-test-add-applicant-team-member-button
           >
             <strong>Add other Team Member</strong>

--- a/client/app/components/packages/pas-form/project-area.hbs
+++ b/client/app/components/packages/pas-form/project-area.hbs
@@ -40,7 +40,7 @@
             (hash code=717170001 label='No')
             (hash code=717170002 label='Unsure at this time')
           }}
-          @onChange={{fn (mut @form.saveableChanges.dcpUrbanareaname) ""}} as |value|
+          @onChange={{fn (mut @form.data.dcpUrbanareaname) ""}} as |value|
         >
           {{#if (eq value 717170000)}}
             <Ui::Question @required={{true}} as |Q|>
@@ -97,7 +97,7 @@
             (hash code=717170001 label='No')
             (hash code=717170002 label='Unsure at this time')
             }}
-          @onChange={{fn (mut @form.saveableChanges.dcpPleaseexplaintypeiienvreview) ""}} as |value|
+          @onChange={{fn (mut @form.data.dcpPleaseexplaintypeiienvreview) ""}} as |value|
         >
           {{#if (eq value 717170000)}}
             <Ui::Question @required={{true}} as |Q|>
@@ -135,7 +135,7 @@
           @options={{array
             (hash code=true label='Yes')
             (hash code=false label='No')}}
-          @onChange={{fn (mut @form.saveableChanges.dcpProjectareaindutrialzonename) ""}} as |value|
+          @onChange={{fn (mut @form.data.dcpProjectareaindutrialzonename) ""}} as |value|
         >
           {{#if value}}
             <Ui::Question @required={{true}} as |Q|>
@@ -169,7 +169,7 @@
           @options={{array
             (hash code=true label='Yes')
             (hash code=false label='No')}}
-          @onChange={{fn (mut @form.saveableChanges.dcpProjectarealandmarkname) ""}} as |value|
+          @onChange={{fn (mut @form.data.dcpProjectarealandmarkname) ""}} as |value|
         >
           {{#if value}}
             <Ui::Question @required={{true}} as |Q|>
@@ -242,7 +242,7 @@
             (hash code=true label='Yes')
             (hash code=false label='No')
           }}
-          @onChange={{fn (mut @form.saveableChanges.dcpCityregisterfilenumber) null}} as |value|
+          @onChange={{fn (mut @form.data.dcpCityregisterfilenumber) null}} as |value|
         >
           {{#if value}}
             <Ui::Question as |Q|>

--- a/client/app/components/packages/pas-form/project-geography.hbs
+++ b/client/app/components/packages/pas-form/project-geography.hbs
@@ -12,8 +12,8 @@
     <div data-test-section="project-geography">
       <Packages::ProjectGeography
         @form={{@form}}
-        @bbls={{@form.saveableChanges.bbls}}
-        @project={{@form.saveableChanges.package.project}}
+        @bbls={{@form.data.bbls}}
+        @project={{@form.data.package.project}}
       />
     </div>
 

--- a/client/app/components/packages/pas-form/proposed-development-site.hbs
+++ b/client/app/components/packages/pas-form/proposed-development-site.hbs
@@ -51,14 +51,14 @@
             as |Checkbox|
           >
             <Checkbox
-              {{on "click" (fn (mut @form.saveableChanges.dcpProposeddevelopmentsiteotherexplanation) "")}}
+              {{on "click" (fn (mut @form.data.dcpProposeddevelopmentsiteotherexplanation) "")}}
             >
               Other&hellip;
             </Checkbox>
           </form.Field>
         </li>
       </ul>
-      {{#if @form.saveableChanges.dcpProposeddevelopmentsiteinfoother}}
+      {{#if @form.data.dcpProposeddevelopmentsiteinfoother}}
         <Ui::Question @required={{true}} as |Q|>
           <Q.Label>
             Explain:
@@ -91,7 +91,7 @@
             (hash code=true label='Yes')
             (hash code=false label='No')
           }}
-          @onChange={{fn (mut @form.saveableChanges.dcpInclusionaryhousingdesignatedareaname) ""}} as |value|
+          @onChange={{fn (mut @form.data.dcpInclusionaryhousingdesignatedareaname) ""}} as |value|
         >
           {{#if value}}
             <Ui::Question as |Q|>
@@ -129,7 +129,7 @@
             (hash code=717170001 label='No')
             (hash code=717170002 label='Unsure at this time')
           }}
-          @onChange={{fn (mut @form.saveableChanges.dcpHousingunittype) ""}} as |value|
+          @onChange={{fn (mut @form.data.dcpHousingunittype) ""}} as |value|
         >
           {{#if (eq value 717170000)}}
             <Ui::Question as |Q|>

--- a/client/app/components/packages/pas-form/proposed-land-use-actions.hbs
+++ b/client/app/components/packages/pas-form/proposed-land-use-actions.hbs
@@ -10,7 +10,7 @@
     <div data-test-section="land-use-actions">
       <Packages::LandUseAction
         @form={{@form}}
-        @pasForm={{@form.saveableChanges}}
+        @pasForm={{@form.data}}
       />
     </div>
   </form.Section>

--- a/client/app/components/packages/project-geography.hbs
+++ b/client/app/components/packages/project-geography.hbs
@@ -32,7 +32,7 @@
         </legend>
 
         <fieldset>
-          <Ui::Legend data-test-development-site-question="{{bbl.dcpBblnumber}}-{{bblForm.saveableChanges.dcpDevelopmentsite}}">
+          <Ui::Legend data-test-development-site-question="{{bbl.dcpBblnumber}}-{{bblForm.data.dcpDevelopmentsite}}">
             Is this BBL part of the Development Site?
           </Ui::Legend>
 
@@ -57,7 +57,7 @@
         </fieldset>
 
         <fieldset>
-          <Ui::Legend data-test-partial-lot-question="{{bbl.dcpBblnumber}}-{{bblForm.saveableChanges.dcpPartiallot}}">
+          <Ui::Legend data-test-partial-lot-question="{{bbl.dcpBblnumber}}-{{bblForm.data.dcpPartiallot}}">
             Is only a portion of this lot included in the project area?
           </Ui::Legend>
 

--- a/client/app/components/packages/rwcds-form/proposed-project-actions-editor.hbs
+++ b/client/app/components/packages/rwcds-form/proposed-project-actions-editor.hbs
@@ -69,7 +69,7 @@
       {{/if}}
 
       {{#if this.zrAppendixF}}
-        This action {{if (eq @rwcdsForm.saveableChanges.dcpIncludezoningtextamendment 717170000) "includes" "does not include"}} MIH. If this is a mistake, please contact City Planning.
+        This action {{if (eq @rwcdsForm.data.dcpIncludezoningtextamendment 717170000) "includes" "does not include"}} MIH. If this is a mistake, please contact City Planning.
       {{/if}}
     {{else}}
       <p class="q-help">

--- a/client/app/components/packages/rwcds-form/proposed-project-actions-editor.js
+++ b/client/app/components/packages/rwcds-form/proposed-project-actions-editor.js
@@ -11,18 +11,18 @@ export default class ProposedActionsComponent extends Component {
   ];
 
   get zrTypeLabel() {
-    const zrTypeCode = this.args.zrForm.saveableChanges.dcpZoningresolutiontype;
+    const zrTypeCode = this.args.zrForm.data.dcpZoningresolutiontype;
 
     return optionset(['affectedZoningResolution', 'actions', 'label', zrTypeCode]);
   }
 
   get zrAppendixF() {
-    const zrSectionNumber = this.args.zrForm.saveableChanges.dcpZrsectionnumber;
+    const zrSectionNumber = this.args.zrForm.data.dcpZrsectionnumber;
     return this.zrTypeLabel === 'ZR' && zrSectionNumber === 'AppendixF';
   }
 
   get zrSectionNumber() {
-    const zrSectionNumber = this.args.zrForm.saveableChanges.dcpZrsectionnumber;
+    const zrSectionNumber = this.args.zrForm.data.dcpZrsectionnumber;
 
     const zrTypeInArray = this.actionsWithSectionNumberAndSectionTitle.includes(this.zrTypeLabel);
     if (zrTypeInArray || this.zrAppendixF) {

--- a/client/app/components/packages/rwcds-form/proposed-project-actions.hbs
+++ b/client/app/components/packages/rwcds-form/proposed-project-actions.hbs
@@ -5,7 +5,7 @@
     </p>
 
     <div data-test-section="proposed-project-actions">
-      {{#each @form.saveableChanges.affectedZoningResolutions as |affectedZoningResolution|}}
+      {{#each @form.data.affectedZoningResolutions as |affectedZoningResolution|}}
         <form.SaveableForm
           @model={{affectedZoningResolution}}
           @validators={{array @validations.SaveableAffectedZoningResolutionFormValidations @validations.SubmittableAffectedZoningResolutionFormValidations}}
@@ -74,7 +74,7 @@
               (hash label='No' code=717170001)
               (hash label='Do not know' code=717170002)
             }}
-            @onChange={{fn (mut @form.saveableChanges.dcpWhichactionsfromotheragenciesaresought) ""}} as |value|
+            @onChange={{fn (mut @form.data.dcpWhichactionsfromotheragenciesaresought) ""}} as |value|
           >
             {{#if (eq value 717170000)}}
               <Ui::Question @required={{true}} as |Q|>

--- a/client/app/components/packages/rwcds-form/with-action-no-action.hbs
+++ b/client/app/components/packages/rwcds-form/with-action-no-action.hbs
@@ -58,7 +58,7 @@
             (hash label='Yes' code=true)
             (hash label='No' code=false)
           }}
-          @onChange={{fn (mut @form.saveableChanges.dcpHowdidyoudeterminethenoactionscenario) ""}} as |value|
+          @onChange={{fn (mut @form.data.dcpHowdidyoudeterminethenoactionscenario) ""}} as |value|
         >
           {{#if (eq value false)}}
             <Ui::Question as |Q|>
@@ -142,7 +142,7 @@
             (hash label='Yes' code=true)
             (hash label='No' code=false)
           }}
-          @onChange={{fn (mut @form.saveableChanges.dcpRwcdsexplanation) ""}} as |value|
+          @onChange={{fn (mut @form.data.dcpRwcdsexplanation) ""}} as |value|
         >
           {{#if value}}
             <Ui::Question @required={{true}} as |Q|>

--- a/client/app/components/saveable-form/index.hbs
+++ b/client/app/components/saveable-form/index.hbs
@@ -8,7 +8,7 @@
     @parent={{@registerSubmittable}} as |submittableValidator|
   >
     {{yield (hash
-      saveableChanges=saveableValidator.changeset
+      data=saveableValidator.changeset
       errors=submittableValidator.changeset.error
 
       isSaveable=(and saveableValidator.isDirty saveableValidator.isValid)

--- a/client/tests/integration/components/saveable-form-test.js
+++ b/client/tests/integration/components/saveable-form-test.js
@@ -57,7 +57,7 @@ module('Integration | Component | f', function(hooks) {
       >
         <Input
           @type="text"
-          @value={{f.saveableChanges.someProp}}
+          @value={{f.data.someProp}}
         />
 
         <f.Field
@@ -153,7 +153,7 @@ module('Integration | Component | f', function(hooks) {
         >
           <Input
             @type="text"
-            @value={{saveable-child-form.saveableChanges.someProp}}
+            @value={{saveable-child-form.data.someProp}}
           />
         </f.SaveableForm>
 


### PR DESCRIPTION
Changes to a more generic name that conceals the distinction between "saveableChanges" and "submittable".

Mergable after https://github.com/NYCPlanning/labs-applicant-portal/pull/530

For immediate review, look at this diff https://github.com/NYCPlanning/labs-applicant-portal/pull/532/commits/d9584463b3fc617b6c9fe81844c8677249268b6d
