### PR TITLE
Extract user badge to new component; add edit link

### DIFF
--- a/client/app/components/auth/user-badge.hbs
+++ b/client/app/components/auth/user-badge.hbs
@@ -1,0 +1,16 @@
+<FaIcon @icon="user-circle" @prefix="fas" @size="2x" class="auth--icon" />
+<div>
+  <span class="auth--name">
+    <a href={{this.userProfileURI}} rel="noopener noreferrer">
+      {{this.session.data.authenticated.emailaddress1}}
+    </a>
+  </span>
+  <button
+    type="button"
+    class="auth--logout-button"
+    {{on "click" this.doLogout}}
+    data-test-auth="logout"
+  >
+    Sign Out
+  </button>
+</div>

--- a/client/app/components/auth/user-badge.js
+++ b/client/app/components/auth/user-badge.js
@@ -1,0 +1,28 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import ENV from '../../config/environment';
+
+const encodeToBase64 = (string) => btoa(string);
+
+export default class UserBadgeComponent extends Component {
+  @service session;
+
+  @service router;
+
+  get currentHref() {
+    return window.location.href;
+  }
+
+  get userProfileURI() {
+    const { origin } = new URL(ENV.NYCIDLocation || 'https://accounts-nonprd.nyc.gov');
+
+    // base64 is a requirement of NYC.ID — target value must be Base64-encoded
+    return `${origin}/account/user/profile.htm?returnOnSave=true&target=${encodeToBase64(this.currentHref)}`;
+  }
+
+  @action
+  doLogout() {
+    this.router.transitionTo('logout');
+  }
+}

--- a/client/app/controllers/application.js
+++ b/client/app/controllers/application.js
@@ -1,12 +1,6 @@
 import Controller from '@ember/controller';
-import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default class ApplicationController extends Controller {
   @service session;
-
-  @action
-  doLogout() {
-    this.transitionToRoute('logout');
-  }
 }

--- a/client/app/templates/application.hbs
+++ b/client/app/templates/application.hbs
@@ -14,20 +14,7 @@
     <ul class="menu vertical medium-horizontal">
       {{#if this.session.isAuthenticated}}
         <li class="auth--container">
-          <FaIcon @icon="user-circle" @prefix="fas" @size="2x" class="auth--icon" />
-          <div>
-            <span class="auth--name">
-              {{this.session.data.authenticated.emailaddress1}}
-            </span>
-            <button
-              type="button"
-              class="auth--logout-button"
-              {{on "click" this.doLogout}}
-              data-test-auth="logout"
-            >
-              Sign Out
-            </button>
-          </div>
+          <Auth::UserBadge />
         </li>
       {{else}}
         <li>

--- a/client/tests/integration/components/auth/user-badge-test.js
+++ b/client/tests/integration/components/auth/user-badge-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | user-badge', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<Auth::UserBadge />`);
+
+    assert.equal(this.element.textContent.trim(), 'Sign Out');
+  });
+});


### PR DESCRIPTION
According to NYC.ID terms of use, we must link out to the user's profile on the NYC.ID website. This allows the user to edige their profile: https://www1.nyc.gov/assets/nyc4d/html/services-nycid/account-profile.shtml.

This change takes some of the existing markup for displaying the user email and "log out" link, extracts it into its own component, and hyperlinks that email out to the required NYC.Id profile edit page.

The complexity in here is due to the requirement of NYC.ID to encode the redirect (which occurs afte ruser "saves" their changes to their profile page) uri back to the app. That must be encoded as base64.  