### PR TITLE
12019: add firstname and lastname attributes for ease of POSTing to project applicant

### DIFF
--- a/client/app/controllers/project.js
+++ b/client/app/controllers/project.js
@@ -41,6 +41,8 @@ export default class ProjectController extends Controller {
     if (!this.matchingCurrentApplicant) {
       const newApplicant = await this.store.createRecord('project-applicant', {
         dcpName: `${this.firstName} ${this.lastName}`,
+        firstname: this.firstName,
+        lastname: this.lastName,
         emailaddress: this.emailAddress,
         dcpApplicantrole: optionset(['projectApplicant', 'applicantrole', 'code', 'Other']),
         project: this.project,

--- a/client/app/models/project-applicant.js
+++ b/client/app/models/project-applicant.js
@@ -9,6 +9,14 @@ export default class ProjectApplicantModel extends Model {
 
   @attr statuscode;
 
+  // NOTE: dcp_name field in projectApplicant entity is automatically filled with...
+  // the firstname and lastname fields in the contact entity. In order to get accurate
+  // firstname and lastname values, we have "fake" firstname and lastname attributes in
+  // the frontend project-applicant model so we can send to backend.
+  @attr firstname;
+
+  @attr lastname;
+
   @belongsTo('project', { async: false })
   project;
 


### PR DESCRIPTION
dcp_name field in projectApplicant entity is automatically filled with the firstname and lastname fields in the contact entity. In order to get accurate firstname and lastname values (instead of having to use regex), we have "fake" firstname and lastname attributes in the frontend project-applicant model so we can send to backend.