### PR TITLE
507 Add access guard for packages

### DIFF
--- a/server/src/packages/package-access.guard.ts
+++ b/server/src/packages/package-access.guard.ts
@@ -1,0 +1,69 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  HttpException,
+  HttpStatus,
+  Injectable
+} from '@nestjs/common';
+import {
+  CrmService
+} from '../crm/crm.service';
+
+const APPLICANT_ACTIVE_STATUS_CODE = 1;
+const PROJECT_ACTIVE_STATE_CODE = 0;
+const PROJECT_VISIBILITY_APPLICANT_ONLY = 717170002;
+const PROJECT_VISIBILITY_GENERAL_PUBLIC = 717170003;
+
+// This guard makes sure that only
+// authenticated users who are part of the requested
+// package's project applicant team can access the package
+@Injectable()
+export class PackageAccessGuard implements CanActivate {
+  constructor(
+    private readonly crmService: CrmService,
+  ) {}
+
+  async canActivate(
+    context: ExecutionContext
+  ): Promise<boolean> {
+    const {
+      params: {
+        id: packageId,
+      },
+      session: {
+        contactId,
+      }
+    } = context.switchToHttp().getRequest();
+
+    if (contactId) {
+      const { records } = await this.crmService.get('dcp_projects', `
+        $filter=
+          dcp_dcp_project_dcp_package_project/
+            any(o:
+              o/dcp_packageid eq '${packageId}'
+            )
+          and
+          dcp_dcp_project_dcp_projectapplicant_Project/
+            any(o:
+              o/_dcp_applicant_customer_value eq '${contactId}'
+              and o/statuscode eq ${APPLICANT_ACTIVE_STATUS_CODE}
+            )
+          and (
+            dcp_visibility eq ${PROJECT_VISIBILITY_APPLICANT_ONLY}
+            or dcp_visibility eq ${PROJECT_VISIBILITY_GENERAL_PUBLIC}
+          )
+          and statecode eq ${PROJECT_ACTIVE_STATE_CODE}
+        `)
+
+      if (records.length > 0) {
+        return true;
+      }
+    }
+
+    throw new HttpException({
+      code: "NO_PACKAGE_ACCESS",
+      title: "No access to package",
+      detail: "Access to the requested package is forbidden."
+    }, HttpStatus.FORBIDDEN);
+  }
+}

--- a/server/src/packages/packages.controller.ts
+++ b/server/src/packages/packages.controller.ts
@@ -1,19 +1,19 @@
 import {
+  Body,
   Controller,
   Get,
   HttpException,
   HttpStatus,
   Param,
-  UseInterceptors,
   Patch,
-  Body,
+  UseInterceptors,
+  UseGuards,
   UsePipes,
-  UseGuards
 } from '@nestjs/common';
 import { PackagesService } from './packages.service';
 import { JsonApiSerializeInterceptor } from '../json-api-serialize.interceptor';
 import { JsonApiDeserializePipe } from '../json-api-deserialize.pipe';
-import { AuthenticateGuard } from '../authenticate.guard';
+import { PackageAccessGuard } from './package-access.guard';
 import { pick } from 'underscore';
 import { RWCDS_FORM_ATTRS } from './rwcds-form/rwcds-form.attrs';
 import { PAS_FORM_ATTRS, PAS_FORM_PROJECTADDRESS_ATTRS } from './pas-form/pas-form.attrs';
@@ -154,7 +154,7 @@ import { APPLICANT_ATTRS } from './pas-form/applicants/applicants.attrs';
   },
 }))
 @UsePipes(JsonApiDeserializePipe)
-@UseGuards(AuthenticateGuard)
+@UseGuards(PackageAccessGuard)
 @Controller('packages')
 export class PackagesController {
   constructor(private readonly packagesService: PackagesService) {}


### PR DESCRIPTION
Only allow access to a package if current authenticated
user is on the package's project applicant team

Note that although PackageAccessGuard replaced AuthenticationGuard,
PackageAccessGuard contains the AuthenticationGuard's same basic check for a contactId.

The guard checks for if there is a project where the authenticated contact is within the project's applicant team, and the requested package is among the project's packages. If so, the guard passes.

Addresses #507 