### PR TITLE
🥾🐜 Conditionally show Proposed Actions sub question

### DIFF
--- a/client/app/components/packages/rwcds-form/show.hbs
+++ b/client/app/components/packages/rwcds-form/show.hbs
@@ -112,23 +112,27 @@
 
           <h3 class="large-margin-top small-margin-bottom">{{zrTypeLabel}}</h3>
 
-          <Ui::Answer @beside={{true}} as |A|>
-            <A.Prompt>
-              Modifying Zoning Resolution sections:
-            </A.Prompt>
-            <A.Field>
-              {{affectedZoningResolution.dcpModifiedzrsectionnumber}}
-            </A.Field>
-          </Ui::Answer>
+          {{#if affectedZoningResolution.dcpModifiedzrsectionnumber}}
+            <Ui::Answer @beside={{true}} as |A|>
+              <A.Prompt>
+                Modifying Zoning Resolution sections:
+              </A.Prompt>
+              <A.Field>
+                {{affectedZoningResolution.dcpModifiedzrsectionnumber}}
+              </A.Field>
+            </Ui::Answer>
+          {{/if}}
 
-          <Ui::Answer @beside={{true}} as |A|>
-            <A.Prompt>
-              Pursuant to Zoning Resolution section:
-            </A.Prompt>
-            <A.Field>
-              {{affectedZoningResolution.dcpZrsectiontitle}}
-            </A.Field>
-          </Ui::Answer>
+          {{#if affectedZoningResolution.dcpZrsectiontitle}}
+            <Ui::Answer @beside={{true}} as |A|>
+              <A.Prompt>
+                Pursuant to Zoning Resolution section:
+              </A.Prompt>
+              <A.Field>
+                {{affectedZoningResolution.dcpZrsectiontitle}}
+              </A.Field>
+            </Ui::Answer>
+          {{/if}}
 
           {{#if (eq
             affectedZoningResolution.dcpZoningresolutiontype
@@ -145,6 +149,13 @@
                 ) "Yes" "No"}}
               </A.Field>
             </Ui::Answer>
+          {{else}}
+            {{#if (and
+              (not affectedZoningResolution.dcpModifiedzrsectionnumber)
+              (not affectedZoningResolution.dcpZrsectiontitle)
+            )}}
+              <span class="text-dark-gray text-small">No additional information for this Action</span>
+            {{/if}}
           {{/if}}
         {{/let}}
       {{/each}}


### PR DESCRIPTION
This PR adds template logic to conditionally show the Proposed Actions sub questions if they were answered, and to show a "No additional info" message if the Action has no data. 

Fixes [AB#12161](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12161)