### PR TITLE
585: fix zap-search hyperlink on projects page

### DIFF
--- a/client/app/components/my-projects/list-item.hbs
+++ b/client/app/components/my-projects/list-item.hbs
@@ -26,8 +26,8 @@
     <span class="text-gray"> | </span>
 
     <strong>Public Status:</strong>
-    <FaIcon @icon={{if this.publicStatusGeneralPublicProjects 'eye' 'eye-slash'}} @prefix="far" class="text-gray"/>
-    {{#if this.publicStatusGeneralPublicProjects}}
+    <FaIcon @icon={{if @project.publicStatusGeneralPublicProject 'eye' 'eye-slash'}} @prefix="far" class="text-gray"/>
+    {{#if @project.publicStatusGeneralPublicProject}}
       <Ui::ExternalLink @href="https://zap.planning.nyc.gov/projects/{{@project.dcpName}}"> {{optionset 'project' 'dcpPublicstatus' 'label' @project.dcpPublicstatus}} </Ui::ExternalLink>
     {{else}}
       {{optionset 'project' 'dcpPublicstatus' 'label' @project.dcpPublicstatus}}

--- a/client/app/components/ui/external-link.hbs
+++ b/client/app/components/ui/external-link.hbs
@@ -1,4 +1,4 @@
-<a href="" target="_blank" rel="noopener noreferrer" class="external-link" ...attributes>
+<a href={{@href}} target="_blank" rel="noopener noreferrer" class="external-link" ...attributes>
   {{yield~}}
   <sup>&#8239;{{!--
 --}}<FaIcon @icon="external-link-alt" @prefix="fas" />

--- a/client/app/controllers/project.js
+++ b/client/app/controllers/project.js
@@ -1,9 +1,0 @@
-import Controller from '@ember/controller';
-import { optionset } from '../helpers/optionset';
-
-export default class ProjectController extends Controller {
-  get publicStatusGeneralPublicProjects() {
-    const isGeneralPublic = this.model.dcpVisibility === optionset(['project', 'dcpVisibility', 'code', 'GENERAL_PUBLIC']);
-    return this.model.dcpPublicstatus && isGeneralPublic;
-  }
-}

--- a/client/app/models/project.js
+++ b/client/app/models/project.js
@@ -27,6 +27,11 @@ export default class ProjectModel extends Model {
   @hasMany('package', { async: false })
   packages;
 
+  get publicStatusGeneralPublicProject() {
+    const isGeneralPublic = this.dcpVisibility === optionset(['project', 'dcpVisibility', 'code', 'GENERAL_PUBLIC']);
+    return this.dcpPublicstatus && isGeneralPublic;
+  }
+
   get pasPackages() {
     const pasPackages = this.packages
       .filter((projectPackage) => projectPackage.dcpPackagetype === optionset(['package', 'type', 'code', 'PAS_PACKAGE']))

--- a/client/app/templates/project.hbs
+++ b/client/app/templates/project.hbs
@@ -21,8 +21,8 @@
       <strong>Project Status:</strong> {{optionset 'project' 'status' 'label' @model.statuscode}}
       <span class="text-gray"> | </span>
       <strong>Public Status:</strong>
-      <FaIcon @icon={{if this.publicStatusGeneralPublicProjects 'eye' 'eye-slash'}} @prefix="far" class="text-gray"/>
-      {{#if this.publicStatusGeneralPublicProjects}}
+      <FaIcon @icon={{if @model.publicStatusGeneralPublicProject 'eye' 'eye-slash'}} @prefix="far" class="text-gray"/>
+      {{#if @model.publicStatusGeneralPublicProject}}
         <Ui::ExternalLink @href="https://zap.planning.nyc.gov/projects/{{@model.dcpName}}"> {{optionset 'project' 'dcpPublicstatus' 'label' @model.dcpPublicstatus}} </Ui::ExternalLink>
       {{else}}
         {{optionset 'project' 'dcpPublicstatus' 'label' @model.dcpPublicstatus}}


### PR DESCRIPTION
Fix zap-search hyperlink on the projects and project page by:
- making sure the `href` for the `ExternalLink` component is dynamic
- moving the `publicStatusGeneralPublicProject` computed property to the project model and using it in both the list-item component and the singular project page

addresses #585 