### PR TITLE
Return "is-registered" flag for non-email accounts

### DIFF
--- a/client/tests/acceptance/user-can-login-test.js
+++ b/client/tests/acceptance/user-can-login-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import {
   click,
+  currentRouteName,
   currentURL,
   find,
   focus,
@@ -93,5 +94,21 @@ module('Acceptance | user can login', function(hooks) {
 
     assert.dom('[data-test-error-key="detail"][data-test-error-idx="0"]')
       .hasText('detail: Invalid auth params - "access_token" missing.');
+  });
+
+  test('User is sent to validation instructions if their account is invalid', async function (assert) {
+    this.server.create('contact', {
+      isNycidValidated: false,
+      isNycidEmailRegistered: true,
+    });
+
+    window.location.hash = '#access_token=a-valid-jwt';
+    try {
+      await visit('/login');
+    } catch (e) {
+      // the promise rejects because the route intentionally aborts the transition if the email isn't validated.
+    }
+
+    assert.equal(currentRouteName(), 'auth.validate');
   });
 });

--- a/client/tests/integration/components/auth/sign-in-test.js
+++ b/client/tests/integration/components/auth/sign-in-test.js
@@ -8,7 +8,7 @@ module('Integration | Component | auth/sign-in', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it routes', async function(assert) {
-    assert.expect(3);
+    assert.expect(4);
 
     class FakeRouter extends Service {
       transitionTo() { assert.ok(true); }
@@ -41,6 +41,14 @@ module('Integration | Component | auth/sign-in', function(hooks) {
     this.set('searchContacts', () => ({
       isNycidValidated: null,
       isNycidEmailRegistered: false,
+      isCityEmployee: true,
+    }));
+
+    await click('[data-test-sign-in="next"]');
+
+    this.set('searchContacts', () => ({
+      isNycidValidated: false,
+      isNycidEmailRegistered: true,
       isCityEmployee: true,
     }));
 

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -135,7 +135,7 @@ export class AuthService {
       emailaddress1: mail,
       dcp_nycid_guid: GUID,
     });
-    console.log(contact);
+
     // if their e-mail is validated, associate the NYCID guid
     if (nycExtEmailValidationFlag && !contact.dcp_nycid_guid) {
       await this.contactService.update(contact.contactid, {

--- a/server/src/authenticate.guard.ts
+++ b/server/src/authenticate.guard.ts
@@ -4,7 +4,6 @@ import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 export class AuthenticateGuard implements CanActivate {
   canActivate(context: ExecutionContext): boolean {
     const { session } = context.switchToHttp().getRequest();
-    console.log(session);
 
     return !!session.contactId;
   }

--- a/server/src/contact/nycid/nycid.service.ts
+++ b/server/src/contact/nycid/nycid.service.ts
@@ -57,8 +57,17 @@ export class NycidService {
       errors = e.response.body.ERRORS;
     }
 
+    const hasUnknownEmail = errors.hasOwnProperty('cpui.unknownEmail');
+
+    // this implies that an e-mail exists in the system. however, because NYC.ID
+    // does not enable this feature for users who are authenticated through OAUTH,
+    // it returns an "unauthorized" error: The search is unauthorized. This means that
+    // the user exists in the system, but searching for them isn't allowed.
+    const hasUnauthorizedSearch = errors.hasOwnProperty('cpui.unauthorized');
+    const is_nycid_email_registered = !hasUnknownEmail && hasUnauthorizedSearch;
+
     return {
-      is_nycid_email_registered: !errors.hasOwnProperty('cpui.unknownEmail'),
+      is_nycid_email_registered,
     };
   }
 


### PR DESCRIPTION
Fixes minor bug which allowed non-email types to return a "is-registered" 

Bumps test coverage