### PR TITLE
12019: replace projectApplicants with contacts in project editor list

### DIFF
--- a/client/app/components/project/project-editor-list-item.hbs
+++ b/client/app/components/project/project-editor-list-item.hbs
@@ -3,7 +3,7 @@
     <FaIcon @icon='user' @fixedWidth={{true}} @transform='down-1' class="text-gray" />
   </div>
   <div class="cell auto">
-    <div class="text-weight-bold">{{@projectApplicant.dcpName}}</div>
-    <div class="text-small"><a href="mailto:{{@projectApplicant.emailaddress}}">{{@projectApplicant.emailaddress}}</a></div>
+    <div class="text-weight-bold">{{@contact.firstname}} {{@contact.lastname}}</div>
+    <div class="text-small"><a href="mailto:{{@contact.emailaddress1}}">{{@contact.emailaddress1}}</a></div>
   </div>
 </li>

--- a/client/app/models/contact.js
+++ b/client/app/models/contact.js
@@ -1,9 +1,18 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class UserModel extends Model {
+  @belongsTo('project')
+  project;
+
   @attr
   contactid;
 
   @attr
   emailaddress1;
+
+  @attr
+  firstname;
+
+  @attr
+  lastname;
 }

--- a/client/app/models/project.js
+++ b/client/app/models/project.js
@@ -30,6 +30,9 @@ export default class ProjectModel extends Model {
   @hasMany('project-applicant', { async: true })
   projectApplicants;
 
+  @hasMany('contact', { async: true })
+  contacts;
+
   get publicStatusGeneralPublicProject() {
     const isGeneralPublic = this.dcpVisibility === optionset(['project', 'dcpVisibility', 'code', 'GENERAL_PUBLIC']);
     return this.dcpPublicstatus && isGeneralPublic;

--- a/client/app/routes/project.js
+++ b/client/app/routes/project.js
@@ -7,7 +7,7 @@ export default class ProjectRoute extends Route.extend(AuthenticatedRouteMixin) 
   async model(params) {
     const project = await this.store.findRecord('project', params.id, {
       reload: true,
-      include: 'packages.pasForm,packages.rwcdsForm,projectApplicants',
+      include: 'packages.pasForm,packages.rwcdsForm,contacts',
       ...params,
     });
 

--- a/client/app/templates/project.hbs
+++ b/client/app/templates/project.hbs
@@ -65,8 +65,8 @@
       <FaIcon @icon='users-cog' @fixedWidth={{true}} />
     </h3>
     <ul class="no-bullet">
-      {{#each @model.projectApplicants as |projectApplicant|}}
-        <Project::ProjectEditorListItem @projectApplicant={{projectApplicant}} />
+      {{#each @model.contacts as |contact|}}
+        <Project::ProjectEditorListItem @contact={{contact}} />
       {{/each}}
     </ul>
 

--- a/client/mirage/config.js
+++ b/client/mirage/config.js
@@ -22,6 +22,7 @@ export default function() {
 
   this.get('/projects');
   this.get('/contacts', (schema) => schema.contacts.first());
+  this.get('/contacts');
 
   this.get('/projects/:id');
 

--- a/client/mirage/models/contact.js
+++ b/client/mirage/models/contact.js
@@ -1,0 +1,5 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  contact: belongsTo('project'),
+});

--- a/client/mirage/models/project.js
+++ b/client/mirage/models/project.js
@@ -3,4 +3,5 @@ import { Model, hasMany } from 'ember-cli-mirage';
 export default Model.extend({
   packages: hasMany('package'),
   projectApplicants: hasMany('project-applicant'),
+  contacts: hasMany('contact'),
 });

--- a/client/tests/integration/components/project/project-editor-list-item-test.js
+++ b/client/tests/integration/components/project/project-editor-list-item-test.js
@@ -7,14 +7,15 @@ module('Integration | Component | project/project-editor-list-item', function(ho
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-    this.projectApplicant = {
-      dcpName: 'Bugs Bunny',
-      emailaddress: 'bugs@bunny.com',
+    this.contact = {
+      firstname: 'Bugs',
+      lastname: 'Bunny',
+      emailaddress1: 'bugs@bunny.com',
     };
 
     // Template block usage:
     await render(hbs`
-      <Project::ProjectEditorListItem @projectApplicant={{this.projectApplicant}}/>
+      <Project::ProjectEditorListItem @contact={{this.contact}}/>
     `);
 
     assert.dom(this.element).includesText('Bugs Bunny');

--- a/server/src/contact/contacts.attrs.ts
+++ b/server/src/contact/contacts.attrs.ts
@@ -1,0 +1,7 @@
+export const CONTACT_ATTRS = [
+  'firstname',
+  'lastname',
+  'emailaddress1',
+  'contactid',
+];
+  

--- a/server/src/projects/project-applicants/project-applicants.attrs.ts
+++ b/server/src/projects/project-applicants/project-applicants.attrs.ts
@@ -3,4 +3,5 @@ export const PROJECTAPPLICANT_ATTRS = [
   'emailaddress',
   'dcp_projectapplicantid',
   'dcp_applicantrole',
+  'dcp_applicant_customer_contact',
 ];

--- a/server/src/projects/projects.controller.ts
+++ b/server/src/projects/projects.controller.ts
@@ -17,6 +17,7 @@ import { AuthenticateGuard } from '../authenticate.guard';
 import { PROJECT_ATTRS } from './projects.attrs';
 import { PACKAGE_ATTRS } from '../packages/packages.attrs';
 import { PROJECTAPPLICANT_ATTRS } from './project-applicants/project-applicants.attrs';
+import { CONTACT_ATTRS } from '../contact/contacts.attrs';
 
 @UseInterceptors(new JsonApiSerializeInterceptor('projects', {
   id: 'dcp_projectid',
@@ -25,6 +26,7 @@ import { PROJECTAPPLICANT_ATTRS } from './project-applicants/project-applicants.
 
     'packages',
     'project-applicants',
+    'contacts',
   ],
   packages: {
     ref: 'dcp_packageid',
@@ -38,6 +40,12 @@ import { PROJECTAPPLICANT_ATTRS } from './project-applicants/project-applicants.
       ...PROJECTAPPLICANT_ATTRS,
     ],
   },
+  'contacts': {
+    ref: 'contactid',
+    attributes: [
+      ...CONTACT_ATTRS,
+    ],
+  },
 
   // remap verbose navigation link names to
   // more concise names
@@ -47,6 +55,7 @@ import { PROJECTAPPLICANT_ATTRS } from './project-applicants/project-applicants.
         ...project,
         packages: project.dcp_dcp_project_dcp_package_project,
         'project-applicants': project.dcp_dcp_project_dcp_projectapplicant_Project,
+        'contacts': project.contacts,
       };
     } catch(e) {
       if (e instanceof HttpException) {

--- a/server/src/projects/projects.service.ts
+++ b/server/src/projects/projects.service.ts
@@ -103,6 +103,13 @@ export class ProjectsService {
           )
       `);
 
+      const projectApplicantsWithContacts = await this.crmService.get('dcp_projectapplicants', `
+        $filter=
+          _dcp_project_value eq ${projectId}
+        &$expand=
+          dcp_applicant_customer_contact
+      `);
+
       const [ project ] = this.overwriteCodesWithLabels(records);
 
       if (!project) {
@@ -116,7 +123,12 @@ export class ProjectsService {
         }, HttpStatus.NOT_FOUND);
       }
 
-      return project;
+      const projectWithContacts = {
+        ...project,
+        contacts: projectApplicantsWithContacts.records.map(applicant => applicant.dcp_applicant_customer_contact),
+      };
+
+      return projectWithContacts;
     } catch(e) {
       throw new HttpException({
         "code": "PROJECTS_SERVICE_FAILURE",


### PR DESCRIPTION
This PR employs a double `$expand` (two network requests) in order to get access to contacts that are associated with `dcp_projectapplicants` on the project entity. 

The purpose of this was to replace `dcp_projectapplicants` with `contacts` as list items on the project editor list on the project page. 