### PR TITLE
12020 deactivate projectapplicant

### DIFF
--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -84,6 +84,7 @@
           @footer={{component 'packages/pas-form/pas-form-error'
             package=@package
           }}
+          @continueButtonTitle="Continue Editing"
           data-test-confirm-submit-button={{true}}
         >
           <h6>Confirm Pre-Applicant Statement Submission</h6>

--- a/client/app/components/packages/rwcds-form/edit.hbs
+++ b/client/app/components/packages/rwcds-form/edit.hbs
@@ -76,6 +76,7 @@
         @footer={{component 'packages/rwcds-form/rwcds-form-error'
           package=@package
         }}
+        @continuteButtonTitle="Continue Editing"
         data-test-confirm-submit-button={{true}}
       >
         <h6>Confirm Reasonable Worst Case Development Scenario Submission</h6>

--- a/client/app/components/project/project-editor-list-item.hbs
+++ b/client/app/components/project/project-editor-list-item.hbs
@@ -3,7 +3,7 @@
     <FaIcon @icon='user' @fixedWidth={{true}} @transform='down-1' class="text-gray" />
   </div>
   <div class="cell auto">
-    <div class="text-weight-bold">{{@contact.firstname}} {{@contact.lastname}}</div>
-    <div class="text-small"><a href="mailto:{{@contact.emailaddress1}}">{{@contact.emailaddress1}}</a></div>
+    <div class="text-weight-bold">{{@name}}</div>
+    <div class="text-small"><a href="mailto:{{@emailAddress}}">{{@emailAddress}}</a></div>
   </div>
 </li>

--- a/client/app/components/project/project-editor-list-item.hbs
+++ b/client/app/components/project/project-editor-list-item.hbs
@@ -6,4 +6,24 @@
     <div class="text-weight-bold">{{@name}}</div>
     <div class="text-small"><a href="mailto:{{@emailAddress}}">{{@emailAddress}}</a></div>
   </div>
+  {{#unless (or
+    (eq
+      @role
+      (optionset 'projectApplicant' 'applicantrole' 'code' 'PRIMARY_CONTACT')
+    )
+    (eq
+      @role
+      (optionset 'projectApplicant' 'applicantrole' 'code' 'PRIMARY_APPLICANT')
+    )
+  )}}
+    <div class="cell shrink medium-padding-left">
+      <button
+        type="button"
+        class="text-red-dark"
+        {{on "click" @onDelete}}
+      >
+        <FaIcon @icon="times" @prefix="fas" @fixedWidth={{true}} />
+      </button>
+    </div>
+  {{/unless}}
 </li>

--- a/client/app/components/project/project-editor-list-item.hbs
+++ b/client/app/components/project/project-editor-list-item.hbs
@@ -6,24 +6,38 @@
     <div class="text-weight-bold">{{@name}}</div>
     <div class="text-small"><a href="mailto:{{@emailAddress}}">{{@emailAddress}}</a></div>
   </div>
