### PR TITLE
526 unfold correct response in exception filter

### DIFF
--- a/server/src/http-exception.filter.ts
+++ b/server/src/http-exception.filter.ts
@@ -30,15 +30,16 @@ export function unfoldedStackTrace(response, status) {
 export class HttpExceptionFilter implements ExceptionFilter {
   catch(exception: HttpException, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
-    const response = ctx.getResponse<Response>();
+    const httpResponse = ctx.getResponse<Response>();
     const status = exception.getStatus();
+    const errorResponse = exception.getResponse();
 
     // this shapes the error responses into JSON:API
     // see https://jsonapi.org/format/#errors
-    response
+    httpResponse
       .status(status)
       .json({
-        errors: unfoldedStackTrace(response, status),
+        errors: unfoldedStackTrace(errorResponse, status),
       });
   }
 }


### PR DESCRIPTION
This patches the exception filter to correctly
reference the *error* response body when unfolding.
Previously it was referencing the HTTP response
body.