### PR TITLE
565: update syncActions to PATCH updates to dcp_affectedzoningresolution

### DIFF
--- a/server/src/packages/rwcds-form/rwcds-form.service.ts
+++ b/server/src/packages/rwcds-form/rwcds-form.service.ts
@@ -152,7 +152,12 @@ export class RwcdsFormService {
   // The syncActions method queries for project actions (dcp_projectaction) associated
   // with the rwcds form's related project. 
   // Then, it posts each of the project actions to dcp_affectedzoningresolution.
-  // This occurs every time that the rwcds-form endpoint is hit
+  // This occurs every time that the rwcds-form endpoint is hit.
+
+  // dcp_projectaction entity --> dcp_affectedzoningresolution entity attribute mapping:
+  // `_dcp_action_value@OData.Community.Display.V1.FormattedValue`  --> `dcp_zoningresolutiontype`
+  // `ZoningResolution.dcp_zoningresolution` --> `dcp_zrsectionnumeber`
+  // `dcp_zrmodifyingzrtxt` --> `dcp_modifiedzrsectionnumber`
   async syncActions(rwcdsForm) {
     const {
       dcp_rwcdsform_dcp_affectedzoningresolution_rwcdsform: affectedZoningResolutions,
@@ -171,14 +176,30 @@ export class RwcdsFormService {
       const projectActionLabel = action['_dcp_action_value@OData.Community.Display.V1.FormattedValue'];
 
       // Lookup: dcp_affectedzoningresolutions asks for a ZR type,
-      const { label, code } = ZONING_RESOLUTION_TYPES.filter((zr) => zr.label === projectActionLabel)[0] || { label: '', code: null };
+      const { label, code } = ZONING_RESOLUTION_TYPES.find((zr) => zr.label === projectActionLabel) || { label: '', code: null };
+      const matchingZr = affectedZoningResolutions.find(zr => zr.dcp_zoningresolutiontype === code);
+      // action attribute that matches dcp_zrsectionnumber on dcp_affectedzoningresolution
+      const currentActionZoningResolution = action.dcp_ZoningResolution ? action.dcp_ZoningResolution.dcp_zoningresolution : null
 
       if (!label) console.log(`Could not find Affected ZR Type for ${projectActionLabel}`);
 
-      if (!zrTypes.includes(label) && label) {
+      // IF the action.ZoningResolution.dcp_zoningresolution value has changed since the initial POST,
+      // then PATCH the new value to dcp_zrsectionnumber on dcp_affectedzoningresolution entity
+      // NOTE: dcp_modifiedzrsectionnumber not included here because it's updated by applicant on rwcds-form
+      if (matchingZr && matchingZr.dcp_zrsectionnumber !== currentActionZoningResolution) {
+        return this.crmService.update('dcp_affectedzoningresolutions', matchingZr.dcp_affectedzoningresolutionid, {
+          dcp_zrsectionnumber: currentActionZoningResolution,
+        });
+      }
+
+      // IF the zr type does not exist yet, then POST the action
+      // NOTE: some actions that exist in dcp_projectaction SHOULD NOT be copied over
+      // NOTE cont. -- The ZONING_RESOLUTION_TYPES lookup also functions as a list of actions that SHOULD...
+      // NOTE cont. -- be copied over from dcp_projectaction, which is why we check that `label` exists here.
+      if (!matchingZr && label) {
         return this.crmService.create(`dcp_affectedzoningresolutions`, {
-          'dcp_zoningresolutiontype': code, // this is a coded value
-          'dcp_zrsectionnumber': action.dcp_ZoningResolution ? action.dcp_ZoningResolution.dcp_zoningresolution : null,
+          'dcp_zoningresolutiontype': code, // coded value
+          'dcp_zrsectionnumber': currentActionZoningResolution,
           'dcp_modifiedzrsectionnumber': action.dcp_zrmodifyingzrtxt,
           'dcp_rwcdsform@odata.bind': `/dcp_pasforms(${dcp_rwcdsformid})`,
         });

--- a/server/src/packages/rwcds-form/rwcds-form.service.ts
+++ b/server/src/packages/rwcds-form/rwcds-form.service.ts
@@ -193,10 +193,10 @@ export class RwcdsFormService {
       }
 
       // IF the zr type does not exist yet, then POST the action
-      // NOTE: some actions that exist in dcp_projectaction SHOULD NOT be copied over
-      // NOTE cont. -- The ZONING_RESOLUTION_TYPES lookup also functions as a list of actions that SHOULD...
-      // NOTE cont. -- be copied over from dcp_projectaction, which is why we check that `label` exists here.
-      if (!matchingZr && label) {
+      // NOTE: Some actions that exist in dcp_projectaction SHOULD NOT be copied over.
+      // The ZONING_RESOLUTION_TYPES lookup also functions as a list of actions that SHOULD be
+      // copied over from dcp_projectaction, which is why we check that `code` exists here.
+      if (!matchingZr && code) {
         return this.crmService.create(`dcp_affectedzoningresolutions`, {
           'dcp_zoningresolutiontype': code, // coded value
           'dcp_zrsectionnumber': currentActionZoningResolution,


### PR DESCRIPTION
For cases where the specific dcp_projectaction row has already been POSTed to dcp_affectedzoningresolution entity...if a planner updates dcp_projectaction entity in CRM afterwards, then syncActions function will check for these changes and PATCH the changes to dcp_affectedzoningresolution. 

addresses #565 