### PR TITLE
12018 new auth  ac

### DIFF
--- a/client/app/components/auth/sign-in.hbs
+++ b/client/app/components/auth/sign-in.hbs
@@ -3,7 +3,7 @@
     Email Address
   </Q.Label>
 
-  <Input @type="text" @value={{this.email}} />
+  <Input @type="text" @value={{this.email}} id={{Q.questionId}} />
 
   <div class="grid-x grid-margin-x">
     <div class="cell medium-10">

--- a/client/app/components/auth/sign-in.hbs
+++ b/client/app/components/auth/sign-in.hbs
@@ -13,7 +13,7 @@
       </p>
     </div>
     <div class="cell medium-2">
-      <button href="#" class="button secondary"
+      <button class="button secondary"
         {{on 'click' (fn this.startLogin this.email)}}
       >
         Next

--- a/client/app/components/auth/sign-in.hbs
+++ b/client/app/components/auth/sign-in.hbs
@@ -7,8 +7,9 @@
 
   <div class="grid-x grid-margin-x">
     <div class="cell medium-10">
-      <p>
-        If you're unsure which email address to use, contact City Planning.
+      <p class="text-small text-dark-gray">
+        If you're unsure which email address to use, contact City Planning at
+        <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or <a href="tel:212-720-3300" class="nowrap">212-720-3300</a>.
       </p>
     </div>
     <div class="cell medium-2">

--- a/client/app/components/auth/sign-in.hbs
+++ b/client/app/components/auth/sign-in.hbs
@@ -6,18 +6,18 @@
   <Input @type="text" @value={{this.email}} id={{Q.questionId}} />
 
   <div class="grid-x grid-margin-x">
-    <div class="cell medium-10">
-      <p class="text-small text-dark-gray">
-        If you're unsure which email address to use, contact City Planning at
-        <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or <a href="tel:212-720-3300" class="nowrap">212-720-3300</a>.
-      </p>
-    </div>
-    <div class="cell medium-2">
-      <button class="button secondary"
+    <div class="cell medium-3 medium-order-2">
+      <button class="button secondary expanded text-weight-bold"
         {{on 'click' (fn this.startLogin this.email)}}
       >
         Next
       </button>
+    </div>
+    <div class="cell auto medium-order-1">
+      <p class="text-small text-dark-gray">
+        If you're unsure which email address to use, contact City Planning at
+        <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or <a href="tel:212-720-3300" class="nowrap">212-720-3300</a>.
+      </p>
     </div>
   </div>
 </Ui::Question>

--- a/client/app/styles/app.scss
+++ b/client/app/styles/app.scss
@@ -26,7 +26,7 @@ $small-font-size: 81.25%; // TODO: update Style Guide so that <small> matches .t
 @include foundation-reveal;
 @include foundation-float-classes;
 @include foundation-visibility-classes;
-
+@include foundation-flex-classes;
 
 // Style Guide components
 @import 'modules/nyc-planning-all-modules'; // or a subset

--- a/client/app/templates/index.hbs
+++ b/client/app/templates/index.hbs
@@ -14,12 +14,10 @@
 <hr>
 
 <div class="grid-x grid-margin-x">
-  <div class="cell large-6">
+  <div class="cell medium-9 large-6">
     <Auth::SignIn
       @searchContacts={{fn this.queryContacts}}
     />
-  </div>
-  <div class="cell large-6">
   </div>
 </div>
 


### PR DESCRIPTION
- add id to email input so label targets it
- update sign in help text w/ contact info
- nix href on button
- adjust grid so next button follows email input on small screens
- limit width of sign in grid on medium screens
