### PR TITLE
560: manually update dcp_includezoningtextamendment in syncActions function

### DIFF
--- a/client/app/components/packages/rwcds-form/proposed-project-actions-editor.hbs
+++ b/client/app/components/packages/rwcds-form/proposed-project-actions-editor.hbs
@@ -19,7 +19,7 @@
       {{/if}}
     </Ui::Legend>
 
-    {{#if (or this.hasModifiedZrSectionNumberQuestion this.hasZrSectionTitleQuestion)}}
+    {{#if this.isActionWithAdditionalInformation}}
       {{#if this.hasModifiedZrSectionNumberQuestion}}
         <Ui::Question as |Q|>
           <Q.Label>
@@ -67,9 +67,9 @@
           </zrForm.Field>
         </Ui::Question>
       {{/if}}
-
-      {{#if this.zrAppendixF}}
-        This action {{if (eq
+    
+      {{#if (eq this.zrTypeCode (optionset 'affectedZoningResolution' 'actions' 'code' 'ZR'))}}
+          This action {{if (eq
           @rwcdsForm.data.dcpIncludezoningtextamendment
           (optionset 'rwcdsForm' 'dcpIncludezoningtextamendment' 'code' 'YES')
           ) "includes" "does not include"}} MIH.&nbsp;

--- a/client/app/components/packages/rwcds-form/proposed-project-actions-editor.js
+++ b/client/app/components/packages/rwcds-form/proposed-project-actions-editor.js
@@ -10,10 +10,12 @@ export default class ProposedActionsComponent extends Component {
     'ZA', 'ZS', 'SD', 'SA', 'RA', 'RS',
   ];
 
-  get zrTypeLabel() {
-    const zrTypeCode = this.args.zrForm.data.dcpZoningresolutiontype;
+  get zrTypeCode() {
+    return this.args.zrForm.data.dcpZoningresolutiontype;
+  }
 
-    return optionset(['affectedZoningResolution', 'actions', 'label', zrTypeCode]);
+  get zrTypeLabel() {
+    return optionset(['affectedZoningResolution', 'actions', 'label', this.zrTypeCode]);
   }
 
   get zrAppendixF() {
@@ -38,5 +40,11 @@ export default class ProposedActionsComponent extends Component {
   get hasZrSectionTitleQuestion() {
     const zrTypeInArray = this.actionsWithSectionNumberAndSectionTitle.includes(this.zrTypeLabel);
     return zrTypeInArray || this.zrAppendixF;
+  }
+
+  get isActionWithAdditionalInformation() {
+    return this.hasModifiedZrSectionNumberQuestion
+    || this.hasZrSectionTitleQuestion
+    || this.zrTypeCode === optionset(['affectedZoningResolution', 'actions', 'code', 'ZR']);
   }
 }


### PR DESCRIPTION
- this PR sets `dcp_includezoningtextamendment` on the rwcds-form to "Yes" (`717170000`) if there exists a "ZR" action and that action's `dcp_ZoningResolution.dcp_zoningresolution` attribute is equal to "AppendixF". 
- This update occurs every time the `syncActions` function is run in `rwcds-form.service.ts`, which means it runs every time the rwcds form page is visited. 
- Right now the way that it's built, it will PATCH this value each time the user visits the rwcds-form page whether the field is already filled or not. I built it out this way based on the assumption that a planner might go into CRM and update fields on the project actions entity after an action is already created. 

Addresses #560 