### PR TITLE
Enforce auth in documents for everything except GET

### DIFF
--- a/server/src/document/document.controller.ts
+++ b/server/src/document/document.controller.ts
@@ -20,7 +20,6 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { AuthenticateGuard } from '../authenticate.guard';
 
 @Controller('documents')
-@UseGuards(AuthenticateGuard)
 export class DocumentController {
   constructor(
     private readonly config: ConfigService,
@@ -39,6 +38,7 @@ export class DocumentController {
    */
   @Post('/')
   @UseInterceptors(FileInterceptor('file'))
+  @UseGuards(AuthenticateGuard)
   async create(@UploadedFile() file, @Body('instanceId') instanceId, @Session() session) {
     const headers = {
       // Document will be uploaded as this user
@@ -77,6 +77,7 @@ export class DocumentController {
 
   @Delete('/')
   @HttpCode(204)
+  @UseGuards(AuthenticateGuard)
   async destroy(@Query('serverRelativeUrl') serverRelativeUrl) {
     return this.crmService.deleteSharepointFile(serverRelativeUrl);
   }


### PR DESCRIPTION
This is a temporary fix to allow downloads again. The drawback is that these download links are shareable.

We should revisit this authorization issue when we redo our auth workflow.

The reason this broke was due to my change to authentication: we no longer use cookies to sign API requests. We use authorization headers. However, the download link for documents is a plain HTML link. You can't inject headers in requests for downloads in plain HTML hyperlinks. This meant the request wasn't authenticated. 