### PR TITLE
544: remove v in project name on rwcds form

### DIFF
--- a/client/app/components/packages/rwcds-form/edit.hbs
+++ b/client/app/components/packages/rwcds-form/edit.hbs
@@ -17,7 +17,7 @@
         <h2 class="no-margin">
           {{@package.project.dcpProjectname}}
           <small class="text-weight-normal">
-            {{if @package.project.dcpName (concat '(V' @package.project.dcpName ')')}}
+            {{if @package.project.dcpName (concat '(' @package.project.dcpName ')')}}
           </small>
         </h2>
 


### PR DESCRIPTION
Remove unnecessary "v" in project name on rwcds form