### PR TITLE
12250: create component for primary contacts on landuse-form

### DIFF
--- a/client/app/components/packages/landuse-form/edit.hbs
+++ b/client/app/components/packages/landuse-form/edit.hbs
@@ -13,6 +13,10 @@
         </h1>
       </section>
 
+      <Packages::LanduseForm::PrimaryContact
+        @form={{saveableForm}}
+      />
+
       <Packages::LanduseForm::SiteInformation
         @form={{saveableForm}}
       />

--- a/client/app/components/packages/landuse-form/primary-contact.hbs
+++ b/client/app/components/packages/landuse-form/primary-contact.hbs
@@ -1,0 +1,45 @@
+{{#let @form as |form|}}
+  <form.Section @title="Primary Contact">
+    <p>
+      Add all Applicants (either individuals or organizations) and other Team Members (including Land Use Consultants and Environmental Consultants, agency staff, etc.).
+    </p>
+
+    <Ui::Question as |Q|>
+      <Q.Label>
+        Name
+      </Q.Label>
+        
+      <form.Field
+        @attribute="dcpContactname"
+        @maxlength="100"
+        id={{Q.questionId}}
+      />
+      
+    </Ui::Question>
+
+    <Ui::Question as |Q|>
+      <Q.Label>
+        Phone
+      </Q.Label>
+
+      <form.Field
+        @attribute="dcpContactphone"
+        type="number"
+        @maxlength="10"
+        id={{Q.questionId}}
+      />
+    </Ui::Question>
+
+    <Ui::Question as |Q|>
+      <Q.Label>
+        Email
+      </Q.Label>
+
+      <form.Field
+        @attribute="dcpContactemail"
+        @maxlength="100"
+        id={{Q.questionId}}
+      />
+    </Ui::Question>
+  </form.Section>
+{{/let}}

--- a/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
@@ -141,4 +141,31 @@ module('Acceptance | user can click landuse form edit', function(hooks) {
 
     assert.dom('[data-test-related-action-fieldset="0"]').doesNotExist();
   });
+
+  test('User can update the primary contact information on the landuse form', async function(assert) {
+    this.server.create('project', 1, {
+      packages: [this.server.create('package', 'toDo', 'landuseForm')],
+    });
+
+    await visit('/landuse-form/1/edit');
+
+    // filling out necessary information in order to save
+    await click('[data-test-add-applicant-button]');
+    await fillIn('[data-test-input="dcpFirstname"]', 'Tess');
+    await fillIn('[data-test-input="dcpLastname"]', 'Ter');
+    await fillIn('[data-test-input="dcpEmail"]', 'tesster@planning.nyc.gov');
+
+    // filling out the primary contact information
+    await fillIn('[data-test-input="dcpContactname"]', 'contact name');
+    await fillIn('[data-test-input="dcpContactphone"]', '1112223333');
+    await fillIn('[data-test-input="dcpContactemail"]', 'contact@email.com');
+
+    await click('[data-test-save-button]');
+
+    assert.equal(this.server.db.landuseForms.firstObject.dcpContactname, 'contact name');
+    assert.equal(this.server.db.landuseForms.firstObject.dcpContactphone, '1112223333');
+    assert.equal(this.server.db.landuseForms.firstObject.dcpContactemail, 'contact@email.com');
+
+    assert.equal(currentURL(), '/landuse-form/1/edit');
+  });
 });


### PR DESCRIPTION
**Big Picture Summary**
User can enter primary contact information on the landuse-form

**Which major feature does this fit into?**
landuse-form

**Technical Explanation — How does it work?**
- created a new component `packages/landuse-form/primary-contact` that is rendered on the landuse-form. These fields are part of the `dcp_landuse` entity and so are on the `landuse-form` model. 
- test for primary contact form added to landuse-form acceptance test

Closes [AB#12250](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12250)
