### PR TITLE
Synchronize the NYC.ID GUID with the Contact record

### DIFF
--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -119,7 +119,7 @@ export class AuthService {
     const nycIdAccount = this.verifyNYCIDToken(NYCIDToken);
 
     // need the email to lookup a CRM contact.
-    const { mail } = nycIdAccount;
+    const { mail, nycExtEmailValidationFlag, GUID } = nycIdAccount;
 
     const contact = await this.contactService.findOneByEmail(mail);
 
@@ -131,6 +131,13 @@ export class AuthService {
       }
       console.log(error);
       throw new HttpException(error, HttpStatus.UNAUTHORIZED);
+    }
+
+    // if their e-mail is validated, associate the NYCID guid
+    if (nycExtEmailValidationFlag && !contact.dcp_nycid_guid) {
+      await this.contactService.update(contact.contactid, {
+        dcp_nycid_guid: GUID,
+      });
     }
 
     return this.signNewToken(contact.contactid, nycIdAccount);

--- a/server/src/contact/contact.service.ts
+++ b/server/src/contact/contact.service.ts
@@ -3,6 +3,8 @@ import {
   HttpException,
   HttpStatus,
 } from '@nestjs/common';
+import { pick } from 'underscore';
+import { CONTACT_ATTRS } from './contacts.attrs';
 import { CrmService } from '../crm/crm.service';
 
 const ACTIVE_CODE = 1;
@@ -69,5 +71,11 @@ export class ContactService {
       console.log(error);
       throw new HttpException(error, HttpStatus.INTERNAL_SERVER_ERROR);
     }
+  }
+
+  public async update(id: string, body: object) {
+    const allowedAttrs = pick(body, CONTACT_ATTRS);
+
+    return this.crmService.update('contacts', id, allowedAttrs);
   }
 }

--- a/server/src/contact/contact.service.ts
+++ b/server/src/contact/contact.service.ts
@@ -30,7 +30,8 @@ export class ContactService {
   public async findOneById(contactId: string) {
     try  {
       const { records: [firstRecord] } = await this.crmService.get('contacts', `
-        $filter=contactid eq ${contactId}
+        $select=${CONTACT_ATTRS.join(',')}
+        &$filter=contactid eq ${contactId}
           and statuscode eq ${ACTIVE_CODE}
         &$top=1
       `);
@@ -56,7 +57,8 @@ export class ContactService {
   public async findOneByEmail(email: string) {
     try {
       const { records: [firstRecord] } = await this.crmService.get('contacts', `
-        $filter=startswith(emailaddress1, '${email}')
+        $select=${CONTACT_ATTRS.join(',')}
+        &$filter=startswith(emailaddress1, '${email}')
           and statuscode eq ${ACTIVE_CODE}
         &$top=1
       `);

--- a/server/src/contact/contacts.attrs.ts
+++ b/server/src/contact/contacts.attrs.ts
@@ -3,5 +3,5 @@ export const CONTACT_ATTRS = [
   'lastname',
   'emailaddress1',
   'contactid',
+  'dcp_nycid_guid',
 ];
-  


### PR DESCRIPTION
Addresses [AB#12018](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12018) by beginning process of associating NYC.ID's guid with the contact record.

Future improvements may synchronize the contact record based on how long ago it was changed.

This is intended to synchronize with existing users