### PR TITLE
Add validation for dcpInclusionaryhousingdesignatedareaname, max 50

### DIFF
--- a/client/app/validations/saveable-pas-form.js
+++ b/client/app/validations/saveable-pas-form.js
@@ -224,4 +224,11 @@ export default {
       message: 'Text is too long (max {max} characters)',
     }),
   ],
+
+  dcpInclusionaryhousingdesignatedareaname: [
+    validateLength({
+      max: 50,
+      message: 'Text is too long (max {max} characters)',
+    }),
+  ],
 };


### PR DESCRIPTION
Patch fix for validating dcpInclusionaryhousingdesignatedareaname

Prevents saving if this field exceeds 50

