### PR TITLE
12168 reload package on save

### DIFF
--- a/client/app/models/package.js
+++ b/client/app/models/package.js
@@ -75,6 +75,8 @@ export default class PackageModel extends Model {
     }
     await super.save();
 
+    await this.reload();
+
     this._synchronizeDocuments();
   }
 


### PR DESCRIPTION
This also fixes [AB#12168](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12168) by ensuring
that file manager is synced to latest
package data from CRM/Sharepoint after
a save.