### PR TITLE
526 Display JSONAPI errors in frontend

### DIFF
--- a/client/app/components/errors/list.hbs
+++ b/client/app/components/errors/list.hbs
@@ -1,0 +1,11 @@
+{{#each @errors as |error idx|}}
+  {{#each-in error as |key value|}}
+    <code
+      class="callout display-block text-left red-muted"
+      data-test-error-key={{key}}
+      data-test-error-idx={{idx}}
+    >
+      {{key}}: {{value}}
+    </code>
+  {{/each-in}}
+{{/each}}

--- a/client/app/components/packages/pas-form/pas-form-error.hbs
+++ b/client/app/components/packages/pas-form/pas-form-error.hbs
@@ -8,34 +8,12 @@
       />
         There was a problem saving your information.
     </h5>
-      {{#each @package.pasForm.adapterError.errors as |error|}}
-        <p class="font-mono text-red-dark bg-red-white small-padding text-small" data-test-error-message>
-          Message: {{error.message}} <br>
-          Status: {{error.status}} <br>
-          Response: <br>
-          <ul>
-            {{#each-in error as |key value|}}
-              <li class="display-block">
-                {{key}}: {{value}}
-              </li>
-            {{/each-in}}
-          </ul>
-        </p>
-      {{/each}}
-      {{#each @package.adapterError.errors as |error|}}
-        <p class="font-mono text-red-dark bg-red-white small-padding text-small" data-test-error-message>
-          Message: {{error.message}} <br>
-          Status: {{error.status}} <br>
-          Response:
-          <ul>
-            {{#each-in error as |key value|}}
-              <li class="display-block">
-                {{key}}: {{value}}
-              </li>
-            {{/each-in}}
-          </ul>
-        </p>
-      {{/each}}
+      <Errors::List
+        @errors={{@package.pasForm.adapterError.errors}}
+      />
+      <Errors::List
+        @errors={{@package.adapterError.errors}}
+      />
       <p class="text-red-dark text-small">
         Please try again. If the problem persists, please contact NYC Planning at <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or <a href="tel:212-720-3300" class="nowrap">212-720-3300</a>.
       </p>

--- a/client/app/components/packages/rwcds-form/rwcds-form-error.hbs
+++ b/client/app/components/packages/rwcds-form/rwcds-form-error.hbs
@@ -8,34 +8,12 @@
       />
         There was a problem saving your information.
     </h5>
-      {{#each @package.rwcdsForm.adapterError.errors as |error|}}
-        <p class="font-mono text-red-dark bg-red-white small-padding text-small" data-test-error-message>
-          Message: {{error.message}} <br>
-          Status: {{error.status}} <br>
-          Response:
-          <ul>
-            {{#each-in error as |key value|}}
-              <li class="display-block">
-                {{key}}: {{value}}
-              </li>
-            {{/each-in}}
-          </ul>
-        </p>
-      {{/each}}
-      {{#each @package.adapterError.errors as |error|}}
-        <p class="font-mono text-red-dark bg-red-white small-padding text-small" data-test-error-message>
-          Message: {{error.message}} <br>
-          Status: {{error.status}} <br>
-          Response:
-          <ul>
-            {{#each-in error as |key value|}}
-              <li class="display-block">
-                {{key}}: {{value}}
-              </li>
-            {{/each-in}}
-          </ul>
-        </p>
-      {{/each}}
+      <Errors::List
+        @errors={{@package.rwcdsForm.adapterError.errors}}
+      />
+      <Errors::List
+        @errors={{@package.adapterError.errors}}
+      />
       <p class="text-red-dark text-small">
         Please try again. If the problem persists, please contact City Planning at <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or <a href="tel:212-720-3300" class="nowrap">212-720-3300</a>.
       </p>

--- a/client/app/templates/login-error.hbs
+++ b/client/app/templates/login-error.hbs
@@ -16,20 +16,9 @@
           </p>
         {{/if}}
 
-        {{#each @model.errors as |error idx|}}
-          {{#if error.detail}}
-            <code class="callout display-block text-left red-muted" data-test-error-message={{idx}}>{{error.detail}}</code>
-          {{else}}
-            {{#each-in error as |key value|}}
-              <code class="callout display-block text-left red-muted" data-test-error-response={{concat key idx}}>
-                {{key}}: {{value}}
-              </code>
-            {{/each-in}}
-            <code class="callout display-block text-left red-muted">
-              status: {{error.status}}
-            </code>
-          {{/if}}
-        {{/each}}
+        <Errors::List
+          @errors={{@model.errors}}
+        />
 
         <Auth::DoLogout />
 

--- a/client/app/templates/projects-error.hbs
+++ b/client/app/templates/projects-error.hbs
@@ -5,20 +5,9 @@
 <div class="text-center xlarge-padding-top xlarge-padding-bottom xlarge-margin-top xlarge-margin-bottom">
   <span>Hmm, something went wrong:</span>
 
-  {{#each this.model.errors as |error|}}
-    <p class="font-mono text-red-dark bg-red-white small-padding text-small" data-test-error-message>
-      Message: {{error.message}} <br>
-      Status: {{error.status}} <br>
-      Response:
-      <ul>
-        {{#each-in error.response as |key value|}}
-          <li class="display-block">
-            {{key}}: {{value}}
-          </li>
-        {{/each-in}}
-      </ul>
-    </p>
-  {{/each}}
+  <Errors::List
+    @errors={{this.model.errors}}
+  />
 
   {{!-- If there's an error, try to logout --}}
   <Auth::DoLogout />

--- a/client/tests/acceptance/error-message-appears-when-save-fails-test.js
+++ b/client/tests/acceptance/error-message-appears-when-save-fails-test.js
@@ -27,11 +27,11 @@ module('Acceptance | error message appears when save fails', function(hooks) {
       project: this.server.create('project'),
     });
 
-    this.server.patch('/pas-forms/:id', { errors: [{ message: 'server problem with pasForm' }] }, 500); // force mirage to error
+    this.server.patch('/pas-forms/:id', { errors: [{ detail: 'server problem with pasForm' }] }, 500); // force mirage to error
 
     await visit('/pas-form/1/edit');
 
-    assert.dom('[data-test-error-message]').doesNotExist();
+    assert.dom('[data-test-error-key="detail"]').doesNotExist();
 
     await fillIn('[data-test-input="dcpRevisedprojectname"]', 'Some Cool New Project Name');
 
@@ -39,10 +39,10 @@ module('Acceptance | error message appears when save fails', function(hooks) {
     await click('[data-test-save-button]');
     await settled(); // async make sure save action finishes before assertion
 
-    await waitFor('[data-test-error-message]');
+    await waitFor('[data-test-error-key="detail"]');
 
-    assert.dom('[data-test-error-message]').exists();
-    assert.dom('[data-test-error-message]').includesText('server problem with pasForm');
+    assert.dom('[data-test-error-key="detail"]').exists();
+    assert.dom('[data-test-error-key="detail"]').includesText('server problem with pasForm');
 
     // check that model was not saved
     assert.equal(this.server.db.pasForms[0].dcpRevisedprojectname, undefined);
@@ -53,11 +53,11 @@ module('Acceptance | error message appears when save fails', function(hooks) {
       project: this.server.create('project'),
     });
 
-    this.server.patch('/rwcds-forms/:id', { errors: [{ message: 'server problem with rwcdsForm' }] }, 500); // force mirage to error
+    this.server.patch('/rwcds-forms/:id', { errors: [{ detail: 'server problem with rwcdsForm' }] }, 500); // force mirage to error
 
     await visit('/rwcds-form/1/edit');
 
-    assert.dom('[data-test-error-message]').doesNotExist();
+    assert.dom('[data-test-error-key="detail"]').doesNotExist();
 
     await fillIn('[data-test-input="dcpProjectsitedescription"]', 'Whatever affects one directly, affects all indirectly.');
 
@@ -65,10 +65,10 @@ module('Acceptance | error message appears when save fails', function(hooks) {
     await click('[data-test-save-button]');
     await settled(); // async make sure save action finishes before assertion
 
-    await waitFor('[data-test-error-message]');
+    await waitFor('[data-test-error-key="detail"]');
 
-    assert.dom('[data-test-error-message]').exists();
-    assert.dom('[data-test-error-message]').includesText('server problem with rwcdsForm');
+    assert.dom('[data-test-error-key="detail"]').exists();
+    assert.dom('[data-test-error-key="detail"]').includesText('server problem with rwcdsForm');
 
     // check that model was not saved
     assert.equal(this.server.db.rwcdsForms[0].dcpProjectsitedescription, undefined);
@@ -83,11 +83,11 @@ module('Acceptance | error message appears when save fails', function(hooks) {
       }),
     });
 
-    this.server.patch('/packages/:id', { errors: [{ message: 'server problem with package' }] }, 500); // force mirage to error
+    this.server.patch('/packages/:id', { errors: [{ detail: 'server problem with package' }] }, 500); // force mirage to error
 
     await visit('/pas-form/2/edit');
 
-    assert.dom('[data-test-error-message]').doesNotExist();
+    assert.dom('[data-test-error-key="detail"]').doesNotExist();
 
     const file = new File(['foo'], 'Zoning Application.pdf', { type: 'text/plain' });
     await selectFiles('#FileUploader2 > input', file);
@@ -96,10 +96,10 @@ module('Acceptance | error message appears when save fails', function(hooks) {
     await click('[data-test-save-button]');
     await settled(); // async make sure save action finishes before assertion
 
-    await waitFor('[data-test-error-message]');
+    await waitFor('[data-test-error-key="detail"]');
 
-    assert.dom('[data-test-error-message]').exists();
-    assert.dom('[data-test-error-message]').includesText('server problem with package');
+    assert.dom('[data-test-error-key="detail"]').exists();
+    assert.dom('[data-test-error-key="detail"]').includesText('server problem with package');
 
     // check that model was not saved
     assert.equal(this.server.db.packages[1].documents.length, 0);
@@ -123,19 +123,19 @@ module('Acceptance | error message appears when save fails', function(hooks) {
       }),
     });
 
-    this.server.patch('/pas-forms/:id', { errors: [{ message: 'server problem with pasForm' }] }, 500); // force mirage to error
+    this.server.patch('/pas-forms/:id', { errors: [{ detail: 'server problem with pasForm' }] }, 500); // force mirage to error
 
     await visit('/pas-form/1/edit');
 
-    assert.dom('[data-test-error-message]').doesNotExist();
+    assert.dom('[data-test-error-key="detail"]').doesNotExist();
 
     await click('[data-test-submit-button]');
     await click('[data-test-confirm-submit-button]');
 
-    await waitFor('[data-test-error-message]');
+    await waitFor('[data-test-error-key="detail"]');
 
-    assert.dom('[data-test-error-message]').exists();
-    assert.dom('[data-test-error-message]').includesText('server problem with pasForm');
+    assert.dom('[data-test-error-key="detail"]').exists();
+    assert.dom('[data-test-error-key="detail"]').includesText('server problem with pasForm');
 
     // make sure route did not transition
     assert.equal(currentURL(), '/pas-form/1/edit');

--- a/client/tests/acceptance/user-can-login-test.js
+++ b/client/tests/acceptance/user-can-login-test.js
@@ -55,7 +55,7 @@ module('Acceptance | user can login', function(hooks) {
     await visit('/login');
 
     assert.ok(find('[data-test-applicant-error-message="contact-not-assigned"'));
-    assert.dom('[data-test-error-response="code0"]')
+    assert.dom('[data-test-error-key="code"]')
       .hasText('code: NO_CONTACT_FOUND', 'It displays the correct error code');
   });
 
@@ -85,7 +85,7 @@ module('Acceptance | user can login', function(hooks) {
 
     await visit('/login');
 
-    assert.dom('[data-test-error-message="0"]')
-      .hasText('Invalid auth params - "access_token" missing.');
+    assert.dom('[data-test-error-key="detail"][data-test-error-idx="0"]')
+      .hasText('detail: Invalid auth params - "access_token" missing.');
   });
 });

--- a/client/tests/integration/components/errors/list-test.js
+++ b/client/tests/integration/components/errors/list-test.js
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | errors/list', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+    this.mockErrors = [
+      {
+        code: 1,
+        title: '1 title',
+        detail: '1 detail',
+      },
+      {
+        code: 2,
+        title: '2 title',
+        detail: '2 detail',
+      },
+    ];
+
+    await render(hbs`<Errors::List
+      @errors={{this.mockErrors}}
+    />`);
+
+    assert.dom('[data-test-error-key="detail"][data-test-error-idx="0"]').includesText('detail: 1 detail');
+    assert.dom('[data-test-error-key="code"][data-test-error-idx="1"]').includesText('code: 2');
+  });
+});


### PR DESCRIPTION
This PR unifies the frontend *-error templates
in how they render JSONAPI errors from the backend.
It creates a component, which the templates share,
that iterates through the incoming `errors` array
and renders the keys in each error object.

complements #562 