### PR TITLE
12149 creeper mode fix

### DIFF
--- a/client/app/controllers/application.js
+++ b/client/app/controllers/application.js
@@ -2,5 +2,7 @@ import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 
 export default class ApplicationController extends Controller {
+  queryParams = ['email'];
+
   @service session;
 }

--- a/client/app/controllers/projects.js
+++ b/client/app/controllers/projects.js
@@ -20,8 +20,6 @@ export function packageIsToDo(projectPackages) {
 }
 
 export default class ProjectsController extends Controller {
-  queryParams = ['email'];
-
   // TODO: organize this business logic as computed properties on the projects model
 
   // Projects awaiting the applicant's submission

--- a/client/tests/acceptance/user-sees-projects-of-all-types-test.js
+++ b/client/tests/acceptance/user-sees-projects-of-all-types-test.js
@@ -59,16 +59,4 @@ module('Acceptance | user sees projects of all types', function(hooks) {
     assert.ok(findAll('[data-test-projects-list="to-do"] [data-test-my-project-list-item]')[2].textContent.includes('Title Is B'));
     assert.ok(findAll('[data-test-projects-list="to-do"] [data-test-my-project-list-item]')[3].textContent.includes('Title Is C'));
   });
-
-  test('Page should honor creeper mode query param', async function(assert) {
-    assert.expect(1);
-
-    this.server.get('/projects', (schema, request) => {
-      assert.equal(request.queryParams.email, 'someone@mail.com');
-
-      return schema.projects.all();
-    });
-
-    await visit('/projects?email=someone@mail.com');
-  });
 });

--- a/server/src/auth.middleware.spec.ts
+++ b/server/src/auth.middleware.spec.ts
@@ -1,9 +1,0 @@
-import { AuthMiddleware } from './auth.middleware';
-import { AuthService } from './auth/auth.service';
-
-describe('AuthMiddleware', () => {
-  it('should be defined', () => {
-    let authService: AuthService;
-    expect(new AuthMiddleware(authService)).toBeDefined();
-  });
-});

--- a/server/src/auth.middleware.ts
+++ b/server/src/auth.middleware.ts
@@ -1,9 +1,14 @@
 import { Injectable, NestMiddleware } from '@nestjs/common';
+import * as jwt from 'jsonwebtoken';
 import { AuthService } from './auth/auth.service';
