### PR TITLE
542: update logic for frontend package versioning

### DIFF
--- a/client/app/controllers/projects.js
+++ b/client/app/controllers/projects.js
@@ -2,6 +2,20 @@ import Controller from '@ember/controller';
 import { sort } from '@ember/object/computed';
 import { PACKAGE_STATUS, PACKAGE_VISIBILITY } from '../optionsets/package';
 
+export function packageIsToDo(projectPackages) {
+  return projectPackages.some((projectPackage) => {
+    if (
+      projectPackage.statuscode === PACKAGE_STATUS.PACKAGE_PREPARATION.code
+      && [
+        PACKAGE_VISIBILITY.APPLICANT_ONLY.code,
+        PACKAGE_VISIBILITY.GENERAL_PUBLIC.code,
+      ].includes(projectPackage.dcpVisibility)
+    ) {
+      return true;
+    } return false;
+  });
+}
+
 export default class ProjectsController extends Controller {
   queryParams = ['email'];
 
@@ -10,40 +24,16 @@ export default class ProjectsController extends Controller {
   // Projects awaiting the applicant's submission
   // (includes active projects with packages that haven't been submitted)
   get toDoProjects () {
-    return this.model.filter((project) => project.pasPackages.some((projectPackage) => {
-      if (
-        projectPackage.statuscode === PACKAGE_STATUS.PACKAGE_PREPARATION.code
-        && [
-          PACKAGE_VISIBILITY.APPLICANT_ONLY.code,
-          PACKAGE_VISIBILITY.GENERAL_PUBLIC.code,
-        ].includes(projectPackage.dcpVisibility)
-      ) {
-        return true;
-      }
-      return false;
-    }));
+    return this.model.filter((project) =>
+      // Check that at least ONE of the packages is currently editable
+      packageIsToDo(project.pasPackages) || packageIsToDo(project.rwcdsPackages));
   }
 
   // Projects in NYC Planning's hands
   // These are all other returned projects that are not in toDoProjects
   // (includes projects under review, on hold, with no packages, etc)
   get doneProjects () {
-    return this.model.filter((project) => {
-      // if pasPackages is empty, some() automatically returnse false, but we want to return true.
-      if (project.pasPackages.length === 0) return true;
-      return project.pasPackages.some((projectPackage) => {
-        if (
-          projectPackage.statuscode === PACKAGE_STATUS.PACKAGE_PREPARATION.code
-          && [
-            PACKAGE_VISIBILITY.APPLICANT_ONLY.code,
-            PACKAGE_VISIBILITY.GENERAL_PUBLIC.code,
-          ].includes(projectPackage.dcpVisibility)
-        ) {
-          return false;
-        }
-        return true;
-      });
-    });
+    return this.model.filter((project) => !this.toDoProjects.includes(project));
   }
 
   // TODO: Possibly improve this sort to consider the house numbers

--- a/client/app/models/project.js
+++ b/client/app/models/project.js
@@ -28,26 +28,20 @@ export default class ProjectModel extends Model {
   packages;
 
   get pasPackages() {
-    const [firstPackage] = this.packages
+    const pasPackages = this.packages
       .filter((projectPackage) => projectPackage.dcpPackagetype === optionset(['package', 'type', 'code', 'PAS_PACKAGE']))
       .sortBy('dcpPackageversion')
       .reverse();
 
-    if (firstPackage) {
-      return [firstPackage];
-    }
-    return [];
+    return pasPackages;
   }
 
   get rwcdsPackages() {
-    const [firstPackage] = this.packages
+    const rwcdsPackages = this.packages
       .filter((projectPackage) => projectPackage.dcpPackagetype === optionset(['package', 'type', 'code', 'RWCDS']))
       .sortBy('dcpPackageversion')
       .reverse();
 
-    if (firstPackage) {
-      return [firstPackage];
-    }
-    return [];
+    return rwcdsPackages;
   }
 }


### PR DESCRIPTION
**Problem 1:**
- Previously, `pasPackages` on the project model was only returning the first package in the array (which represented the most recent version). 
- This PR separates out `pasPackages` computed property and `latestPasPackage` computed property so that we have access to all the package versions in an array as well as the most recent one. 
- This was necessary for displaying ALL versions of a package on the project.hbs template.

**Problem 2:**
- the filtering logic for `done` vs `todo` projects was pulled out of the `todo` and `done` computed properties on the projects.js controller and placed in an exported function at the top of the file.
- This not only simplifies the logic but also fixes faulty display logic that was causing projects to end up in both columns rather than just one.
- Checks for rwcds package (instead of just PAS package) were also added in.