### PR TITLE
12019: user can create new contact record associated with project on project editors list

### DIFF
--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -84,6 +84,7 @@
           @footer={{component 'packages/pas-form/pas-form-error'
             package=@package
           }}
+          @cancelButtonText="Continue Editing"
           data-test-confirm-submit-button={{true}}
         >
           <h6>Confirm Pre-Applicant Statement Submission</h6>

--- a/client/app/components/packages/rwcds-form/edit.hbs
+++ b/client/app/components/packages/rwcds-form/edit.hbs
@@ -76,6 +76,7 @@
         @footer={{component 'packages/rwcds-form/rwcds-form-error'
           package=@package
         }}
+        @continuteButtonTitle="Continue Editing"
         data-test-confirm-submit-button={{true}}
       >
         <h6>Confirm Reasonable Worst Case Development Scenario Submission</h6>

--- a/client/app/components/project/project-editor-list-item.hbs
+++ b/client/app/components/project/project-editor-list-item.hbs
@@ -3,7 +3,7 @@
     <FaIcon @icon='user' @fixedWidth={{true}} @transform='down-1' class="text-gray" />
   </div>
   <div class="cell auto">
-    <div class="text-weight-bold">{{@contact.firstname}} {{@contact.lastname}}</div>
-    <div class="text-small"><a href="mailto:{{@contact.emailaddress1}}">{{@contact.emailaddress1}}</a></div>
+    <div class="text-weight-bold">{{@name}}</div>
+    <div class="text-small"><a href="mailto:{{@emailAddress}}">{{@emailAddress}}</a></div>
   </div>
 </li>

--- a/client/app/components/ui/confirmation-modal.hbs
+++ b/client/app/components/ui/confirmation-modal.hbs
@@ -26,7 +26,7 @@
             class="button expanded large secondary" {{on "click" @toggle}}
             data-test-continue-button
           >
-            Continue Editing
+            {{@cancelButtonText}}
           </button>
         </div>
         <div class="cell large-6 small-padding-left">

