### PR TITLE
12239: create model for land use form and associated relationships

### DIFF
--- a/client/app/models/applicant.js
+++ b/client/app/models/applicant.js
@@ -4,6 +4,9 @@ export default class ApplicantModel extends Model {
   @belongsTo('pas-form')
   pasForm;
 
+  @belongsTo('landuse-form')
+  landuseForm;
+
   // only exists on dcp_applicantinformation CRM entity
   // either 'Applicant' or 'Authorized Applicant Representative'
   // either 717170000 or 717170001

--- a/client/app/models/bbl.js
+++ b/client/app/models/bbl.js
@@ -7,6 +7,9 @@ export default class BblModel extends Model {
   @belongsTo('project')
   project;
 
+  @belongsTo('landuse-form')
+  landuseForm;
+
   @attr
   dcpBblnumber;
 

--- a/client/app/models/landuse-action.js
+++ b/client/app/models/landuse-action.js
@@ -1,0 +1,12 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class LanduseActionModel extends Model {
+  @belongsTo('landuse-form', { async: false })
+  landuseForm;
+
+  @attr dcpActioncode;
+
+  @attr dcpPreviouslyapprovedactioncode;
+
+  @attr dcpApplicantispublicagencyactions;
+}

--- a/client/app/models/landuse-form.js
+++ b/client/app/models/landuse-form.js
@@ -1,0 +1,81 @@
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
+
+export default class LanduseFormModel extends Model {
+  @belongsTo('package', { async: false })
+  package;
+
+  @hasMany('applicant', { async: false })
+  applicants;
+
+  @hasMany('landuse-action', { async: false })
+  landuseActions;
+
+  @hasMany('bbl', { async: false })
+  bbls;
+
+  @hasMany('related-action', { async: false })
+  relatedActions;
+
+  @attr dcpVersion;
+
+  // project name
+  @attr dcpProject;
+
+  @attr dcpContactname;
+
+  @attr dcpContactphone;
+
+  @attr dcpContactemail;
+
+  @attr dcpSitedataadress;
+
+  @attr dcpCitycouncil;
+
+  @attr dcpSitedatacommunitydistrict;
+
+  @attr dcpSitedatazoningsectionnumbers;
+
+  @attr dcpSitedataexistingzoningdistrict;
+
+  @attr dcpSpecialdistricts;
+
+  @attr dcpWholecity;
+
+  @attr dcpEntiretyboroughs;
+
+  @attr dcpBoroughs;
+
+  @attr dcpEntiretycommunity;
+
+  @attr dcpCommunity;
+
+  @attr dcpNotaxblock;
+
+  @attr dcpSitedatapropertydescription;
+
+  @attr dcpZonesspecialdistricts;
+
+  @attr dcpStateczm;
+
+  @attr dcpHistoricdistrict;
+
+  @attr dcpSitedatarenewalarea;
+
+  @attr dcp500kpluszone;
+
+  @attr dcpDevsize;
+
+  @attr dcpSitedatasiteisinnewyorkcity;
+
+  @attr dcpSitedataidentifylandmark;
+
+  @attr dcpLeadagency;
+
+  @attr dcpCeqrnumber;
+
+  @attr dcpCeqrtype;
+
+  @attr dcpTypecategory;
+
+  @attr dcpDeterminationdate;
+}

--- a/client/app/models/related-action.js
+++ b/client/app/models/related-action.js
@@ -1,0 +1,18 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class RelatedActionModel extends Model {
+  @belongsTo('landuse-form', { async: false })
+  landuseForm;
+
+  @attr dcpIscompletedaction;
+
+  @attr dcpReferenceapplicationno;
+
+  @attr dcpApplicationdescription;
+
+  @attr dcpDispositionorstatus;
+
+  @attr dcpCalendarnumbercalendarnumber;
+
+  @attr dcpApplicationdate;
+}

--- a/client/mirage/models/applicant.js
+++ b/client/mirage/models/applicant.js
@@ -2,4 +2,5 @@ import { Model, belongsTo } from 'ember-cli-mirage';
 
 export default Model.extend({
   pasForm: belongsTo('pas-form'),
+  landuseForm: belongsTo('landuse-form'),
 });

--- a/client/mirage/models/bbl.js
+++ b/client/mirage/models/bbl.js
@@ -3,4 +3,5 @@ import { Model, belongsTo } from 'ember-cli-mirage';
 export default Model.extend({
   pasForm: belongsTo('pas-form'),
   project: belongsTo('project'),
+  landuseForm: belongsTo('landuse-form'),
 });

--- a/client/mirage/models/landuse-form.js
+++ b/client/mirage/models/landuse-form.js
@@ -1,0 +1,9 @@
+import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
+
+export default Model.extend({
+  package: belongsTo('project'),
+  applicants: hasMany('applicant'),
+  landuseActions: hasMany('landuse-action'),
+  bbls: hasMany('bbl'),
+  relatedActions: hasMany('related-action'),
+});

--- a/client/mirage/models/package.js
+++ b/client/mirage/models/package.js
@@ -4,4 +4,5 @@ export default Model.extend({
   project: belongsTo('project'),
   pasForm: belongsTo('pas-form'),
   rwcdsForm: belongsTo('rwcds-form'),
+  landuseForm: belongsTo('landuse-form'),
 });

--- a/client/tests/unit/models/landuse-action-test.js
+++ b/client/tests/unit/models/landuse-action-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | landuse action', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('landuse-action', {});
+    assert.ok(model);
+  });
+});

--- a/client/tests/unit/models/landuse-form-test.js
+++ b/client/tests/unit/models/landuse-form-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | landuse form', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('landuse-form', {});
+    assert.ok(model);
+  });
+});

--- a/client/tests/unit/models/related-action-test.js
+++ b/client/tests/unit/models/related-action-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | related action', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('related-action', {});
+    assert.ok(model);
+  });
+});


### PR DESCRIPTION
Create basic model structure for land use form. 

**New models**: `landuse-form`, `landuse-action`, `related-action`

**`landuse-form` model has these relationships:** 
- **hasMany**: `bbl`, `applicant`, `landuse-action`, `related-action`
- **belongsTo**: `package`

Closes [AB#12239](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12239)