### PR TITLE
12127 Display original RWCDS description fields if no PAS

### DIFF
--- a/server/src/packages/pas-form/pas-form.service.ts
+++ b/server/src/packages/pas-form/pas-form.service.ts
@@ -43,16 +43,24 @@ export class PasFormService {
           dcp_pasform
       `);
 
-      // if pasA is of a higher version than pasB, it should come first
-      const [{ dcp_pasform: latestPasForm }] = pasPackages.sort((pasA, pasB) => {
-        return pasB.dcp_packageversion - pasA.dcp_packageversion;
-      });
+      if (pasPackages.length > 0) {
+        // if pasA is of a higher version than pasB, it should come first
+        const [{ dcp_pasform: latestPasForm }] = pasPackages.sort((pasA, pasB) => {
+          return pasB.dcp_packageversion - pasA.dcp_packageversion;
+        });
 
-      return latestPasForm;
+        return latestPasForm;
+      }
+
+      return null;
     } catch (e) {
-      const errorMessage = `Error finding a PAS Form on given Project. ${e.message}`;
-      console.log(errorMessage);
-      throw new HttpException(errorMessage, HttpStatus.UNAUTHORIZED);
+      const error = {
+        code: `LATEST_PAS_ERROR`,
+        title: `Error finding PAS form`,
+        detail: `Error finding the latest PAS Form on given Project. ${e.message}`,
+      };
+      console.log(error);
+      throw new HttpException(error, HttpStatus.UNAUTHORIZED);
     }
   }
 }

--- a/server/src/packages/rwcds-form/rwcds-form.service.ts
+++ b/server/src/packages/rwcds-form/rwcds-form.service.ts
@@ -132,17 +132,24 @@ export class RwcdsFormService {
       rwcdsForm.dcp_projectsitedescription === null
       || rwcdsForm.dcp_proposedprojectdevelopmentdescription === null
     ) {
-      const {
-        dcp_projectdescriptionproposedarea,
-        dcp_projectdescriptionproposeddevelopment,
-      } = await this.pasFormService.getLatestPasForm(_dcp_projectid_value);
+     const latestPasForm = await this.pasFormService.getLatestPasForm(_dcp_projectid_value);
 
-      if (rwcdsForm.dcp_projectsitedescription === null) {
-        rwcdsForm.dcp_projectsitedescription = dcp_projectdescriptionproposedarea;
-      }
+     if (latestPasForm) {
+        const {
+          dcp_projectdescriptionproposedarea,
+          dcp_projectdescriptionproposeddevelopment,
+        } = latestPasForm;
 
-      if (rwcdsForm.dcp_proposedprojectdevelopmentdescription === null) {
-        rwcdsForm.dcp_proposedprojectdevelopmentdescription = dcp_projectdescriptionproposeddevelopment;
+        // It is possible that only one of dcp_projectsitedescription
+        // or dcp_proposedprojectdevelopmentdescription is not yet
+        // edited on the RWCDs form
+        if (rwcdsForm.dcp_projectsitedescription === null) {
+          rwcdsForm.dcp_projectsitedescription = dcp_projectdescriptionproposedarea;
+        }
+
+        if (rwcdsForm.dcp_proposedprojectdevelopmentdescription === null) {
+          rwcdsForm.dcp_proposedprojectdevelopmentdescription = dcp_projectdescriptionproposeddevelopment;
+        }
       }
     }
 


### PR DESCRIPTION
If there is no PAS form on a project, then while loading the RWCDS form, don't copy PAS "project description"  field values into the RWCDS. Just display the usually blank RWCDS form values for those fields.

Addresses #580 
