### PR TITLE
Update Labs UI

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -76,7 +76,7 @@
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-node": "^11.0.0",
     "labs-ember-search": "^3.1.2",
-    "labs-ui": "^1.0.1",
+    "labs-ui": "^1.0.2",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "qunit-dom": "^1.1.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -9542,10 +9542,10 @@ labs-ember-search@^3.1.2:
     ember-promise-helpers "1.0.6"
     ember-truth-helpers "^2.0.0"
 
-labs-ui@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/labs-ui/-/labs-ui-1.0.1.tgz#d379680eb7f0ac5cd33b5cfdc4f71419d83ad165"
-  integrity sha512-VzStlpQfUHwHaiwyKF9PVIuxNEaTxfLQDzkOvuetsQ+95SQn7MRRyMCdYiTa6tXcrse5TMHEbdBt3I4TLIKHwg==
+labs-ui@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/labs-ui/-/labs-ui-1.0.2.tgz#66f50a6e07642aa253d9990074f174778c06eabc"
+  integrity sha512-AS1KWfFZAAGCcTdVbDXdVMwl/hVKDM88keJoZEftgmtcW72SezqLw8lVlaO9JSpgAS4h4HZT/98HsR4W0o9rMQ==
   dependencies:
     "@fortawesome/ember-fontawesome" ">=0.2.1"
     "@fortawesome/free-brands-svg-icons" ">=5.2.0"
@@ -9968,12 +9968,7 @@ lodash.values@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.values/-/lodash.values-4.3.0.tgz#a3a6c2b0ebecc5c2cba1c17e6e620fe81b53d347"
   integrity sha1-o6bCsOvsxcLLocF+bmIP6BtT00c=
 
-lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@~4.17.12:
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
-
-lodash@^4.17.19:
+lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@~4.17.12:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==


### PR DESCRIPTION
This simple PR updates Labs UI to the latest patch version which loads the NYC Planning logo from addon instead of from raw.githubusercontent. 