### PR TITLE
526 List errors on projects page like for forms

### DIFF
--- a/client/app/templates/projects-error.hbs
+++ b/client/app/templates/projects-error.hbs
@@ -6,7 +6,18 @@
   <span>Hmm, something went wrong:</span>
 
   {{#each this.model.errors as |error|}}
-    <span>{{error.message}}</span>
+    <p class="font-mono text-red-dark bg-red-white small-padding text-small" data-test-error-message>
+      Message: {{error.message}} <br>
+      Status: {{error.status}} <br>
+      Response:
+      <ul>
+        {{#each-in error.response as |key value|}}
+          <li class="display-block">
+            {{key}}: {{value}}
+          </li>
+        {{/each-in}}
+      </ul>
+    </p>
   {{/each}}
 
   {{!-- If there's an error, try to logout --}}


### PR DESCRIPTION
Short and sweet PR to list errors on the Projects page just like how we decided to do so on the PAS and RWCDS form pages, and login page. 

We should also do this for `projects/id`, and work to componentize this code. Perhaps we can do so in #515 