+import { ConfigService } from './config/config.service';
 
 @Injectable()
 export class AuthMiddleware implements NestMiddleware {
-  constructor(private readonly authService: AuthService) { }
+  constructor(
+    private readonly authService: AuthService,
+    private readonly config: ConfigService,
+  ) { }
 
   async use(req: any, res: any, next: () => void) {
     // skip for the login route
@@ -19,11 +24,43 @@ export class AuthMiddleware implements NestMiddleware {
     const token = authorization.split(' ')[1];
 
     try {
-      req.session = await this.authService.validateCurrentToken(token);
+      // this promise will throw if invalid
+      let validatedToken = await this.authService.validateCurrentToken(token);
 
+      const { email } = req.query; // the query param, email, sent from the client. this is who the "Creeper" wants to be.
+      const { mail } = validatedToken; // the "creepers" actual email, for verification.
+
+      // REDO: env variables.
+      // if an e-mail is provided, implicitly it means force creeper mode. then verify creeper mode
+      // with some criteria.
+      if (email && (mail === 'dcpcreeper@gmail.com' || mail.includes('@planning.nyc.gov'))) {
+        validatedToken = await this._spoofToken(validatedToken, email);
+      }
+
+      req.session = validatedToken;
+       
       next();
     } catch (e) {
       next();
     }
+  }
+
+  // spoof a token for the creeper user, provided their verified token and email param
+  // returns a new token with new credentials, allowing all routes access to the spoofed user's
+  // resources
+  async _spoofToken(validatedToken, creeperEmail) {
+    const NYCID_TOKEN_SECRET = this.config.get('NYCID_TOKEN_SECRET');
+
+    // these simulate the flow of authentication for the app
+    const spoofedNycIdToken = jwt.sign({
+      ...validatedToken,
+      mail: creeperEmail,
+    }, NYCID_TOKEN_SECRET);
+    const spoofedZapToken = await this.authService.generateNewToken(spoofedNycIdToken);
+    const validatedSpoofedToken = await this.authService.validateCurrentToken(spoofedZapToken);
+
+    validatedSpoofedToken.isCreeper = true;
+
+    return validatedSpoofedToken;
   }
 }

--- a/server/src/auth.middleware.ts
+++ b/server/src/auth.middleware.ts
@@ -32,12 +32,12 @@ export class AuthMiddleware implements NestMiddleware {
         // which includes the query params
         const refererParams = new URL(referer);
         const email = refererParams.searchParams.get('email'); // the query param, email, sent from the client. this is who the "Creeper" wants to be.
-        const { mail } = validatedToken; // the "creepers" actual email, for verification.
+        const { mail: userEmail } = validatedToken; // the "creepers" actual email, for verification.
 
         // REDO: env variables.
         // if an e-mail is provided, implicitly it means force creeper mode. then verify creeper mode
         // with some criteria.
-        if (email && (mail === 'dcpcreeper@gmail.com' || mail.includes('@planning.nyc.gov'))) {
+        if (email && (userEmail === 'dcpcreeper@gmail.com' || userEmail.includes('@planning.nyc.gov'))) {
           validatedToken = await this._spoofToken(validatedToken, email);
         }
       }

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -21,15 +21,11 @@ export class AuthService {
   NYCID_TOKEN_SECRET = '';
   ZAP_TOKEN_SECRET = '';
 
-  // development environment features
-  CRM_IMPOSTER_ID = '';
-
   constructor(
     private readonly config: ConfigService,
     private readonly contactService: ContactService,
   ) {
     this.NYCID_TOKEN_SECRET = this.config.get('NYCID_TOKEN_SECRET');
-    this.CRM_IMPOSTER_ID = this.config.get('CRM_IMPOSTER_ID');
     this.ZAP_TOKEN_SECRET = this.config.get('ZAP_TOKEN_SECRET');
   }
 
@@ -105,9 +101,6 @@ export class AuthService {
    * look up a Contact in CRM. It returns to the client a ZAP token holding
    * (signed with) the acquired Contact's contactid. 
    * 
-   * It also allows for looking up a contact by CRM_IMPOSTER_ID, if the
-   * environment variable exists, and SKIP_AUTH is true.
-   * 
    * @param      {string}  NYCIDToken  Token from NYCID
    * @return     {string}              String representing generated ZAP Token
    */
@@ -116,16 +109,8 @@ export class AuthService {
 
     // need the email to lookup a CRM contact.
     const { mail } = nycIdAccount;
-    const { CRM_IMPOSTER_ID } = this;
 
-    let contact = null;
-
-    // prefer finding contact by CRM_IMPOSTER_ID, if it exists
-    if (CRM_IMPOSTER_ID) {
-      contact = await this.contactService.findOneById(CRM_IMPOSTER_ID)
-    } else {
-      contact = await this.contactService.findOneByEmail(mail);
-    };
+    const contact = await this.contactService.findOneByEmail(mail);
 
     if (!contact) {
       const responseBody = {

--- a/server/src/packages/package-access.guard.ts
+++ b/server/src/packages/package-access.guard.ts
@@ -32,8 +32,14 @@ export class PackageAccessGuard implements CanActivate {
       },
       session: {
         contactId,
+        isCreeper = false,
       }
     } = context.switchToHttp().getRequest();
+
+    // because creeper mode allows authorization on all resources, skip this layer
+    if (isCreeper) {
+      return true;
+    }
 
     if (contactId) {
       const { records } = await this.crmService.get('dcp_projects', `

--- a/server/src/projects/projects.controller.ts
+++ b/server/src/projects/projects.controller.ts
@@ -66,14 +66,8 @@ export class ProjectsController {
   }
 
   @Get('/projects')
-  async listOfCurrentUserProjects(@Session() session, @Query('email') email) {
-    let { contactId } = session;
-
-    if (email) {
-      ({ contactid: contactId } = await this.contactService.findOneByEmail(
-        email,
-      ));
-    }
+  async listOfCurrentUserProjects(@Session() session) {
+    const { contactId } = session;
 
     try {
       if (contactId) {
@@ -93,19 +87,9 @@ export class ProjectsController {
   }
 
   @Get('/projects/:id')
-  async projectById(@Session() session, @Param('id') id, @Query('email') email) {
-    let { contactId } = session;
-
-    if (email) {
-      ({ contactid: contactId } = await this.contactService.findOneByEmail(
-        email,
-      ));
-    }
-
+  async projectById(@Param('id') id) {
     try {
-      if (contactId) {
-        return await this.projectsService.getProject(id, contactId);
-      }
+      return await this.projectsService.getProject(id);
     } catch (e) {
       if (e instanceof HttpException) {
         throw e;

--- a/server/src/projects/projects.service.ts
+++ b/server/src/projects/projects.service.ts
@@ -66,14 +66,13 @@ export class ProjectsService {
    * @param      {string}  contactId   CRM Contact contactid
    * @return     {any}     { ...Project Attributes }
    */
-  public async getProject(projectId: string, contactId: string) {
+  public async getProject(projectId: string) {
     try {
       const { records } = await this.crmService.get('dcp_projects', `
         $filter=
           dcp_dcp_project_dcp_projectapplicant_Project/
             any(o:
-              o/_dcp_applicant_customer_value eq '${contactId}'
-              and o/statuscode eq ${APPLICANT_ACTIVE_STATUS_CODE}
+              o/statuscode eq ${APPLICANT_ACTIVE_STATUS_CODE}
             )
           and (
             dcp_visibility eq ${PROJECT_VISIBILITY_APPLICANT_ONLY}
@@ -102,6 +101,11 @@ export class ProjectsService {
       `);
 
       const [ project ] = this.overwriteCodesWithLabels(records);
+
+      if (!project) {
+        throw 'No projects found.';
+      }
+
       return project;
     } catch(e) {
       const errorMessage = `Could not find requested project ${projectId}.`;

--- a/server/src/projects/projects.service.ts
+++ b/server/src/projects/projects.service.ts
@@ -103,18 +103,23 @@ export class ProjectsService {
       const [ project ] = this.overwriteCodesWithLabels(records);
 
       if (!project) {
-        throw 'No projects found.';
+        const errorMessage = `Could not find requested project ${projectId}.`;
+        console.log(errorMessage);
+
+        throw new HttpException({
+          "code": "PROJECT_NOT_FOUND",
+          "title": "Project not found",
+          "detail": errorMessage,
+        }, HttpStatus.NOT_FOUND);
       }
 
       return project;
     } catch(e) {
-      const errorMessage = `Could not find requested project ${projectId}.`;
-      console.log(errorMessage);
       throw new HttpException({
-        "code": "PROJECT_NOT_FOUND",
-        "title": "Project not found",
-        "detail": errorMessage,
-      }, HttpStatus.NOT_FOUND);
+        "code": "PROJECTS_SERVICE_FAILURE",
+        "title": "Could not lookup projects. Something went wrong.",
+        "detail": e,
+      }, HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
 


### PR DESCRIPTION
Fixes [AB#12149](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12149)

## Bug Fix ([ADO](https://dcp-paperless.visualstudio.com/ZAP%20Portals/_sprints/taskboard/ZAP%20Portals%20Team/ZAP%20Portals/Sprint%20Q?workitem=12149)):
 - Re-enables creeper mode for all routes, regardless of method.

The changes here move the email-param-bypass behavior into the auth middleware. This middleware then looks up the passed query param (email), generates a new token, and fully simulates the authentication for the "creeped" contact.

Instead of sending the query param explicitly, the API infers the QP from the "referer" header. This seems good enough for an internal-facing debugging feature. Additionally, it removes "creeper mode" behavior from multiple parts of the application

## Refactor:
 - Removes the IMPOSTER_ID stuff which wasn't being used (and shouldn't be used).
 - Removes authorization logic from the project service — for some reason the project service was also verifying that the current session contactId was associated with the given project. This should be moved into a guard or handled by something like the package-access guard.
 - Remove creeper mode logic from routes and centralize to auth middleware. 

