### PR TITLE
Housekeeping: Standardize optionset keys

### DIFF
--- a/client/app/components/my-projects/list-item.hbs
+++ b/client/app/components/my-projects/list-item.hbs
@@ -21,7 +21,7 @@
 
   <p>
     <strong>Project Status:</strong>
-    {{optionset 'project' 'status' 'label' @project.statuscode}}
+    {{optionset 'project' 'statuscode' 'label' @project.statuscode}}
 
     <span class="text-gray"> | </span>
 

--- a/client/app/components/packages/applicant-fieldset.hbs
+++ b/client/app/components/packages/applicant-fieldset.hbs
@@ -25,14 +25,14 @@
           as |RadioGroup|
         >
           <RadioGroup
-            @options={{optionset 'applicant' 'type' 'list'}}
+            @options={{optionset 'applicant' 'dcpType' 'list'}}
           />
         </form.Field>
       </Ui::Question>
     {{/if}}
 
     {{!-- and if the applicant is on behalf of an organization, we need to know which organization --}}
-    {{#if (eq @applicant.dcpType (optionset 'applicant' 'type' 'code' 'ORGANIZATION'))}}
+    {{#if (eq @applicant.dcpType (optionset 'applicant' 'dcpType' 'code' 'ORGANIZATION'))}}
       <label data-test-applicant-organization>
         Organization Name <Ui::RequiredAsterisk />
         <form.Field @attribute="dcpOrganization" />
@@ -93,10 +93,10 @@
             @placeholder="state"
             @searchEnabled={{true}}
             @searchField="label"
-            @options={{map-by 'code' (optionset 'applicant' 'state' 'list')}}
+            @options={{map-by 'code' (optionset 'applicant' 'dcpState' 'list')}}
             @onchange={{fn (mut @applicant.dcpState)}}
           as |stateCode|>
-            {{optionset 'applicant' 'state' 'label' stateCode}}
+            {{optionset 'applicant' 'dcpState' 'label' stateCode}}
           </PowerSelect>
         </label>
       </div>

--- a/client/app/components/packages/pas-form/show.hbs
+++ b/client/app/components/packages/pas-form/show.hbs
@@ -37,7 +37,7 @@
             {{#if applicant.dcpAddress}}
               <div>
                 <FaIcon @icon="map-marker-alt" class="text-gray" @fixedWidth={{true}} />
-                {{applicant.dcpAddress}}, {{applicant.dcpCity}}, {{optionset 'applicant' 'state' 'label' applicant.dcpState}} {{applicant.dcpZipcode}}
+                {{applicant.dcpAddress}}, {{applicant.dcpCity}}, {{optionset 'applicant' 'dcpState' 'label' applicant.dcpState}} {{applicant.dcpZipcode}}
               </div>
             {{/if}}
             {{#if applicant.dcpPhone}}

--- a/client/app/components/packages/rwcds-form/edit.hbs
+++ b/client/app/components/packages/rwcds-form/edit.hbs
@@ -23,7 +23,7 @@
 
         <p class="text-large text-dark-gray">
           {{optionset 'bbl' 'boroughs' 'label' @package.project.dcpBorough}} |
-          {{optionset 'package' 'status' 'label' @package.statuscode}}
+          {{optionset 'package' 'statuscode' 'label' @package.statuscode}}
         </p>
 
         <p>

--- a/client/app/components/packages/rwcds-form/show.hbs
+++ b/client/app/components/packages/rwcds-form/show.hbs
@@ -22,7 +22,7 @@
 
       <p class="text-large text-dark-gray">
         {{optionset 'bbl' 'boroughs' 'label' @package.project.dcpBorough}} |
-        {{optionset 'package' 'status' 'label' @package.statuscode}}
+        {{optionset 'package' 'statuscode' 'label' @package.statuscode}}
       </p>
     </section>
 

--- a/client/app/components/project/package-list-item.hbs
+++ b/client/app/components/project/package-list-item.hbs
@@ -1,31 +1,31 @@
 <li>
-  {{#if (eq @package.statuscode (optionset 'package' 'status' 'code' 'REVIEWED_REVISIONS_REQUIRED'))}}
+  {{#if (eq @package.statuscode (optionset 'package' 'statuscode' 'code' 'REVIEWED_REVISIONS_REQUIRED'))}}
     <FaIcon @icon="exclamation-triangle" class="text-gold" />
   {{else}}
     <FaIcon
-      @icon={{if (eq @package.statuscode (optionset 'package' 'status' 'code' 'PACKAGE_PREPARATION')) 'edit' 'check'}}
-      class={{if (eq @package.statuscode (optionset 'package' 'status' 'code' 'PACKAGE_PREPARATION')) '' 'text-green-dark'}}
+      @icon={{if (eq @package.statuscode (optionset 'package' 'statuscode' 'code' 'PACKAGE_PREPARATION')) 'edit' 'check'}}
+      class={{if (eq @package.statuscode (optionset 'package' 'statuscode' 'code' 'PACKAGE_PREPARATION')) '' 'text-green-dark'}}
     />
   {{/if}}
-  {{#if (eq @package.dcpPackagetype (optionset 'package' 'type' 'code' "PAS_PACKAGE"))}}
+  {{#if (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' "PAS_PACKAGE"))}}
     <LinkTo
-      @route={{if (eq @package.statuscode (optionset 'package' 'status' 'code' 'PACKAGE_PREPARATION')) 'pas-form.edit' 'pas-form.show'}}
+      @route={{if (eq @package.statuscode (optionset 'package' 'statuscode' 'code' 'PACKAGE_PREPARATION')) 'pas-form.edit' 'pas-form.show'}}
       @model={{@package.id}}
       data-test-package-link={{@package.id}}
     >
       <strong>Version {{@package.dcpPackageversion}}</strong>
     </LinkTo>
   {{/if}}
-  {{#if (eq @package.dcpPackagetype (optionset 'package' 'type' 'code' 'RWCDS'))}}
+  {{#if (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' 'RWCDS'))}}
     <LinkTo
-      @route={{if (eq @package.statuscode (optionset 'package' 'status' 'code' 'PACKAGE_PREPARATION')) 'rwcds-form.edit' 'rwcds-form.show'}}
+      @route={{if (eq @package.statuscode (optionset 'package' 'statuscode' 'code' 'PACKAGE_PREPARATION')) 'rwcds-form.edit' 'rwcds-form.show'}}
       @model={{@package.id}}
       data-test-package-link={{@package.id}}
     >
       <strong>Version {{@package.dcpPackageversion}}</strong>
     </LinkTo>
   {{/if}}
-  <span class="text-gray">| {{if (eq @package.statuscode (optionset 'package' 'status' 'code' 'PACKAGE_PREPARATION')) 'Editable since ' 'Submitted '}}
+  <span class="text-gray">| {{if (eq @package.statuscode (optionset 'package' 'statuscode' 'code' 'PACKAGE_PREPARATION')) 'Editable since ' 'Submitted '}}
     <Ui::DateDisplay @date={{@package.dcpStatusdate}} @outputFormat="MM/D/YYYY" @errorMessage="Date Unknown"/>
   </span>
 </li>

--- a/client/app/controllers/projects.js
+++ b/client/app/controllers/projects.js
@@ -1,14 +1,17 @@
 import Controller from '@ember/controller';
 import { sort } from '@ember/object/computed';
-import { PACKAGE_STATUS, PACKAGE_VISIBILITY } from '../optionsets/package';
+import {
+  STATUSCODE,
+  DCPVISIBILITY,
+} from '../optionsets/package';
 
 export function packageIsToDo(projectPackages) {
   return projectPackages.some((projectPackage) => {
     if (
-      projectPackage.statuscode === PACKAGE_STATUS.PACKAGE_PREPARATION.code
+      projectPackage.statuscode === STATUSCODE.PACKAGE_PREPARATION.code
       && [
-        PACKAGE_VISIBILITY.APPLICANT_ONLY.code,
-        PACKAGE_VISIBILITY.GENERAL_PUBLIC.code,
+        DCPVISIBILITY.APPLICANT_ONLY.code,
+        DCPVISIBILITY.GENERAL_PUBLIC.code,
       ].includes(projectPackage.dcpVisibility)
     ) {
       return true;
@@ -24,8 +27,8 @@ export default class ProjectsController extends Controller {
   // Projects awaiting the applicant's submission
   // (includes active projects with packages that haven't been submitted)
   get toDoProjects () {
+    // Check that at least ONE of the packages is currently editable
     return this.model.filter((project) =>
-      // Check that at least ONE of the packages is currently editable
       packageIsToDo(project.pasPackages) || packageIsToDo(project.rwcdsPackages));
   }
 

--- a/client/app/helpers/helpers.md
+++ b/client/app/helpers/helpers.md
@@ -13,7 +13,7 @@ See [./optionset.js](./optionset.js) for details on the parameters.
 
 The examples below illustrate the six different uses of the helper.
 
-**{{optionset 'package' 'status'}}** --> returns the optionset object
+**{{optionset 'package' 'statuscode'}}** --> returns the optionset object
 ```js
     {
       UNDER_REVIEW: {
@@ -28,7 +28,7 @@ The examples below illustrate the six different uses of the helper.
     } 
 ```
 
-**{{optionset 'package' 'status' 'list'}}** --> returns an array of the optionset's options
+**{{optionset 'package' 'statuscode' 'list'}}** --> returns an array of the optionset's options
 ```js
     [
       {
@@ -43,22 +43,22 @@ The examples below illustrate the six different uses of the helper.
     ] 
 ```
 
-**{{optionset  'package' 'status' 'label' 717170013}}** --> returns label for given code 
+**{{optionset 'package' 'statuscode' 'label' 717170013}}** --> returns label for given code 
 ```
 'Under Review'
 ```
 
-**{{optionset  'package' 'status' 'label' 'UNDER_REVIEW'}}** --> returns label for given identifier 
+**{{optionset 'package' 'statuscode' 'label' 'UNDER_REVIEW'}}** --> returns label for given identifier 
 ```
 'Under Review'
 ```
 
-**{{optionset  'package' 'status' 'code' 'Under Review'}}** --> returns code for given label
+**{{optionset 'package' 'statuscode' 'code' 'Under Review'}}** --> returns code for given label
 ```
 717170013
 ```
 
-**{{optionset  'package' 'status' 'code' 'UNDER_REVIEW'}}** --> returns label for given identifier 
+**{{optionset 'package' 'statuscode' 'code' 'UNDER_REVIEW'}}** --> returns label for given identifier 
 ```
 717170013
 ```

--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -6,10 +6,7 @@ import {
   YES_NO_UNSURE,
   YES_NO_DONT_KNOW,
 } from '../optionsets/common';
-import {
-  DCPSTATE,
-  DCPTYPE,
-} from '../optionsets/applicant';
+import APPLICANT_OPTIONSETS from '../optionsets/applicant';
 import {
   BOROUGHS,
 } from '../optionsets/bbl';
@@ -37,8 +34,8 @@ import {
 
 const OPTIONSET_LOOKUP = {
   applicant: {
-    dcpState: DCPSTATE,
-    dcpType: DCPTYPE,
+    dcpState: APPLICANT_OPTIONSETS.DCPSTATE,
+    dcpType: APPLICANT_OPTIONSETS.DCPTYPE,
   },
   bbl: {
     boroughs: BOROUGHS,

--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -7,8 +7,8 @@ import {
   YES_NO_DONT_KNOW,
 } from '../optionsets/common';
 import {
-  STATE,
-  TYPE,
+  DCPSTATE,
+  DCPTYPE,
 } from '../optionsets/applicant';
 import {
   BOROUGHS,
@@ -37,8 +37,8 @@ import {
 
 const OPTIONSET_LOOKUP = {
   applicant: {
-    state: STATE,
-    type: TYPE,
+    dcpState: DCPSTATE,
+    dcpType: DCPTYPE,
   },
   bbl: {
     boroughs: BOROUGHS,

--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -21,11 +21,7 @@ import {
   DCPLEGALSTREETFRONTAGE,
   DCPHOUSINGUNITTYPE,
 } from '../optionsets/pas-form';
-import {
-  DCPPUBLICSTATUS,
-  PROJECT_VISIBILITY,
-  PROJECT_STATUS,
-} from '../optionsets/project';
+import PROJECT_OPTIONSETS from '../optionsets/project';
 
 const OPTIONSET_LOOKUP = {
   applicant: {
@@ -42,9 +38,9 @@ const OPTIONSET_LOOKUP = {
     dcpPackagetype: PACKAGE_OPTIONSETS.DCPPACKAGETYPE,
   },
   project: {
-    dcpPublicstatus: DCPPUBLICSTATUS,
-    dcpVisibility: PROJECT_VISIBILITY,
-    status: PROJECT_STATUS,
+    dcpPublicstatus: PROJECT_OPTIONSETS.DCPPUBLICSTATUS,
+    dcpVisibility: PROJECT_OPTIONSETS.DCPVISIBILITY,
+    statuscode: PROJECT_OPTIONSETS.STATUSCODE,
   },
   rwcdsForm: {
     dcpHasprojectchangedsincesubmissionofthepas: YES_NO,

--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -17,10 +17,10 @@ import {
   AFFECTED_ZONING_RESOLUTION_ACTION,
 } from '../optionsets/affected-zoning-resolution';
 import {
-  PACKAGE_STATE,
-  PACKAGE_STATUS,
-  PACKAGE_VISIBILITY,
-  PACKAGE_TYPE,
+  STATUSCODE,
+  STATECODE,
+  DCPPACKAGETYPE,
+  DCPVISIBILITY,
 } from '../optionsets/package';
 import {
   DCPCONSTRUCTIONPHASING,
@@ -44,10 +44,10 @@ const OPTIONSET_LOOKUP = {
     boroughs: BOROUGHS,
   },
   package: {
-    state: PACKAGE_STATE,
-    status: PACKAGE_STATUS,
-    visibility: PACKAGE_VISIBILITY,
-    type: PACKAGE_TYPE,
+    statecode: STATECODE,
+    statuscode: STATUSCODE,
+    dcpVisibility: DCPVISIBILITY,
+    dcpPackagetype: DCPPACKAGETYPE,
   },
   project: {
     dcpPublicstatus: DCPPUBLICSTATUS,

--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -13,12 +13,7 @@ import {
 import {
   AFFECTED_ZONING_RESOLUTION_ACTION,
 } from '../optionsets/affected-zoning-resolution';
-import {
-  STATUSCODE,
-  STATECODE,
-  DCPPACKAGETYPE,
-  DCPVISIBILITY,
-} from '../optionsets/package';
+import PACKAGE_OPTIONSETS from '../optionsets/package';
 import {
   DCPCONSTRUCTIONPHASING,
 } from '../optionsets/rwcds-form';
@@ -41,10 +36,10 @@ const OPTIONSET_LOOKUP = {
     boroughs: BOROUGHS,
   },
   package: {
-    statecode: STATECODE,
-    statuscode: STATUSCODE,
-    dcpVisibility: DCPVISIBILITY,
-    dcpPackagetype: DCPPACKAGETYPE,
+    statecode: PACKAGE_OPTIONSETS.STATECODE,
+    statuscode: PACKAGE_OPTIONSETS.STATUSCODE,
+    dcpVisibility: PACKAGE_OPTIONSETS.DCPVISIBILITY,
+    dcpPackagetype: PACKAGE_OPTIONSETS.DCPPACKAGETYPE,
   },
   project: {
     dcpPublicstatus: DCPPUBLICSTATUS,

--- a/client/app/models/package.js
+++ b/client/app/models/package.js
@@ -2,9 +2,9 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 import { inject as service } from '@ember/service';
 import FileManager from '../services/file-manager';
 import {
-  PACKAGE_STATUS,
-  PACKAGE_STATE,
-  PACKAGE_TYPE,
+  STATUSCODE,
+  STATECODE,
+  DCPPACKAGETYPE,
 } from '../optionsets/package';
 
 export default class PackageModel extends Model {
@@ -65,16 +65,16 @@ export default class PackageModel extends Model {
   documents;
 
   setAttrsForSubmission() {
-    this.statuscode = PACKAGE_STATUS.SUBMITTED.code;
-    this.statecode = PACKAGE_STATE.INACTIVE.code;
+    this.statuscode = STATUSCODE.SUBMITTED.code;
+    this.statecode = STATECODE.INACTIVE.code;
   }
 
   async save() {
     await this.fileManager.save();
-    if (this.dcpPackagetype === PACKAGE_TYPE.PAS_PACKAGE.code) {
+    if (this.dcpPackagetype === DCPPACKAGETYPE.PAS_PACKAGE.code) {
       await this.pasForm.save();
     }
-    if (this.dcpPackagetype === PACKAGE_TYPE.RWCDS.code) {
+    if (this.dcpPackagetype === DCPPACKAGETYPE.RWCDS.code) {
       await this.rwcdsForm.save();
     }
     await super.save();
@@ -90,13 +90,13 @@ export default class PackageModel extends Model {
     const isPackageDirty = this.hasDirtyAttributes
       || this.fileManager.isDirty;
 
-    if (this.dcpPackagetype === PACKAGE_TYPE.PAS_PACKAGE.code) {
+    if (this.dcpPackagetype === DCPPACKAGETYPE.PAS_PACKAGE.code) {
       return isPackageDirty
         || this.pasForm.hasDirtyAttributes
         || this.pasForm.isBblsDirty
         || this.pasForm.isApplicantsDirty;
     }
-    if (this.dcpPackagetype === PACKAGE_TYPE.RWCDS.code) {
+    if (this.dcpPackagetype === DCPPACKAGETYPE.RWCDS.code) {
       return isPackageDirty
         || this.rwcdsForm.hasDirtyAttributes
         || this.rwcdsForm.isAffectedZoningResolutionsDirty;

--- a/client/app/models/project.js
+++ b/client/app/models/project.js
@@ -34,7 +34,7 @@ export default class ProjectModel extends Model {
 
   get pasPackages() {
     const pasPackages = this.packages
-      .filter((projectPackage) => projectPackage.dcpPackagetype === optionset(['package', 'type', 'code', 'PAS_PACKAGE']))
+      .filter((projectPackage) => projectPackage.dcpPackagetype === optionset(['package', 'dcpPackagetype', 'code', 'PAS_PACKAGE']))
       .sortBy('dcpPackageversion')
       .reverse();
 
@@ -43,7 +43,7 @@ export default class ProjectModel extends Model {
 
   get rwcdsPackages() {
     const rwcdsPackages = this.packages
-      .filter((projectPackage) => projectPackage.dcpPackagetype === optionset(['package', 'type', 'code', 'RWCDS']))
+      .filter((projectPackage) => projectPackage.dcpPackagetype === optionset(['package', 'dcpPackagetype', 'code', 'RWCDS']))
       .sortBy('dcpPackageversion')
       .reverse();
 

--- a/client/app/optionsets/applicant.js
+++ b/client/app/optionsets/applicant.js
@@ -247,3 +247,10 @@ export const DCPSTATE = {
     code: 717170052,
   },
 };
+
+const APPLICANT_OPTIONSETS = {
+  DCPTYPE,
+  DCPSTATE,
+};
+
+export default APPLICANT_OPTIONSETS;

--- a/client/app/optionsets/applicant.js
+++ b/client/app/optionsets/applicant.js
@@ -1,4 +1,4 @@
-export const TYPE = {
+export const DCPTYPE = {
   INDIVIDUAL: {
     label: 'Individual',
     code: 717170000,
@@ -9,7 +9,7 @@ export const TYPE = {
   },
 };
 
-export const STATE = {
+export const DCPSTATE = {
   AK: {
     code: 717170000,
     label: 'AK',

--- a/client/app/optionsets/package.js
+++ b/client/app/optionsets/package.js
@@ -133,3 +133,12 @@ export const DCPPACKAGETYPE = {
     label: 'Working Package',
   },
 };
+
+const PACKAGE_OPTIONSETS = {
+  STATUSCODE,
+  DCPVISIBILITY,
+  STATECODE,
+  DCPPACKAGETYPE,
+};
+
+export default PACKAGE_OPTIONSETS;

--- a/client/app/optionsets/package.js
+++ b/client/app/optionsets/package.js
@@ -1,4 +1,4 @@
-export const PACKAGE_STATUS = {
+export const STATUSCODE = {
   PACKAGE_PREPARATION: {
     code: 1,
     label: 'Package Preparation',
@@ -37,7 +37,7 @@ export const PACKAGE_STATUS = {
   },
 };
 
-export const PACKAGE_VISIBILITY = {
+export const DCPVISIBILITY = {
   INTERNAL_DCP_ONLY: {
     code: 717170000,
     label: 'Internal DCP Only',
@@ -60,7 +60,7 @@ export const PACKAGE_VISIBILITY = {
   },
 };
 
-export const PACKAGE_STATE = {
+export const STATECODE = {
   ACTIVE: {
     code: 0,
     label: 'Active',
@@ -71,7 +71,7 @@ export const PACKAGE_STATE = {
   },
 };
 
-export const PACKAGE_TYPE = {
+export const DCPPACKAGETYPE = {
   INFORMATION_MEETING: {
     code: 717170014,
     label: 'Information Meeting',

--- a/client/app/optionsets/project.js
+++ b/client/app/optionsets/project.js
@@ -17,7 +17,7 @@ export const DCPPUBLICSTATUS = {
   },
 };
 
-export const PROJECT_VISIBILITY = {
+export const DCPVISIBILITY = {
   APPLICANT_ONLY: {
     code: 717170002,
     label: 'Applicant Only',
@@ -40,7 +40,7 @@ export const PROJECT_VISIBILITY = {
   },
 };
 
-export const PROJECT_STATUS = {
+export const STATUSCODE = {
   ACTIVE: {
     code: 1,
     label: 'Active',
@@ -70,3 +70,11 @@ export const PROJECT_STATUS = {
     label: 'Withdrawn-Other',
   },
 };
+
+const PROJECT_OPTIONSETS = {
+  DCPPUBLICSTATUS,
+  DCPVISIBILITY,
+  STATUSCODE,
+};
+
+export default PROJECT_OPTIONSETS;

--- a/client/app/templates/project.hbs
+++ b/client/app/templates/project.hbs
@@ -18,7 +18,7 @@
     </p>
 
     <p>
-      <strong>Project Status:</strong> {{optionset 'project' 'status' 'label' @model.statuscode}}
+      <strong>Project Status:</strong> {{optionset 'project' 'statuscode' 'label' @model.statuscode}}
       <span class="text-gray"> | </span>
       <strong>Public Status:</strong>
       <FaIcon @icon={{if @model.publicStatusGeneralPublicProject 'eye' 'eye-slash'}} @prefix="far" class="text-gray"/>

--- a/client/mirage/factories/package.js
+++ b/client/mirage/factories/package.js
@@ -1,5 +1,8 @@
 import { Factory, trait } from 'ember-cli-mirage';
-import { PACKAGE_STATUS, PACKAGE_VISIBILITY } from '../../optionsets/package';
+import {
+  STATUSCODE,
+  DCPVISIBILITY,
+} from '../../optionsets/package';
 
 export default Factory.extend({
   dcpStatusdate: new Date('December 17, 1995 03:24:00'),
@@ -58,7 +61,7 @@ export default Factory.extend({
   toDo: trait({
     statuscode(i) {
       const statuses = [
-        PACKAGE_STATUS.PACKAGE_PREPARATION.code,
+        STATUSCODE.PACKAGE_PREPARATION.code,
       ];
 
       return statuses[i % statuses.length];
@@ -66,8 +69,8 @@ export default Factory.extend({
 
     dcpVisibility(i) {
       const visibility = [
-        PACKAGE_VISIBILITY.APPLICANT_ONLY.code,
-        PACKAGE_VISIBILITY.GENERAL_PUBLIC.code,
+        DCPVISIBILITY.APPLICANT_ONLY.code,
+        DCPVISIBILITY.GENERAL_PUBLIC.code,
       ];
 
       return visibility[i % visibility.length];
@@ -80,13 +83,13 @@ export default Factory.extend({
   done: trait({
     statuscode(i) {
       const statuses = [
-        PACKAGE_STATUS.CERTIFIED.code,
-        PACKAGE_STATUS.FINAL_APPROVAL.code,
-        PACKAGE_STATUS.REVIEWED_NO_REVISIONS_REQUIRED.code,
-        PACKAGE_STATUS.REVIEWED_REVISIONS_REQUIRED.code,
-        PACKAGE_STATUS.WITHDRAWN.code,
-        PACKAGE_STATUS.SUBMITTED.code,
-        PACKAGE_STATUS.UNDER_REVIEW.code,
+        STATUSCODE.CERTIFIED.code,
+        STATUSCODE.FINAL_APPROVAL.code,
+        STATUSCODE.REVIEWED_NO_REVISIONS_REQUIRED.code,
+        STATUSCODE.REVIEWED_REVISIONS_REQUIRED.code,
+        STATUSCODE.WITHDRAWN.code,
+        STATUSCODE.SUBMITTED.code,
+        STATUSCODE.UNDER_REVIEW.code,
       ];
 
       return statuses[i % statuses.length];
@@ -94,11 +97,11 @@ export default Factory.extend({
 
     dcpVisibility(i) {
       const visibility = [
-        PACKAGE_VISIBILITY.INTERNAL_DCP_ONLY.code,
-        PACKAGE_VISIBILITY.CPC_ONLY.code,
-        PACKAGE_VISIBILITY.APPLICANT_ONLY.code,
-        PACKAGE_VISIBILITY.GENERAL_PUBLIC.code,
-        PACKAGE_VISIBILITY.LUP.code,
+        DCPVISIBILITY.INTERNAL_DCP_ONLY.code,
+        DCPVISIBILITY.CPC_ONLY.code,
+        DCPVISIBILITY.APPLICANT_ONLY.code,
+        DCPVISIBILITY.GENERAL_PUBLIC.code,
+        DCPVISIBILITY.LUP.code,
       ];
 
       return visibility[i % visibility.length];

--- a/client/tests/integration/helpers/optionset-test.js
+++ b/client/tests/integration/helpers/optionset-test.js
@@ -29,7 +29,7 @@ module('Integration | Helper | optionset', function(hooks) {
   });
 
   test('it returns a label for a given identifier', async function(assert) {
-    await render(hbs`{{optionset 'applicant' 'state' 'label' 'OR'}}`);
+    await render(hbs`{{optionset 'applicant' 'dcpState' 'label' 'OR'}}`);
 
     assert.equal(this.element.textContent.trim(), 'OR');
   });

--- a/client/tests/integration/helpers/optionset-test.js
+++ b/client/tests/integration/helpers/optionset-test.js
@@ -7,23 +7,23 @@ module('Integration | Helper | optionset', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it returns an optionset given a model and optionsetId', async function(assert) {
-    await render(hbs`{{get (get (optionset 'package' 'state') 'ACTIVE') 'label'}}`);
+    await render(hbs`{{get (get (optionset 'package' 'statecode') 'ACTIVE') 'label'}}`);
 
     assert.equal(this.element.textContent.trim(), 'Active');
 
-    await render(hbs`{{get (get (optionset 'package' 'state') 'INACTIVE') 'code'}}`);
+    await render(hbs`{{get (get (optionset 'package' 'statecode') 'INACTIVE') 'code'}}`);
 
     assert.equal(this.element.textContent.trim(), '1');
   });
 
   test('it returns an options list given a model and optionsetId, when returnType is "list"', async function(assert) {
-    await render(hbs`{{#each (optionset 'package' 'state' 'list') as |option|}}{{option.label}},{{option.code}}{{/each}}`);
+    await render(hbs`{{#each (optionset 'package' 'statecode' 'list') as |option|}}{{option.label}},{{option.code}}{{/each}}`);
 
     assert.equal(this.element.textContent.trim(), 'Active,0Inactive,1');
   });
 
   test('it returns a label for a given code', async function(assert) {
-    await render(hbs`{{optionset 'package' 'visibility' 'label' 717170002}}`);
+    await render(hbs`{{optionset 'package' 'dcpVisibility' 'label' 717170002}}`);
 
     assert.equal(this.element.textContent.trim(), 'Applicant Only');
   });
@@ -35,25 +35,25 @@ module('Integration | Helper | optionset', function(hooks) {
   });
 
   test('it returns a code for a given label', async function(assert) {
-    await render(hbs`{{optionset 'package' 'visibility' 'code' 'Internal DCP Only'}}`);
+    await render(hbs`{{optionset 'package' 'dcpVisibility' 'code' 'Internal DCP Only'}}`);
 
     assert.equal(this.element.textContent.trim(), '717170000');
   });
 
   test('it returns a code for a given identifier', async function(assert) {
-    await render(hbs`{{optionset 'package' 'visibility' 'code' 'INTERNAL_DCP_ONLY'}}`);
+    await render(hbs`{{optionset 'package' 'dcpVisibility' 'code' 'INTERNAL_DCP_ONLY'}}`);
 
     assert.equal(this.element.textContent.trim(), '717170000');
   });
 
   test('it returns a blank label for an invalid code', async function(assert) {
-    await render(hbs`{{optionset 'package' 'visibility' 'label' 'asdf'}}`);
+    await render(hbs`{{optionset 'package' 'dcpVisibility' 'label' 'asdf'}}`);
 
     assert.equal(this.element.textContent.trim(), '');
   });
 
   test('it returns a blank code for an invalid label', async function(assert) {
-    await render(hbs`{{optionset 'package' 'visibility' 'code' 'asdf'}}`);
+    await render(hbs`{{optionset 'package' 'dcpVisibility' 'code' 'asdf'}}`);
 
     assert.equal(this.element.textContent.trim(), '');
   });


### PR DESCRIPTION
This PR makes sure that all optionset keys strictly match their corresponding model field names.

For example, for the Package optionset, use the key `statuscode` instead of `status`, since `statuscode` is an actual field on the Package model. 

 `{{optionset 'package' 'statuscode' ....}}`, instead of  `{{optionset 'package' 'status' ....}}`. 

This is important for develop experience, and easy, predictable API for the optionset helper.

This PR also better scopes the exports from optionset files, since multiple optionsets/models may have the same fields (statuscode, statecode, etc.)