### PR TITLE
526 Add error pages for form edit/show and project routes

### DIFF
--- a/client/app/templates/pas-form-error.hbs
+++ b/client/app/templates/pas-form-error.hbs
@@ -1,0 +1,10 @@
+<Ui::Breadcrumbs as |Crumb|>
+  <Crumb @text="My Projects" @route='projects' />
+  <Crumb @text="..." @disabled={{true}} />
+  <Crumb @text="..." @disabled={{true}} />
+  <Crumb @text="..." @disabled={{true}} />
+</Ui::Breadcrumbs>
+
+<Errors::List
+  @errors={{@model.errors}}
+/>

--- a/client/app/templates/pas-form/edit-error.hbs
+++ b/client/app/templates/pas-form/edit-error.hbs
@@ -1,0 +1,12 @@
+<Ui::Breadcrumbs as |Crumb|>
+  <Crumb @text="My Projects" @route='projects' />
+  <Crumb @text="(Error / Not Found)" @disabled={{true}} />
+  <Crumb @text="PAS" @disabled={{true}} />
+  <Crumb @text="Edit" @current={{true}} />
+</Ui::Breadcrumbs>
+
+<Errors::List
+  @errors={{this.model.errors}}
+/>
+
+{{outlet}}

--- a/client/app/templates/pas-form/show-error.hbs
+++ b/client/app/templates/pas-form/show-error.hbs
@@ -1,0 +1,9 @@
+<Ui::Breadcrumbs as |Crumb|>
+  <Crumb @text="My Projects" @route='projects' />
+  <Crumb @text="(Error / Not Found)" @disabled={{true}} />
+  <Crumb @text="PAS" @current={{true}} />
+</Ui::Breadcrumbs>
+
+<Errors::List
+  @errors={{@model.errors}}
+/>

--- a/client/app/templates/project-error.hbs
+++ b/client/app/templates/project-error.hbs
@@ -1,0 +1,8 @@
+<Ui::Breadcrumbs as |Crumb|>
+  <Crumb @text="My Projects" @route='projects' />
+  <Crumb @text="(Error / Not Found)" @current={{true}} />
+</Ui::Breadcrumbs>
+
+<Errors::List
+  @errors={{@model.errors}}
+/>

--- a/client/app/templates/rwcds-form-error.hbs
+++ b/client/app/templates/rwcds-form-error.hbs
@@ -1,0 +1,11 @@
+<Ui::Breadcrumbs as |Crumb|>
+  <Crumb @text="My Projects" @route='projects' />
+  <Crumb @text="..." @disabled={{true}} />
+  <Crumb @text="..." @disabled={{true}} />
+  <Crumb @text="..." @disabled={{true}} />
+</Ui::Breadcrumbs>
+
+<Errors::List
+  @errors={{@model.errors}}
+/>
+

--- a/client/app/templates/rwcds-form/edit-error.hbs
+++ b/client/app/templates/rwcds-form/edit-error.hbs
@@ -1,0 +1,10 @@
+<Ui::Breadcrumbs as |Crumb|>
+  <Crumb @text="My Projects" @route='projects' />
+  <Crumb @text="(Error / Not Found)" @disabled={{true}} />
+  <Crumb @text="RWCDS" @disabled={{true}} />
+  <Crumb @text="Edit" @current={{true}} />
+</Ui::Breadcrumbs>
+
+<Errors::List
+  @errors={{@model.errors}}
+/>

--- a/client/app/templates/rwcds-form/show-error.hbs
+++ b/client/app/templates/rwcds-form/show-error.hbs
@@ -1,0 +1,9 @@
+<Ui::Breadcrumbs as |Crumb|>
+  <Crumb @text="My Projects" @route='projects' />
+  <Crumb @text="(Error / Not Found)" @disabled={{true}} />
+  <Crumb @text="RWCDS" @current={{true}} />
+</Ui::Breadcrumbs>
+
+<Errors::List
+  @errors={{@model.errors}}
+/>


### PR DESCRIPTION
This is similar to the work for #596 , but stands up error pages for the remaining templates