### PR TITLE
526 Flatten nested response objects and mold to JSON API format 

### DIFF
--- a/server/src/http-exception.filter.spec.ts
+++ b/server/src/http-exception.filter.spec.ts
@@ -1,7 +1,42 @@
-import { HttpExceptionFilter } from './http-exception.filter';
+import { unfoldedStackTrace } from './http-exception.filter';
 
 describe('HttpExceptionFilter', () => {
-  it('should be defined', () => {
-    expect(new HttpExceptionFilter()).toBeDefined();
+  it('should unfold recursively nested response objects', () => {
+    const mockResponse = {
+      code: 1,
+      title: "1 title",
+      detail: "1 detail",
+      response: {
+        code: 2,
+        title: "2 title",
+        detail: "2 detail",
+        response: {
+          code: 3,
+          title: "3 title",
+          detail: "3 detail",
+        }
+      }
+    };
+
+    expect(unfoldedStackTrace(mockResponse, 400)).toEqual([
+      {
+        code: 1,
+        title: "1 title",
+        detail: "1 detail",
+        status: 400,
+      },
+      {
+        code: 2,
+        title: "2 title",
+        detail: "2 detail",
+        status: 400,
+      },
+      {
+        code: 3,
+        title: "3 title",
+        detail: "3 detail",
+        status: 400,
+      }
+    ]);
   });
 });


### PR DESCRIPTION
Rework the HTTP Exception Filter to mold Exceptions to JSON API
compliant error objects before returning them to the client.

Also, response objects from HttpExceptions may be recursively
nested to reflect a stack trace (each level is a layer in the stack).
This flattens them out so that each response
is a top-level item in the errors array.