### PR TITLE
548: update which actions question on rwcds form to include validation message/counter, update to text-area

### DIFF
--- a/client/app/components/packages/rwcds-form/proposed-project-actions.hbs
+++ b/client/app/components/packages/rwcds-form/proposed-project-actions.hbs
@@ -76,16 +76,12 @@
                 </Q.Label>
 
                 <form.Field
+                  @type="text-area"
                   @attribute="dcpWhichactionsfromotheragenciesaresought"
-                  as |TextInput|
-                >
-                  <TextInput
-                    type="text"
-                    maxlength="200"
-                    data-test-input="dcpWhichactionsfromotheragenciesaresought"
-                    id={{Q.questionId}}
-                  />
-                </form.Field>
+                  @maxlength="2400"
+                  id={{Q.questionId}}
+                />
+
               </Ui::Question>
             {{/if}}
           </RadioGroup>


### PR DESCRIPTION
Update "which actions from other agencies are sought" question on rwcds form to "text-area" to since users are able to type in 2400 characters. This update fixed the validation message and character counter error.