-  {{#unless (or
-    (eq
-      @role
-      (optionset 'projectApplicant' 'applicantrole' 'code' 'PRIMARY_CONTACT')
-    )
-    (eq
-      @role
-      (optionset 'projectApplicant' 'applicantrole' 'code' 'PRIMARY_APPLICANT')
-    )
-  )}}
-    <div class="cell shrink medium-padding-left">
-      <button
-        type="button"
-        class="text-red-dark"
-        {{on "click" @onDelete}}
-      >
-        <FaIcon @icon="times" @prefix="fas" @fixedWidth={{true}} />
-      </button>
-    </div>
+  {{#unless @disableDelete}}
+    {{#unless this.isPrimaryApplicantOrContact}}
+      <div class="cell shrink medium-padding-left">
+        <button
+          type="button"
+          class="text-red-dark"
+          {{on "click" this.tryRemoveEditor}}
+        >
+          <FaIcon @icon="times" @prefix="fas" @fixedWidth={{true}} />
+        </button>
+      </div>
+    {{/unless}}
   {{/unless}}
 </li>
+
+<Ui::ConfirmationModal
+  @show={{this.removeEditorModalOpen}}
+  @toggle={{this.cancelRemoveEditor}}
+  @continueButtonTitle="Cancel"
+>
+    <h4>Are you sure you want to remove...</h4>
+    <Project::ProjectEditorListItem
+      @name={{@name}}
+      @emailAddress={{@emailAddress}}
+      @disableDelete={{true}}
+    />
+    <p>If you remove this editor, they will not be able to view and edit this project.</p>
+    <button
+      class="button expanded no-margin"
+      type="button"
+      {{on "click" this.confirmRemoveEditor}}
+    >
+      <strong>Remove Editor</strong>
+    </button>
+</Ui::ConfirmationModal>

--- a/client/app/components/project/project-editor-list-item.js
+++ b/client/app/components/project/project-editor-list-item.js
@@ -1,0 +1,34 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { optionset } from '../../helpers/optionset';
+
+export default class ProjectEditorListComponent extends Component {
+  get disableDelete() {
+    return this.args.disableDelete ?? false;
+  }
+
+  @tracked removeEditorModalOpen = false;
+
+  get isPrimaryApplicantOrContact() {
+    const { role } = this.args;
+    return role === optionset(['projectApplicant', 'applicantrole', 'code', 'PRIMARY_CONTACT'])
+      || role === optionset(['projectApplicant', 'applicantrole', 'code', 'PRIMARY_APPLICANT']);
+  }
+
+  @action
+  tryRemoveEditor() {
+    this.removeEditorModalOpen = true;
+  }
+
+  @action
+  async confirmRemoveEditor() {
+    await this.args.onDelete();
+    this.removeEditorModalOpen = false;
+  }
+
+  @action
+  cancelRemoveEditor() {
+    this.removeEditorModalOpen = false;
+  }
+}

--- a/client/app/components/ui/confirmation-modal.hbs
+++ b/client/app/components/ui/confirmation-modal.hbs
@@ -26,7 +26,7 @@
             class="button expanded large secondary" {{on "click" @toggle}}
             data-test-continue-button
           >
-            Continue Editing
+            {{@continueButtonTitle}}
           </button>
         </div>
         <div class="cell large-6 small-padding-left">

--- a/client/app/controllers/project.js
+++ b/client/app/controllers/project.js
@@ -1,0 +1,45 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { optionset } from '../helpers/optionset';
+
+export default class ProjectController extends Controller {
+  @tracked modalOpen;
+
+  @tracked emailAddress;
+
+  @tracked firstName;
+
+  @tracked lastName;
+
+  @service
+  store;
+
+  get matchingCurrentApplicant() {
+    const currentApplicants = this.project.projectApplicants;
+    return currentApplicants.find((applicant) => applicant.emailaddress === this.emailAddress);
+  }
+
+  @action
+  addEditor() {
+    this.modalOpen = true;
+  }
+
+  @action
+  async saveEditor() {
+    this.modalOpen = false;
+    if (!this.matchingCurrentApplicant) {
+      const newApplicant = await this.store.createRecord('project-applicant', {
+        dcpName: `${this.firstName} ${this.lastName}`,
+        emailaddress: this.emailAddress,
+        dcpApplicantrole: optionset(['projectApplicant', 'applicantrole', 'code', 'Other']),
+        project: this.project,
+      });
+      await newApplicant.save();
+    }
+    this.firstName = '';
+    this.lastName = '';
+    this.emailAddress = '';
+  }
+}

--- a/client/app/controllers/project.js
+++ b/client/app/controllers/project.js
@@ -27,6 +27,11 @@ export default class ProjectController extends Controller {
   }
 
   @action
+  removeEditor(applicant) {
+    applicant.destroyRecord();
+  }
+
+  @action
   async saveEditor() {
     this.modalOpen = false;
     if (!this.matchingCurrentApplicant) {

--- a/client/app/controllers/project.js
+++ b/client/app/controllers/project.js
@@ -5,7 +5,7 @@ import { tracked } from '@glimmer/tracking';
 import { optionset } from '../helpers/optionset';
 
 export default class ProjectController extends Controller {
-  @tracked modalOpen;
+  @tracked addEditorModalOpen;
 
   @tracked emailAddress;
 
@@ -23,7 +23,7 @@ export default class ProjectController extends Controller {
 
   @action
   addEditor() {
-    this.modalOpen = true;
+    this.addEditorModalOpen = true;
   }
 
   @action
@@ -33,7 +33,7 @@ export default class ProjectController extends Controller {
 
   @action
   async saveEditor() {
-    this.modalOpen = false;
+    this.addEditorModalOpen = false;
     if (!this.matchingCurrentApplicant) {
       const newApplicant = await this.store.createRecord('project-applicant', {
         dcpName: `${this.firstName} ${this.lastName}`,

--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -22,6 +22,9 @@ import {
   DCPHOUSINGUNITTYPE,
 } from '../optionsets/pas-form';
 import PROJECT_OPTIONSETS from '../optionsets/project';
+import {
+  DCPAPPLICANTROLE,
+} from '../optionsets/project-applicant';
 
 const OPTIONSET_LOOKUP = {
   applicant: {
@@ -30,6 +33,9 @@ const OPTIONSET_LOOKUP = {
   },
   bbl: {
     boroughs: BOROUGHS,
+  },
+  projectApplicant: {
+    applicantrole: DCPAPPLICANTROLE,
   },
   package: {
     statecode: PACKAGE_OPTIONSETS.STATECODE,

--- a/client/app/models/contact.js
+++ b/client/app/models/contact.js
@@ -1,11 +1,11 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class UserModel extends Model {
-  @belongsTo('project')
+  @belongsTo('project', { async: false })
   project;
 
-  @attr
-  contactid;
+  @belongsTo('project-applicant', { async: false })
+  projectApplicant;
 
   @attr
   emailaddress1;

--- a/client/app/models/project-applicant.js
+++ b/client/app/models/project-applicant.js
@@ -7,6 +7,11 @@ export default class ProjectApplicantModel extends Model {
 
   @attr dcpApplicantrole;
 
-  @belongsTo('project')
+  @attr statuscode;
+
+  @belongsTo('project', { async: false })
   project;
+
+  @belongsTo('contact', { async: false })
+  contact;
 }

--- a/client/app/optionsets/project-applicant.js
+++ b/client/app/optionsets/project-applicant.js
@@ -1,0 +1,46 @@
+export const DCPAPPLICANTROLE = {
+  PRIMARY_CONTACT: {
+    code: 717170003,
+    label: 'Primary Contact',
+  },
+  PRIMARY_APPLICANT: {
+    code: 717170002,
+    label: 'Primary Applicant',
+  },
+  AGENCY_STAFF: {
+    code: 717170010,
+    label: 'Agency Staff',
+  },
+  PLANNER: {
+    code: 717170011,
+    label: 'Planner',
+  },
+  AUTHORIZED_APPLICANT_REPRESENTATIVE: {
+    code: 717170009,
+    label: 'Authorized Applicant Representative',
+  },
+  ARCHITECT: {
+    code: 717170004,
+    label: 'Architect',
+  },
+  CO_APPLICANT: {
+    code: 717170000,
+    label: 'Co-Applicant',
+  },
+  ENGINEER: {
+    code: 717170006,
+    label: 'Engineer',
+  },
+  LAND_USE_ATTORNEY: {
+    code: 717170001,
+    label: 'Land Use Attorney',
+  },
+  LANDSCAPE_ARCHITECT: {
+    code: 717170005,
+    label: 'Landscape Architect',
+  },
+  OTHER: {
+    code: 717170007,
+    label: 'Other',
+  },
+};

--- a/client/app/routes/project.js
+++ b/client/app/routes/project.js
@@ -7,10 +7,14 @@ export default class ProjectRoute extends Route.extend(AuthenticatedRouteMixin) 
   async model(params) {
     const project = await this.store.findRecord('project', params.id, {
       reload: true,
-      include: 'packages.pasForm,packages.rwcdsForm,contacts',
+      include: 'packages.pasForm,packages.rwcdsForm,contacts,projectApplicants',
       ...params,
     });
 
     return project;
+  }
+
+  setupController(controller, model) {
+    controller.set('project', model);
   }
 }

--- a/client/app/templates/project.hbs
+++ b/client/app/templates/project.hbs
@@ -69,6 +69,8 @@
         <Project::ProjectEditorListItem 
           @name={{applicant.dcpName}}
           @emailAddress={{applicant.emailaddress}}
+          @role={{applicant.dcpApplicantrole}}
+          @onDelete={{fn this.removeEditor applicant}}
         />
       {{/each}}
     </ul>

--- a/client/app/templates/project.hbs
+++ b/client/app/templates/project.hbs
@@ -65,10 +65,91 @@
       <FaIcon @icon='users-cog' @fixedWidth={{true}} />
     </h3>
     <ul class="no-bullet">
-      {{#each @model.contacts as |contact|}}
-        <Project::ProjectEditorListItem @contact={{contact}} />
+      {{#each this.project.projectApplicants as |applicant|}}
+        <Project::ProjectEditorListItem 
+          @name={{applicant.dcpName}}
+          @emailAddress={{applicant.emailaddress}}
+        />
       {{/each}}
     </ul>
+
+    <Ui::Question
+      class="fieldset relative"
+      ...attributes
+      as |Q|
+    >
+
+      <div class="grid-x grid-margin-x">
+        <div class="cell medium-6">
+          <Q.Label class="middle">
+            First Name
+          </Q.Label>
+          <Input
+            @type="text"
+            autocomplete="off"
+            @value={{this.firstName}}
+          />
+        </div>
+      </div>
+
+      <div class="grid-x grid-margin-x">
+        <div class="cell medium-6">
+          <Q.Label class="middle">
+            Last Name
+          </Q.Label>
+          <Input
+            @type="text"
+            autocomplete="off"
+            @value={{this.lastName}}
+          />
+        </div>
+      </div>
+
+      <div class="grid-x grid-margin-x">
+        <div class="cell medium-6">
+          <Q.Label class="middle">
+            Email Address
+          </Q.Label>
+          <Input
+            @type="text"
+            autocomplete="off"
+            @value={{this.emailAddress}}
+          />
+        </div>
+      </div>
+    </Ui::Question>
+
+    <button
+      class="button expanded secondary no-margin"
+      type="button"
+      {{on "click" (fn this.addEditor) }}
+    >
+      <strong>Add Project Editor</strong>
+    </button>
+
+    <Ui::ConfirmationModal
+      @show={{this.modalOpen}}
+      @toggle={{fn this.saveEditor}}
+      @continueButtonTitle="Cancel"
+    >
+      {{#if this.matchingCurrentApplicant}}
+        <h4>The applicant you entered already exists on this project.</h4>
+      {{else}}
+        <h4>Are you sure you want to add...</h4>
+        <Project::ProjectEditorListItem 
+          @name="{{this.firstName}} {{this.lastName}}"
+          @emailAddress={{this.emailAddress}}
+        />
+        <p>If you add this editor, they will be able to view and edit this project.</p>
+        <button
+          class="button expanded secondary no-margin"
+          type="button"
+          {{on "click" (fn this.saveEditor) }}
+        >
+          <strong>Add Editor</strong>
+        </button>
+      {{/if}}
+    </Ui::ConfirmationModal>
 
     <Messages::Assistance class="large-margin-top" />
 

--- a/client/app/templates/project.hbs
+++ b/client/app/templates/project.hbs
@@ -130,7 +130,7 @@
     </button>
 
     <Ui::ConfirmationModal
-      @show={{this.modalOpen}}
+      @show={{this.addEditorModalOpen}}
       @toggle={{fn this.saveEditor}}
       @continueButtonTitle="Cancel"
     >

--- a/client/tests/integration/components/project/project-editor-list-item-test.js
+++ b/client/tests/integration/components/project/project-editor-list-item-test.js
@@ -7,15 +7,17 @@ module('Integration | Component | project/project-editor-list-item', function(ho
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-    this.contact = {
-      firstname: 'Bugs',
-      lastname: 'Bunny',
-      emailaddress1: 'bugs@bunny.com',
+    this.projectApplicant = {
+      dcpName: 'Bugs Bunny',
+      emailaddress: 'bugs@bunny.com',
     };
 
     // Template block usage:
     await render(hbs`
-      <Project::ProjectEditorListItem @contact={{this.contact}}/>
+      <Project::ProjectEditorListItem
+        @name={{this.projectApplicant.dcpName}}
+        @emailAddress={{this.projectApplicant.emailaddress}}
+      />
     `);
 
     assert.dom(this.element).includesText('Bugs Bunny');

--- a/client/tests/integration/components/ui/confirmation-modal-test.js
+++ b/client/tests/integration/components/ui/confirmation-modal-test.js
@@ -18,6 +18,7 @@ module('Integration | Component | ui/confirmation-modal', function(hooks) {
       <Ui::ConfirmationModal
         @show={{this.show}}
         @toggle={{this.toggle}}
+        @continueButtonTitle="Continue Editing"
       >
         template block text
       </Ui::ConfirmationModal>

--- a/server/src/contact/contact.controller.ts
+++ b/server/src/contact/contact.controller.ts
@@ -1,6 +1,9 @@
-import { Controller, Session, Get, UseInterceptors, HttpException, HttpStatus } from '@nestjs/common';
+import { Controller, Session, Get, UseInterceptors, HttpException, HttpStatus, Post, Body } from '@nestjs/common';
+import { pick } from 'underscore';
 import { ContactService } from './contact.service';
 import { JsonApiSerializeInterceptor } from '../json-api-serialize.interceptor';
+import { CONTACT_ATTRS } from './contacts.attrs';
+
 
 @UseInterceptors(new JsonApiSerializeInterceptor('contacts', {
   attributes: ['contactid', 'emailaddress1'],

--- a/server/src/json-api-deserialize.pipe.ts
+++ b/server/src/json-api-deserialize.pipe.ts
@@ -24,6 +24,12 @@ export class JsonApiDeserializePipe implements PipeTransform {
         projects: {
           valueForRelationship: relationship => relationship.id,
         },
+        'project-applicants': {
+          valueForRelationship: relationship => relationship.id,
+        },
+        contacts: {
+          valueForRelationship: relationship => relationship.id,
+        },
       }).deserialize(value);
     }
 

--- a/server/src/projects/project-applicants/project-applicant.controller.ts
+++ b/server/src/projects/project-applicants/project-applicant.controller.ts
@@ -1,0 +1,85 @@
+import { Controller, Patch, Body, Param, Post, UseInterceptors, UseGuards, UsePipes, Delete, HttpException, HttpStatus } from '@nestjs/common';
+import { pick } from 'underscore';
+import { CrmService } from '../../crm/crm.service';
+import { JsonApiSerializeInterceptor } from '../../json-api-serialize.interceptor';
+import { AuthenticateGuard } from '../../authenticate.guard';
+import { JsonApiDeserializePipe } from '../../json-api-deserialize.pipe';
+import { PROJECTAPPLICANT_ATTRS } from './project-applicants.attrs';
+import { CONTACT_ATTRS } from '../../contact/contacts.attrs';
+
+const ACTIVE_CODE = 1;
+
+@UseInterceptors(new JsonApiSerializeInterceptor('project-applicants', {
+  id: 'dcp_projectapplicantid',
+  attributes: [
+    ...PROJECTAPPLICANT_ATTRS,
+
+    'contact',
+  ],
+
+  contact: {
+    ref: 'contactid',
+    attributes: CONTACT_ATTRS,
+  },
+}))
+@UseGuards(AuthenticateGuard)
+@UsePipes(JsonApiDeserializePipe)
+@Controller('project-applicants')
+export class ProjectApplicantController {
+  constructor(private readonly crmService: CrmService) {}
+
+  @Post('/')
+  async create(@Body() body) {
+    const allowedAttrs = pick(body, PROJECTAPPLICANT_ATTRS);
+    const email = body.emailaddress;
+    const projectId = body.project;
+    const fullName = body.dcp_name;
+
+    let contactId;
+
+    // check if contact already exists for this email address
+    const { records } = await this.crmService.get('contacts', `
+      $select=${CONTACT_ATTRS.join(',')}
+      &$filter=startswith(emailaddress1, '${email}')
+        and statuscode eq ${ACTIVE_CODE}
+      &$top=1
+    `);
+
+    let newContact = {
+      contactid: null,
+    };
+
+    if (records.length > 0) {
+      contactId = records[0].contactid;
+    } else {
+      const regex = /^([\w\-]+)/g;
+      const firstName = fullName.match(regex)[0];
+      const lastName = fullName.replace(`${firstName} `, '');
+      newContact = await this.crmService.create(`contacts`, {
+        'emailaddress1': email,
+        'firstname': firstName,
+        'lastname': lastName,
+      });
+      contactId = newContact.contactid;
+    }
+
+    if (!body.emailaddress || !body.project) throw new HttpException(
+      'Missing email address or project id',
+      HttpStatus.UNPROCESSABLE_ENTITY,
+    );
+
+    const newProjectApplicant = await this.crmService.create('dcp_projectapplicants', {
+      ...allowedAttrs,
+
+      // Dy365 syntax for associating a newly-created record
+      // with an existing record.
+      // see: https://docs.microsoft.com/en-us/powerapps/developer/common-data-service/webapi/create-entity-web-api#associate-entity-records-on-create
+      ...(body.project ? { 'dcp_Project@odata.bind': `/dcp_projects(${projectId})` } : {}),
+      "dcp_applicant_customer_contact@odata.bind": `/contacts(${contactId})`,
+    });
+    return {
+      ...newProjectApplicant,
+       contact: newContact,
+    }
+  }
+}

--- a/server/src/projects/project-applicants/project-applicants.attrs.ts
+++ b/server/src/projects/project-applicants/project-applicants.attrs.ts
@@ -4,4 +4,5 @@ export const PROJECTAPPLICANT_ATTRS = [
   'dcp_projectapplicantid',
   'dcp_applicantrole',
   'dcp_applicant_customer_contact',
+  'statuscode',
 ];

--- a/server/src/projects/projects.module.ts
+++ b/server/src/projects/projects.module.ts
@@ -5,6 +5,7 @@ import { ProjectsService } from './projects.service';
 import { ConfigModule } from '../config/config.module';
 import { AuthModule } from '../auth/auth.module';
 import { ProjectsController } from './projects.controller';
+import { ProjectApplicantController } from './project-applicants/project-applicant.controller';
 
 @Module({
   imports: [
@@ -15,6 +16,6 @@ import { ProjectsController } from './projects.controller';
   ],
   providers: [ProjectsService],
   exports: [ProjectsService],
-  controllers: [ProjectsController],
+  controllers: [ProjectsController, ProjectApplicantController],
 })
 export class ProjectsModule {}


### PR DESCRIPTION
Ready for handoff to @allthesignals  and @andycochran . 

I've added a basic confirmation modal for delete. However it still needs to match
the style/layout in the wireframes. I.e. The "Remove Editor" button should sit to the right of "Cancel".  Ideally, it also has the same behavior as the form "Save" button --
using tasks to reflect the save state (but this can be done in another PR).
![image](https://user-images.githubusercontent.com/3311663/91755718-6e793580-eb80-11ea-891d-a9cddaaf5577.png)

Todos for other PRs:
- I think we can improve the underlying architecture of the project, project applicant classes.
For example, it's not great that we have "first name" and "last name" properties on the project
controller. 

- We can also rename the "toggle" parameter name on confirmation modal to "onClose" to better reflect its purpose. 

- We can abstract the save-button component to handle all generic async task based actions
