### PR TITLE
🐞 Package Lists Improvements

### DIFF
--- a/client/app/components/project/package-list-item.hbs
+++ b/client/app/components/project/package-list-item.hbs
@@ -1,35 +1,33 @@
-<ol class="no-bullet">
-  <li>
-    {{#if (eq @package.statuscode (optionset 'package' 'status' 'code' 'REVIEWED_REVISIONS_REQUIRED'))}}
-      <FaIcon @icon="exclamation-triangle" class="text-gold" />
-    {{else}}
-      <FaIcon
-        @icon={{if (eq @package.statuscode (optionset 'package' 'status' 'code' 'PACKAGE_PREPARATION')) 'edit' 'check'}}
-        class={{if (eq @package.statuscode (optionset 'package' 'status' 'code' 'PACKAGE_PREPARATION')) '' 'text-green-dark'}}
-      />
-    {{/if}}
-    {{#if (eq @package.dcpPackagetype (optionset 'package' 'type' 'code' "PAS_PACKAGE"))}}
-      <LinkTo
-        @route={{if (eq @package.statuscode (optionset 'package' 'status' 'code' 'PACKAGE_PREPARATION')) 'pas-form.edit' 'pas-form.show'}}
-        @model={{@package.id}}
-        data-test-package-link={{@package.id}}
-      >
-        <strong>Version {{@package.dcpPackageversion}}</strong>
-      </LinkTo>
-    {{/if}}
-    {{#if (eq @package.dcpPackagetype (optionset 'package' 'type' 'code' 'RWCDS'))}}
-      <LinkTo
-        @route={{if (eq @package.statuscode (optionset 'package' 'status' 'code' 'PACKAGE_PREPARATION')) 'rwcds-form.edit' 'rwcds-form.show'}}
-        @model={{@package.id}}
-        data-test-package-link={{@package.id}}
-      >
-        <strong>Version {{@package.dcpPackageversion}}</strong>
-      </LinkTo>
-    {{/if}}
-    <span class="text-gray">| {{if (eq @package.statuscode (optionset 'package' 'status' 'code' 'PACKAGE_PREPARATION')) 'Editable since ' 'Submitted '}}
-      <Ui::DateDisplay @date={{@package.dcpStatusdate}} @outputFormat="MM/D/YYYY" @errorMessage="Date Unknown"/>
-    </span>
-  </li>
-</ol>
+<li>
+  {{#if (eq @package.statuscode (optionset 'package' 'status' 'code' 'REVIEWED_REVISIONS_REQUIRED'))}}
+    <FaIcon @icon="exclamation-triangle" class="text-gold" />
+  {{else}}
+    <FaIcon
+      @icon={{if (eq @package.statuscode (optionset 'package' 'status' 'code' 'PACKAGE_PREPARATION')) 'edit' 'check'}}
+      class={{if (eq @package.statuscode (optionset 'package' 'status' 'code' 'PACKAGE_PREPARATION')) '' 'text-green-dark'}}
+    />
+  {{/if}}
+  {{#if (eq @package.dcpPackagetype (optionset 'package' 'type' 'code' "PAS_PACKAGE"))}}
+    <LinkTo
+      @route={{if (eq @package.statuscode (optionset 'package' 'status' 'code' 'PACKAGE_PREPARATION')) 'pas-form.edit' 'pas-form.show'}}
+      @model={{@package.id}}
+      data-test-package-link={{@package.id}}
+    >
+      <strong>Version {{@package.dcpPackageversion}}</strong>
+    </LinkTo>
+  {{/if}}
+  {{#if (eq @package.dcpPackagetype (optionset 'package' 'type' 'code' 'RWCDS'))}}
+    <LinkTo
+      @route={{if (eq @package.statuscode (optionset 'package' 'status' 'code' 'PACKAGE_PREPARATION')) 'rwcds-form.edit' 'rwcds-form.show'}}
+      @model={{@package.id}}
+      data-test-package-link={{@package.id}}
+    >
+      <strong>Version {{@package.dcpPackageversion}}</strong>
+    </LinkTo>
+  {{/if}}
+  <span class="text-gray">| {{if (eq @package.statuscode (optionset 'package' 'status' 'code' 'PACKAGE_PREPARATION')) 'Editable since ' 'Submitted '}}
+    <Ui::DateDisplay @date={{@package.dcpStatusdate}} @outputFormat="MM/D/YYYY" @errorMessage="Date Unknown"/>
+  </span>
+</li>
 
 {{yield}}

--- a/client/app/templates/project.hbs
+++ b/client/app/templates/project.hbs
@@ -35,19 +35,27 @@
 
     <hr>
 
-    <h2>Reasonable Worst Case Development Scenario</h2>
-    {{#each @model.rwcdsPackages as |rwcdsPackage|}}
-      <Project::PackageListItem
-        @package={{rwcdsPackage}}
-      />
-    {{/each}}
+    {{#if @model.rwcdsPackages.length}}
+      <h2>Reasonable Worst Case Development Scenario</h2>
+      <ol class="no-bullet">
+        {{#each @model.rwcdsPackages as |rwcdsPackage|}}
+          <Project::PackageListItem
+            @package={{rwcdsPackage}}
+          />
+        {{/each}}
+      </ol>
+    {{/if}}
 
-    <h2>Pre-Application Statement</h2>
-    {{#each @model.pasPackages as |pasPackage|}}
-      <Project::PackageListItem
-        @package={{pasPackage}}
-      />
-    {{/each}}
+    {{#if @model.pasPackages.length}}
+      <h2>Pre-Application Statement</h2>
+      <ol class="no-bullet">
+        {{#each @model.pasPackages as |pasPackage|}}
+          <Project::PackageListItem
+            @package={{pasPackage}}
+          />
+        {{/each}}
+      </ol>
+    {{/if}}
 
   </div>{{! end left/main column }}
   <div class="cell large-4 sticky-sidebar">


### PR DESCRIPTION
This PR fixes [AB#12123](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12123) by improving the package lists on the project view: 
- Conditionally show headers 
- Put all items in one list (they were previously each in their own `<ol>`, resulting in a one-item list for each item)