### PR TITLE
526 Standardize Projects &Packages error handling

### DIFF
--- a/server/src/packages/packages.service.ts
+++ b/server/src/packages/packages.service.ts
@@ -99,64 +99,95 @@ export class PackagesService {
     // Double network request approach
 
     // Get package
-    const { records: [firstPackage] } = await this.crmService.get('dcp_packages', `
-      $select=${PACKAGE_ATTRS.join(',')}
-      &$filter=dcp_packageid eq ${packageId}
-      &$expand=dcp_project($select=${PROJECT_ATTRS.join(',')})
-    `);
+    try {
+        const { records: [firstPackage] } = await this.crmService.get('dcp_packages', `
+        $select=${PACKAGE_ATTRS.join(',')}
+        &$filter=dcp_packageid eq ${packageId}
+        &$expand=dcp_project($select=${PROJECT_ATTRS.join(',')})
+      `);
 
-    if (!firstPackage) {
-      return new HttpException('Package not found. Is it the right id?', HttpStatus.NOT_FOUND);
+      if (!firstPackage) {
+        throw new HttpException({
+          code: 'PACKAGE_NOT_FOUND',
+          title: 'Package not found',
+          detail: 'Package not found for given ID',
+        }, HttpStatus.NOT_FOUND);
+      }
+
+      const {
+        dcp_project,
+        dcp_packageid,
+        dcp_name,
+      } = firstPackage;
+
+      // drive-by redefine because the sharepoint lookup
+      // is failing for some reason and we don't want it
+      // to take the entire system down with it.
+      //
+      // TODO: Why does it need to be this? We should check to see if this is still
+      // flakey given current configuration
+      let documents = [];
+      documents = await this.findPackageSharepointDocuments(dcp_name, dcp_packageid);
+
+      const formData = await this.fetchPackageForm(firstPackage);
+
+      return {
+        ...firstPackage,
+        ...formData,
+
+        project: dcp_project,
+        documents: documents.map(document => ({
+          name: document['Name'],
+          timeCreated: document['TimeCreated'],
+          serverRelativeUrl: document['ServerRelativeUrl'],
+        })),
+      };
+    } catch (e) {
+      // relay lower-level exceptions, like from crmServce.get(),
+      // or sharepoint document retrieval.
+      if (e instanceof HttpException) {
+        throw e;
+      } else {
+        throw new HttpException({
+          code: 'LOAD_PACKAGE_FAILED',
+          title: 'Could not load package',
+          detail: `An unknown error occured while loading package ${packageId}`,
+        }, HttpStatus.NOT_FOUND);
+      }
     }
-
-    const {
-      dcp_project,
-      dcp_packageid,
-      dcp_name,
-    } = firstPackage;
-
-    // drive-by redefine because the sharepoint lookup
-    // is failing for some reason and we don't want it
-    // to take the entire system down with it.
-    //
-    // TODO: Why does it need to be this? We should check to see if this is still
-    // flakey given current configuration
-    let documents = [];
-    documents = await this.tryFindPackageSharepointDocuments(dcp_name, dcp_packageid);
-
-    const formData = await this.fetchPackageForm(firstPackage);
-
-    return {
-      ...firstPackage,
-      ...formData,
-
-      project: dcp_project,
-      documents: documents.map(document => ({
-        name: document['Name'],
-        timeCreated: document['TimeCreated'],
-        serverRelativeUrl: document['ServerRelativeUrl'],
-      })),
-    };
   }
 
   // packages have a dcp_packagetype which indicates the type of form it will have
   async fetchPackageForm(dcpPackage) {
-    if (dcpPackage.dcp_packagetype === PACKAGE_TYPE_OPTIONSET['PAS_PACKAGE'].code) {
-      return {
-        dcp_pasform: await this.pasFormService.find(dcpPackage._dcp_pasform_value)
-      };
-    }
+    try {
+      if (dcpPackage.dcp_packagetype === PACKAGE_TYPE_OPTIONSET['PAS_PACKAGE'].code) {
+        return {
+          dcp_pasform: await this.pasFormService.find(dcpPackage._dcp_pasform_value)
+        };
+      }
 
-    if (dcpPackage.dcp_packagetype === PACKAGE_TYPE_OPTIONSET['RWCDS'].code) {
-      return {
-        dcp_rwcdsform: await this.rwcdsFormService.find(dcpPackage._dcp_rwcdsform_value)
-      };
-    }
+      if (dcpPackage.dcp_packagetype === PACKAGE_TYPE_OPTIONSET['RWCDS'].code) {
+        return {
+          dcp_rwcdsform: await this.rwcdsFormService.find(dcpPackage._dcp_rwcdsform_value)
+        };
+      }
 
-    throw new HttpException({
-      "code": "INVALID_PACKAGE_TYPE",
-      "message": 'Requested package has invalid type.',
-    }, HttpStatus.INTERNAL_SERVER_ERROR);
+      throw new HttpException({
+        code: "INVALID_PACKAGE_TYPE",
+        title: 'Invalid package type',
+        detail: 'Requested package has invalid type.',
+      }, HttpStatus.BAD_REQUEST);
+    } catch (e) {
+      if (e instanceof HttpException) {
+        throw e;
+      } else {
+        throw new HttpException({
+          code: 'PACKAGE_FORM_ERROR',
+          title: 'Error loading package forms',
+          detail: `Error while acquiring ${dcpPackage} forms attached to the package ${dcpPackage.dcp_packageid}`,
+        }, HttpStatus.INTERNAL_SERVER_ERROR);
+      }
+    }
   }
 
   async update(id, body) {
@@ -171,21 +202,28 @@ export class PackagesService {
   // this folder, and we deliberately upload documents for the latest/current
   // revision into this folder.
   async findPackageSharepointDocuments(packageName, id:string) {
-    const strippedPackageName = packageName.replace(/-/g, '').replace(/\s+/g, '').replace(/'+/g,'');
-    const folderIdentifier = `${strippedPackageName}_${id.toUpperCase()}`;
-
-    return this.crmService.getSharepointFolderFiles(`dcp_package/${folderIdentifier}`);
-  }
-
-  async tryFindPackageSharepointDocuments(dcp_name, dcp_packageid){
     try {
-      const { value } = await this.findPackageSharepointDocuments(
-        dcp_name,
-        dcp_packageid,
-      );
-      return value;
+      const strippedPackageName = packageName.replace(/-/g, '').replace(/\s+/g, '').replace(/'+/g,'');
+      const folderIdentifier = `${strippedPackageName}_${id.toUpperCase()}`;
+
+      const { value: documents } = await this.crmService.getSharepointFolderFiles(`dcp_package/${folderIdentifier}`);
+
+      return documents;
     } catch (e) {
-      console.log('Sharepoint request failed:', e);
+      // Relay errors from crmService 
+      if (e instanceof HttpException) {
+        throw e;
+      } else {
+        throw new HttpException({
+          code: 'SHAREPOINT_FOLDER_ERROR',
+          title: 'Bad Sharepoint folder lookup',
+          detail: `An error occured while constructing and looking up folder for package. Perhaps the package name or id is wrong.`,
+          meta: {
+            packageName: packageName,
+            packageId: id,
+          }
+        }, HttpStatus.INTERNAL_SERVER_ERROR);
+      }
     }
   }
 }

--- a/server/src/projects/projects.controller.ts
+++ b/server/src/projects/projects.controller.ts
@@ -65,12 +65,18 @@ export class ProjectsController {
 
     try {
       if (contactId) {
-        return this.projectsService.findManyByContactId(contactId);
+        return await this.projectsService.findManyByContactId(contactId);
       }
     } catch (e) {
-      const errorMessage = `${e}`;
-
-      throw new HttpException(errorMessage, HttpStatus.BAD_REQUEST);
+      if (e instanceof HttpException) {
+        throw e;
+      } else {
+        throw new HttpException({
+          code: 'FIND_USER_PROJECTS_FAILED',
+          title: 'Failed getting projects',
+          detail: `An unknown server error occured while getting projects. ${e.message}`,
+        }, HttpStatus.INTERNAL_SERVER_ERROR);
+      }
     }
   }
 
@@ -86,15 +92,18 @@ export class ProjectsController {
 
     try {
       if (contactId) {
-        return this.projectsService.getProject(id, contactId);
+        return await this.projectsService.getProject(id, contactId);
       }
     } catch (e) {
-      const errorMessage = `${e}`;
-
-      throw new HttpException({
-        "code": "GET_PROJECT_CONTROLLER_ERROR",
-        "message": errorMessage,
-      }, HttpStatus.BAD_REQUEST);
+      if (e instanceof HttpException) {
+        throw e;
+      } else {
+        throw new HttpException({
+          code: 'FIND_PROJECT_FAILED',
+          title: 'Failed getting a project',
+          detail: `An unknown server error occured while finding a project by ID. ${e.message}`,
+        }, HttpStatus.INTERNAL_SERVER_ERROR);
+      }
     }
   }
 }

--- a/server/src/projects/projects.service.ts
+++ b/server/src/projects/projects.service.ts
@@ -39,9 +39,11 @@ export class ProjectsService {
       `);
       return this.overwriteCodesWithLabels(records);
     } catch(e) {
-      const errorMessage = `Error finding projects by contact ID. ${e.message}`;
-      console.log(errorMessage);
-      throw new HttpException(errorMessage, HttpStatus.UNAUTHORIZED);
+      const errorMessage = `Unable to find projects for current user. ${e.message}`;
+      throw new HttpException({
+        "code": "USER_PROJECTS_NOT_FOUND",
+        "detail": errorMessage,
+      }, HttpStatus.NOT_FOUND);
     }
   }
 
@@ -77,12 +79,13 @@ export class ProjectsService {
       const [ project ] = this.overwriteCodesWithLabels(records);
       return project;
     } catch(e) {
-      const errorMessage = `Error finding project by project ID. ${e.message}`;
+      const errorMessage = `Could not find requested project ${projectId}.`;
       console.log(errorMessage);
       throw new HttpException({
-        "code": "GET_PROJECT_SERVICE_ERROR",
-        "message": errorMessage,
-      }, HttpStatus.UNAUTHORIZED);
+        "code": "PROJECT_NOT_FOUND",
+        "title": "Project not found",
+        "detail": errorMessage,
+      }, HttpStatus.NOT_FOUND);
     }
   }
 


### PR DESCRIPTION
This PR standardizes error handling (the format for how errors are thrown) for just the projects and packages controllers and services, and some CRM service methods. As a whole the error handling redesign is getting bigger and more tedious than I first thought, so wanted to first get another round of reactions just these three areas of code.

This standardization trying to implement the guide in #554 