--- a/client/app/controllers/project.js
+++ b/client/app/controllers/project.js
@@ -3,6 +3,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { optionset } from '../helpers/optionset';
+import { STATECODE, STATUSCODE } from '../optionsets/contact';
 
 export default class ProjectController extends Controller {
   @tracked modalOpen;
@@ -19,6 +20,14 @@ export default class ProjectController extends Controller {
   get matchingCurrentApplicant() {
     const currentApplicants = this.project.projectApplicants;
     return currentApplicants.find((applicant) => applicant.emailaddress === this.emailAddress);
+  }
+
+  get contactActiveStatusCode() {
+    return STATUSCODE.ACTIVE.code;
+  }
+
+  get contactActiveStateCode() {
+    return STATECODE.ACTIVE.code;
   }
 
   @action

--- a/client/app/controllers/project.js
+++ b/client/app/controllers/project.js
@@ -1,0 +1,45 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { optionset } from '../helpers/optionset';
+
+export default class ProjectController extends Controller {
+  @tracked modalOpen;
+
+  @tracked emailAddress;
+
+  @tracked firstName;
+
+  @tracked lastName;
+
+  @service
+  store;
+
+  get matchingCurrentApplicant() {
+    const currentApplicants = this.project.projectApplicants;
+    return currentApplicants.find((applicant) => applicant.emailaddress === this.emailAddress);
+  }
+
+  @action
+  addEditor() {
+    this.modalOpen = true;
+  }
+
+  @action
+  async saveEditor() {
+    this.modalOpen = false;
+    if (!this.matchingCurrentApplicant) {
+      const newApplicant = await this.store.createRecord('project-applicant', {
+        dcpName: `${this.firstName} ${this.lastName}`,
+        emailaddress: this.emailAddress,
+        dcpApplicantrole: optionset(['projectApplicant', 'applicantrole', 'code', 'Other']),
+        project: this.project,
+      });
+      await newApplicant.save();
+    }
+    this.firstName = '';
+    this.lastName = '';
+    this.emailAddress = '';
+  }
+}

--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -22,6 +22,9 @@ import {
   DCPHOUSINGUNITTYPE,
 } from '../optionsets/pas-form';
 import PROJECT_OPTIONSETS from '../optionsets/project';
+import {
+  DCPAPPLICANTROLE,
+} from '../optionsets/project-applicant';
 
 const OPTIONSET_LOOKUP = {
   applicant: {
@@ -30,6 +33,9 @@ const OPTIONSET_LOOKUP = {
   },
   bbl: {
     boroughs: BOROUGHS,
+  },
+  projectApplicant: {
+    applicantrole: DCPAPPLICANTROLE,
   },
   package: {
     statecode: PACKAGE_OPTIONSETS.STATECODE,

--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -7,6 +7,7 @@ import {
   YES_NO_DONT_KNOW,
 } from '../optionsets/common';
 import APPLICANT_OPTIONSETS from '../optionsets/applicant';
+import CONTACT_OPTIONSETS from '../optionsets/contact';
 import {
   BOROUGHS,
 } from '../optionsets/bbl';
@@ -36,6 +37,10 @@ const OPTIONSET_LOOKUP = {
   },
   projectApplicant: {
     applicantrole: DCPAPPLICANTROLE,
+  },
+  contact: {
+    statuscode: CONTACT_OPTIONSETS.STATUSCODE,
+    statecode: CONTACT_OPTIONSETS.STATECODE,
   },
   package: {
     statecode: PACKAGE_OPTIONSETS.STATECODE,

--- a/client/app/models/contact.js
+++ b/client/app/models/contact.js
@@ -12,4 +12,10 @@ export default class UserModel extends Model {
 
   @attr
   lastname;
+
+  @attr
+  statuscode;
+
+  @attr
+  statecode;
 }

--- a/client/app/models/contact.js
+++ b/client/app/models/contact.js
@@ -1,11 +1,8 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class UserModel extends Model {
-  @belongsTo('project')
-  project;
-
-  @attr
-  contactid;
+  @belongsTo('project-applicant', { async: false })
+  projectApplicant;
 
   @attr
   emailaddress1;

--- a/client/app/models/project-applicant.js
+++ b/client/app/models/project-applicant.js
@@ -7,6 +7,11 @@ export default class ProjectApplicantModel extends Model {
 
   @attr dcpApplicantrole;
 
-  @belongsTo('project')
+  @attr statuscode;
+
+  @belongsTo('project', { async: false })
   project;
+
+  @belongsTo('contact', { async: false })
+  contact;
 }

--- a/client/app/models/project.js
+++ b/client/app/models/project.js
@@ -27,11 +27,8 @@ export default class ProjectModel extends Model {
   @hasMany('package', { async: false })
   packages;
 
-  @hasMany('project-applicant', { async: true })
+  @hasMany('project-applicant', { async: false })
   projectApplicants;
-
-  @hasMany('contact', { async: true })
-  contacts;
 
   get publicStatusGeneralPublicProject() {
     const isGeneralPublic = this.dcpVisibility === optionset(['project', 'dcpVisibility', 'code', 'GENERAL_PUBLIC']);

--- a/client/app/optionsets/contact.js
+++ b/client/app/optionsets/contact.js
@@ -1,0 +1,26 @@
+export const STATECODE = {
+  ACTIVE: {
+    code: 0,
+    label: 'Active',
+  },
+  INACTIVE: {
+    code: 1,
+    label: 'Inactive',
+  },
+};
+
+export const STATUSCODE = {
+  ACTIVE: {
+    code: 1,
+    label: 'Active',
+  },
+  INACTIVE: {
+    code: 2,
+    label: 'Inactive',
+  },
+};
+
+export const CONTACT_OPTIONSETS = {
+  STATUSCODE,
+  STATECODE,
+};

--- a/client/app/optionsets/project-applicant.js
+++ b/client/app/optionsets/project-applicant.js
@@ -1,0 +1,46 @@
+export const DCPAPPLICANTROLE = {
+  PRIMARY_CONTACT: {
+    code: 717170003,
+    label: 'Primary Contact',
+  },
+  PRIMARY_APPLICANT: {
+    code: 717170002,
+    label: 'Primary Applicant',
+  },
+  AGENCY_STAFF: {
+    code: 717170010,
+    label: 'Agency Staff',
+  },
+  PLANNER: {
+    code: 717170011,
+    label: 'Planner',
+  },
+  AUTHORIZED_APPLICANT_REPRESENTATIVE: {
+    code: 717170009,
+    label: 'Authorized Applicant Representative',
+  },
+  ARCHITECT: {
+    code: 717170004,
+    label: 'Architect',
+  },
+  CO_APPLICANT: {
+    code: 717170000,
+    label: 'Co-Applicant',
+  },
+  ENGINEER: {
+    code: 717170006,
+    label: 'Engineer',
+  },
+  LAND_USE_ATTORNEY: {
+    code: 717170001,
+    label: 'Land Use Attorney',
+  },
+  LANDSCAPE_ARCHITECT: {
+    code: 717170005,
+    label: 'Landscape Architect',
+  },
+  OTHER: {
+    code: 717170007,
+    label: 'Other',
+  },
+};

--- a/client/app/routes/project.js
+++ b/client/app/routes/project.js
@@ -7,10 +7,14 @@ export default class ProjectRoute extends Route.extend(AuthenticatedRouteMixin) 
   async model(params) {
     const project = await this.store.findRecord('project', params.id, {
       reload: true,
-      include: 'packages.pasForm,packages.rwcdsForm,contacts',
+      include: 'packages.pasForm,packages.rwcdsForm,projectApplicants.contacts',
       ...params,
     });
 
     return project;
+  }
+
+  setupController(controller, model) {
+    controller.set('project', model);
   }
 }

--- a/client/app/templates/project.hbs
+++ b/client/app/templates/project.hbs
@@ -65,10 +65,91 @@
       <FaIcon @icon='users-cog' @fixedWidth={{true}} />
     </h3>
     <ul class="no-bullet">
-      {{#each @model.contacts as |contact|}}
-        <Project::ProjectEditorListItem @contact={{contact}} />
+      {{#each this.project.projectApplicants as |applicant|}}
+        <Project::ProjectEditorListItem 
+          @name={{if applicant.contact.lastname (concat applicant.contact.firstname " " applicant.contact.lastname) applicant.dcpName}}
+          @emailAddress={{if applicant.contact.emailaddress1 applicant.contact.emailaddress1 applicant.emailaddress}}
+        />
       {{/each}}
     </ul>
+
+    <Ui::Question
+      class="fieldset relative"
+      ...attributes
+      as |Q|
+    >
+
+      <div class="grid-x grid-margin-x">
+        <div class="cell medium-6">
+          <Q.Label class="middle">
+            First Name
+          </Q.Label>
+          <Input
+            @type="text"
+            autocomplete="off"
+            @value={{this.firstName}}
+          />
+        </div>
+      </div>
+
+      <div class="grid-x grid-margin-x">
+        <div class="cell medium-6">
+          <Q.Label class="middle">
+            Last Name
+          </Q.Label>
+          <Input
+            @type="text"
+            autocomplete="off"
+            @value={{this.lastName}}
+          />
+        </div>
+      </div>
+
+      <div class="grid-x grid-margin-x">
+        <div class="cell medium-6">
+          <Q.Label class="middle">
+            Email Address
+          </Q.Label>
+          <Input
+            @type="text"
+            autocomplete="off"
+            @value={{this.emailAddress}}
+          />
+        </div>
+      </div>
+    </Ui::Question>
+
+    <button
+      class="button expanded secondary no-margin"
+      type="button"
+      {{on "click" (fn this.addEditor) }}
+    >
+      <strong>Add Project Editor</strong>
+    </button>
+
+    <Ui::ConfirmationModal
+      @show={{this.modalOpen}}
+      @toggle={{fn this.saveEditor}}
+      @cancelButtonText="Cancel"
+    >
+      {{#if this.matchingCurrentApplicant}}
+        <h4>A Project Editor with the email address you entered already exists on this project.</h4>
+      {{else}}
+        <h4>Are you sure you want to add...</h4>
+        <Project::ProjectEditorListItem 
+          @name="{{this.firstName}} {{this.lastName}}"
+          @emailAddress={{this.emailAddress}}
+        />
+        <p>If you add this Editor, they will be able to view and edit this Project.</p>
+        <button
+          class="button expanded no-margin"
+          type="button"
+          {{on "click" (fn this.saveEditor) }}
+        >
+          <strong>Add Editor</strong>
+        </button>
+      {{/if}}
+    </Ui::ConfirmationModal>
 
     <Messages::Assistance class="large-margin-top" />
 

--- a/client/app/templates/project.hbs
+++ b/client/app/templates/project.hbs
@@ -66,10 +66,12 @@
     </h3>
     <ul class="no-bullet">
       {{#each this.project.projectApplicants as |applicant|}}
-        <Project::ProjectEditorListItem 
-          @name={{if applicant.contact.lastname (concat applicant.contact.firstname " " applicant.contact.lastname) applicant.dcpName}}
-          @emailAddress={{if applicant.contact.emailaddress1 applicant.contact.emailaddress1 applicant.emailaddress}}
-        />
+        {{#if (and (eq applicant.contact.statuscode this.contactActiveStatusCode) (eq applicant.contact.statecode this.contactActiveStateCode))}}
+          <Project::ProjectEditorListItem 
+            @name={{if applicant.contact.lastname (concat applicant.contact.firstname " " applicant.contact.lastname) applicant.dcpName}}
+            @emailAddress={{if applicant.contact.emailaddress1 applicant.contact.emailaddress1 applicant.emailaddress}}
+          />
+        {{/if}}
       {{/each}}
     </ul>
 

--- a/client/tests/integration/components/project/project-editor-list-item-test.js
+++ b/client/tests/integration/components/project/project-editor-list-item-test.js
@@ -7,15 +7,17 @@ module('Integration | Component | project/project-editor-list-item', function(ho
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-    this.contact = {
-      firstname: 'Bugs',
-      lastname: 'Bunny',
-      emailaddress1: 'bugs@bunny.com',
+    this.projectApplicant = {
+      dcpName: 'Bugs Bunny',
+      emailaddress: 'bugs@bunny.com',
     };
 
     // Template block usage:
     await render(hbs`
-      <Project::ProjectEditorListItem @contact={{this.contact}}/>
+      <Project::ProjectEditorListItem
+        @name={{this.projectApplicant.dcpName}}
+        @emailAddress={{this.projectApplicant.emailaddress}}
+      />
     `);
 
     assert.dom(this.element).includesText('Bugs Bunny');

--- a/client/tests/integration/components/ui/confirmation-modal-test.js
+++ b/client/tests/integration/components/ui/confirmation-modal-test.js
@@ -18,6 +18,7 @@ module('Integration | Component | ui/confirmation-modal', function(hooks) {
       <Ui::ConfirmationModal
         @show={{this.show}}
         @toggle={{this.toggle}}
+        @cancelButtonText="Continue Editing"
       >
         template block text
       </Ui::ConfirmationModal>

--- a/server/src/contact/contact.controller.ts
+++ b/server/src/contact/contact.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Session, Get, UseInterceptors, HttpException, HttpStatus } 
 import { ContactService } from './contact.service';
 import { JsonApiSerializeInterceptor } from '../json-api-serialize.interceptor';
 
+
 @UseInterceptors(new JsonApiSerializeInterceptor('contacts', {
   attributes: ['contactid', 'emailaddress1'],
   id: 'contactid',

--- a/server/src/contact/contacts.attrs.ts
+++ b/server/src/contact/contacts.attrs.ts
@@ -4,4 +4,6 @@ export const CONTACT_ATTRS = [
   'emailaddress1',
   'contactid',
   'dcp_nycid_guid',
+  'statuscode',
+  'statecode',
 ];

--- a/server/src/json-api-deserialize.pipe.ts
+++ b/server/src/json-api-deserialize.pipe.ts
@@ -24,6 +24,12 @@ export class JsonApiDeserializePipe implements PipeTransform {
         projects: {
           valueForRelationship: relationship => relationship.id,
         },
+        'project-applicants': {
+          valueForRelationship: relationship => relationship.id,
+        },
+        contacts: {
+          valueForRelationship: relationship => relationship.id,
+        },
       }).deserialize(value);
     }
 

--- a/server/src/projects/project-applicants/project-applicant.controller.ts
+++ b/server/src/projects/project-applicants/project-applicant.controller.ts
@@ -1,0 +1,84 @@
+import { Controller, Body, Post, UseInterceptors, UseGuards, UsePipes, HttpException, HttpStatus } from '@nestjs/common';
+import { pick } from 'underscore';
+import { CrmService } from '../../crm/crm.service';
+import { JsonApiSerializeInterceptor } from '../../json-api-serialize.interceptor';
+import { AuthenticateGuard } from '../../authenticate.guard';
+import { JsonApiDeserializePipe } from '../../json-api-deserialize.pipe';
+import { PROJECTAPPLICANT_ATTRS } from './project-applicants.attrs';
+import { CONTACT_ATTRS } from '../../contact/contacts.attrs';
+
+const ACTIVE_CODE = 1;
+
+@UseInterceptors(new JsonApiSerializeInterceptor('project-applicants', {
+  id: 'dcp_projectapplicantid',
+  attributes: [
+    ...PROJECTAPPLICANT_ATTRS,
+
+    'contact',
+  ],
+
+  contact: {
+    ref: 'contactid',
+    attributes: CONTACT_ATTRS,
+  },
+}))
+@UseGuards(AuthenticateGuard)
+@UsePipes(JsonApiDeserializePipe)
+@Controller('project-applicants')
+export class ProjectApplicantController {
+  constructor(private readonly crmService: CrmService) {}
+
+  @Post('/')
+  async create(@Body() body) {
+    const allowedAttrs = pick(body, PROJECTAPPLICANT_ATTRS);
+    const {
+      emailaddress: email,
+      project: projectId,
+    } = body;
+
+    if (!email || !projectId) {
+      throw new HttpException({
+        code: 'ADD_PROJECT_APPLICANT_ERROR',
+        title: 'Add Project Applicant failed',
+        detail: 'Cannot add project applicant because missing email or project id',
+      }, HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    // check if contact already exists for this email address
+    const { records } = await this.crmService.get('contacts', `
+      $select=${CONTACT_ATTRS.join(',')}
+      &$filter=startswith(emailaddress1, '${email}')
+        and statuscode eq ${ACTIVE_CODE}
+      &$top=1
+    `);
+
+    let contactId;
+
+    let newContact = {
+      contactid: null,
+    };
+
+    if (records.length > 0) {
+      contactId = records[0].contactid;
+    } else {
+      newContact = await this.crmService.create(`contacts`, {
+        'emailaddress1': email,
+      });
+      contactId = newContact.contactid;
+    }
+
+    const newProjectApplicant = await this.crmService.create('dcp_projectapplicants', {
+      ...allowedAttrs,
+
+      // Dy365 syntax for associating a newly-created record
+      // with an existing record.
+      // see: https://docs.microsoft.com/en-us/powerapps/developer/common-data-service/webapi/create-entity-web-api#associate-entity-records-on-create
+      ...(projectId ? { 'dcp_Project@odata.bind': `/dcp_projects(${projectId})` } : {}),
+      "dcp_applicant_customer_contact@odata.bind": `/contacts(${contactId})`,
+    });
+    return {
+      ...newProjectApplicant,
+       contact: newContact,
+    }
+  }
+}

--- a/server/src/projects/project-applicants/project-applicants.attrs.ts
+++ b/server/src/projects/project-applicants/project-applicants.attrs.ts
@@ -4,4 +4,5 @@ export const PROJECTAPPLICANT_ATTRS = [
   'dcp_projectapplicantid',
   'dcp_applicantrole',
   'dcp_applicant_customer_contact',
+  'statuscode',
 ];

--- a/server/src/projects/projects.controller.ts
+++ b/server/src/projects/projects.controller.ts
@@ -38,13 +38,15 @@ import { CONTACT_ATTRS } from '../contact/contacts.attrs';
     ref: 'dcp_projectapplicantid',
     attributes: [
       ...PROJECTAPPLICANT_ATTRS,
+
+      'contact'
     ],
-  },
-  'contacts': {
-    ref: 'contactid',
-    attributes: [
-      ...CONTACT_ATTRS,
-    ],
+    contact: {
+      ref: 'contactid',
+      attributes: [
+        ...CONTACT_ATTRS,
+      ],
+    },
   },
 
   // remap verbose navigation link names to
@@ -54,8 +56,7 @@ import { CONTACT_ATTRS } from '../contact/contacts.attrs';
       return {
         ...project,
         packages: project.dcp_dcp_project_dcp_package_project,
-        'project-applicants': project.dcp_dcp_project_dcp_projectapplicant_Project,
-        'contacts': project.contacts,
+        projectApplicants: project['project-applicants'],
       };
     } catch(e) {
       if (e instanceof HttpException) {

--- a/server/src/projects/projects.module.ts
+++ b/server/src/projects/projects.module.ts
@@ -5,6 +5,7 @@ import { ProjectsService } from './projects.service';
 import { ConfigModule } from '../config/config.module';
 import { AuthModule } from '../auth/auth.module';
 import { ProjectsController } from './projects.controller';
+import { ProjectApplicantController } from './project-applicants/project-applicant.controller';
 
 @Module({
   imports: [
@@ -15,6 +16,6 @@ import { ProjectsController } from './projects.controller';
   ],
   providers: [ProjectsService],
   exports: [ProjectsService],
-  controllers: [ProjectsController],
+  controllers: [ProjectsController, ProjectApplicantController],
 })
 export class ProjectsModule {}

--- a/server/src/projects/projects.service.ts
+++ b/server/src/projects/projects.service.ts
@@ -97,18 +97,18 @@ export class ProjectsService {
               or statuscode eq ${PACKAGE_STATUSCODE.REVIEWED_NO_REVISIONS_REQUIRED}
               or statuscode eq ${PACKAGE_STATUSCODE.REVIEWED_REVISION_REQUIRED}
             )
-          ),
-          dcp_dcp_project_dcp_projectapplicant_Project(
-            $filter= statuscode eq ${APPLICANT_ACTIVE_STATUS_CODE}
           )
       `);
 
-      const projectApplicantsWithContacts = await this.crmService.get('dcp_projectapplicants', `
+      const projectApplicants = await this.crmService.get('dcp_projectapplicants', `
         $filter=
           _dcp_project_value eq ${projectId}
+          and statuscode eq ${APPLICANT_ACTIVE_STATUS_CODE}
         &$expand=
           dcp_applicant_customer_contact
       `);
+
+      const projectApplicantsWithContacts = projectApplicants.records.map(applicant => ({ ...applicant, contact: applicant.dcp_applicant_customer_contact }));
 
       const [ project ] = this.overwriteCodesWithLabels(records);
 
@@ -125,7 +125,7 @@ export class ProjectsService {
 
       const projectWithContacts = {
         ...project,
-        contacts: projectApplicantsWithContacts.records.map(applicant => applicant.dcp_applicant_customer_contact),
+        'project-applicants': projectApplicantsWithContacts,
       };
 
       return projectWithContacts;


### PR DESCRIPTION
Allow user to create new "project editors" on the project page. 

**Overall Behavior**
- When a user enters first name, last name, and email address into the project editor form, they are prompted with a confirmation modal and allowed to save this new project editor. 
- If a contact that matches that email address is already created, then the only POST that occurs is on the project applicant entity associated with the current project. 
- If a contact does NOT exist that matches the email address entered, then a POST will occur on both the contact entity and the project applicant entity

**Server Behavior**
- While we are only creating a record and saving it for project applicants on the frontend, we also POST a new contact in the server when we POST on the `project-applicant.controller`

**ToDo**
- separate out project editor form into own component
- update design on project editor form and associated confirmation modal
- incorporate activation/deactivation scenarios for project applicant
- implement form validation / update form with UI components

Closes [AB#12019](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12019)