### PR TITLE
12251 Set up Land Use Site Information section

### DIFF
--- a/client/app/components/packages/landuse-form/edit.hbs
+++ b/client/app/components/packages/landuse-form/edit.hbs
@@ -13,6 +13,10 @@
         </h1>
       </section>
 
+      <Packages::LanduseForm::SiteInformation
+        @form={{saveableForm}}
+      />
+
       <Packages::ApplicantTeam
         @form={{saveableForm}}
         @addApplicant={{this.addApplicant}}

--- a/client/app/components/packages/landuse-form/site-information.hbs
+++ b/client/app/components/packages/landuse-form/site-information.hbs
@@ -1,0 +1,75 @@
+{{#let @form as |form|}}
+  <form.Section @title="Site Information">
+    <Ui::Question as |Q|>
+      <Q.Label>
+        Primary Street Address
+      </Q.Label>
+
+      <form.Field
+        @attribute="dcpSitedataadress"
+        @maxlength="250"
+        id={{Q.questionId}}
+      />
+    </Ui::Question>
+
+    <Ui::Question as |Q|>
+      <Q.Label>
+        City Council District(s)
+      </Q.Label>
+
+      <form.Field
+        @attribute="dcpCitycouncil"
+        @maxlength="100"
+        id={{Q.questionId}}
+      />
+    </Ui::Question>
+
+        <Ui::Question as |Q|>
+      <Q.Label>
+        Community District(s)
+      </Q.Label>
+
+      <form.Field
+        @attribute="dcpSitedatacommunitydistrict"
+        @maxlength="60"
+        id={{Q.questionId}}
+      />
+    </Ui::Question>
+
+    <Ui::Question as |Q|>
+      <Q.Label>
+        Zoning Sectional Map Number(s)
+      </Q.Label>
+
+      <form.Field
+        @attribute="dcpSitedatazoningsectionnumbers"
+        @maxlength="60"
+        id={{Q.questionId}}
+      />
+    </Ui::Question>
+
+    <Ui::Question as |Q|>
+      <Q.Label>
+        Existing Zoning District(s)
+      </Q.Label>
+
+      <form.Field
+        @attribute="dcpSitedataexistingzoningdistrict"
+        @maxlength="60"
+        id={{Q.questionId}}
+      />
+    </Ui::Question>
+
+    <Ui::Question as |Q|>
+      <Q.Label>
+        Special District(s)
+      </Q.Label>
+
+      <form.Field
+        @attribute="dcpSpecialdistricts"
+        @maxlength="200"
+        id={{Q.questionId}}
+      />
+    </Ui::Question>
+  </form.Section>
+{{/let}}

--- a/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
@@ -25,6 +25,32 @@ module('Acceptance | user can click landuse form edit', function(hooks) {
     });
   });
 
+  test('User can edit Site Information on the landuse form', async function(assert) {
+    this.server.create('project', 1, {
+      packages: [this.server.create('package', 'toDo', 'landuseForm')],
+    });
+
+    await visit('/landuse-form/1/edit');
+
+    await fillIn('[data-test-input="dcpSitedataadress"]', 'Some value');
+    await fillIn('[data-test-input="dcpCitycouncil"]', 'Some value');
+    await fillIn('[data-test-input="dcpSitedatacommunitydistrict"]', 'Some value');
+    await fillIn('[data-test-input="dcpSitedatazoningsectionnumbers"]', 'Some value');
+    await fillIn('[data-test-input="dcpSitedataexistingzoningdistrict"]', 'Some value');
+    await fillIn('[data-test-input="dcpSpecialdistricts"]', 'Some value');
+
+    await click('[data-test-save-button]');
+
+    assert.equal(this.server.db.landuseForms.firstObject.dcpSitedataadress, 'Some value');
+    assert.equal(this.server.db.landuseForms.firstObject.dcpCitycouncil, 'Some value');
+    assert.equal(this.server.db.landuseForms.firstObject.dcpSitedatacommunitydistrict, 'Some value');
+    assert.equal(this.server.db.landuseForms.firstObject.dcpSitedatazoningsectionnumbers, 'Some value');
+    assert.equal(this.server.db.landuseForms.firstObject.dcpSitedataexistingzoningdistrict, 'Some value');
+    assert.equal(this.server.db.landuseForms.firstObject.dcpSpecialdistricts, 'Some value');
+
+    assert.equal(currentURL(), '/landuse-form/1/edit');
+  });
+
   test('User can add an applicant on the landuse form', async function(assert) {
     this.server.create('project', 1, {
       packages: [this.server.create('package', 'toDo', 'landuseForm')],


### PR DESCRIPTION
# Summary/Big picture
This PR sets up the Site Information section on the Land Use form, including basic acceptance tests.
Creates a basic component that placed in the `landuse-form/edit.hbs` component

# Technical notes
The acceptance tests currently assert against the Mirage database. Later, when we set up the Land Use Show page,
we should refactor the tests to assert that the submitted Site Info shows up on the Show page.

Fixes [AB#12251](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12251)