### PR TITLE
12254 Set up Land Use Project Area section

### DIFF
--- a/client/app/components/packages/landuse-form/edit.hbs
+++ b/client/app/components/packages/landuse-form/edit.hbs
@@ -26,6 +26,10 @@
         @form={{saveableForm}}
       />
 
+      <Packages::LanduseForm::ProjectArea
+        @form={{saveableForm}}
+      />
+
       <Packages::ApplicantTeam
         @form={{saveableForm}}
         @addApplicant={{this.addApplicant}}

--- a/client/app/components/packages/landuse-form/edit.js
+++ b/client/app/components/packages/landuse-form/edit.js
@@ -11,7 +11,7 @@ import SaveableRelatedActionFormValidations from '../../../validations/saveable-
 import SubmittableRelatedActionFormValidations from '../../../validations/submittable-related-action-form';
 import { addToHasMany, removeFromHasMany } from '../../../utils/ember-changeset';
 
-export default class PasFormComponent extends Component {
+export default class LandUseFormComponent extends Component {
   validations = {
     SaveableProjectFormValidations,
     SubmittableProjectFormValidations,

--- a/client/app/components/packages/landuse-form/project-area.hbs
+++ b/client/app/components/packages/landuse-form/project-area.hbs
@@ -18,6 +18,7 @@
       >
         <DcpWholeCityRadioGroup
           @options={{optionset 'landuseForm' 'dcpWholecity' 'list'}}
+          @onChange={{fn this.resetDependentFields this.dcpWholecity}}
         as |dcpWholecity|>
           {{#if (eq
             dcpWholecity
@@ -37,6 +38,7 @@
               as |DcpEntiretyboroughsRadioGroup|>
                 <DcpEntiretyboroughsRadioGroup
                   @options={{optionset 'landuseForm' 'dcpEntiretyboroughs' 'list'}}
+                  @onChange={{fn this.resetDependentFields this.dcpEntiretyboroughs}}
                 as |dcpEntiretyboroughs|>
                   {{#if (eq
                     dcpEntiretyboroughs
@@ -74,6 +76,7 @@
                       as |DcpEntiretycommunityRadioGroup|>
                         <DcpEntiretycommunityRadioGroup
                           @options={{optionset 'landuseForm' 'dcpEntiretycommunity' 'list'}}
+                          @onChange={{fn this.resetDependentFields this.dcpEntiretycommunity}}
                         as |dcpEntiretycommunity|>
                           {{#if (eq
                             dcpEntiretycommunity
@@ -112,6 +115,7 @@
                               as |DcpNotaxblockRadioGroup|>
                                 <DcpNotaxblockRadioGroup
                                   @options={{optionset 'landuseForm' 'dcpNotaxblock' 'list'}}
+                                  @onChange={{fn this.resetDependentFields this.dcpNotaxblock}}
                                 as |dcpNotaxblock|>
                                   {{#if (eq
                                     dcpNotaxblock

--- a/client/app/components/packages/landuse-form/project-area.hbs
+++ b/client/app/components/packages/landuse-form/project-area.hbs
@@ -1,0 +1,152 @@
+{{#let @form as |form|}}
+  <form.Section @title="Proposed Project Area">
+    <p>
+      The <b>Project Area</b> is the entirety of all land parcels
+      that are affected by all actions being sought.
+    </p>
+
+    <Ui::Question
+    as |dcpWholecityQ|>
+      <dcpWholecityQ.Label>
+        Do <em>all</em> Actions being sought apply to the whole City?
+      </dcpWholecityQ.Label>
+
+      <form.Field
+        @attribute="dcpWholecity"
+        @type="radio-group"
+        as |DcpWholeCityRadioGroup|
+      >
+        <DcpWholeCityRadioGroup
+          @options={{optionset 'landuseForm' 'dcpWholecity' 'list'}}
+        as |dcpWholecity|>
+          {{#if (eq
+            dcpWholecity
+            (optionset 'landuseForm' 'dcpWholecity' 'code' 'NO')
+          )}}
+
+            <Ui::Question
+            as |dcpEntiretyboroughsQ|>
+              <dcpEntiretyboroughsQ.Label>
+                Do <em>all</em> Actions being sought apply to the entirety of one or
+                more Boroughs?
+              </dcpEntiretyboroughsQ.Label>
+
+              <form.Field
+                @attribute="dcpEntiretyboroughs"
+                @type="radio-group"
+              as |DcpEntiretyboroughsRadioGroup|>
+                <DcpEntiretyboroughsRadioGroup
+                  @options={{optionset 'landuseForm' 'dcpEntiretyboroughs' 'list'}}
+                as |dcpEntiretyboroughs|>
+                  {{#if (eq
+                    dcpEntiretyboroughs
+                    (optionset 'landuseForm' 'dcpEntiretyboroughs' 'code' 'YES')
+                  )}}
+                    <Ui::Question
+                      @required={{true}}
+                    as |dcpBoroughsQ|>
+                      <dcpBoroughsQ.Label>
+                        Which Boroughs?
+                      </dcpBoroughsQ.Label>
+
+                      <form.Field
+                        @attribute="dcpBoroughs"
+                        @maxLength="75"
+                        @showCounter={{true}}
+                        id={{dcpBoroughsQ.questionId}}
+                      />
+                    </Ui::Question>
+                  {{/if}}
+                  {{#if (eq
+                    dcpEntiretyboroughs
+                    (optionset 'landuseForm' 'dcpEntiretyboroughs' 'code' 'NO')
+                  )}}
+                    <Ui::Question
+                    as |dcpEntiretycommunityQ|>
+                      <dcpEntiretycommunityQ.Label>
+                        Do <em>all</em> Actions being sought apply to the entirety of one or
+                        more Community District(s)?
+                      </dcpEntiretycommunityQ.Label>
+
+                      <form.Field
+                        @attribute="dcpEntiretycommunity"
+                        @type="radio-group"
+                      as |DcpEntiretycommunityRadioGroup|>
+                        <DcpEntiretycommunityRadioGroup
+                          @options={{optionset 'landuseForm' 'dcpEntiretycommunity' 'list'}}
+                        as |dcpEntiretycommunity|>
+                          {{#if (eq
+                            dcpEntiretycommunity
+                            (optionset 'landuseForm' 'dcpEntiretycommunity' 'code' 'YES')
+                          )}}
+                            <Ui::Question
+                              @required={{true}}
+                            as |dcpCommunityQ|>
+                                <dcpCommunityQ.Label>
+                                  Which Community District(s)?
+                                </dcpCommunityQ.Label>
+
+                                <form.Field
+                                  @attribute="dcpCommunity"
+                                  @maxLength="175"
+                                  @showCounter={{true}}
+                                  id={{dcpCommunityQ.questionId}}
+                                />
+                            </Ui::Question>
+                          {{/if}}
+                          {{#if (eq
+                            dcpEntiretycommunity
+                            (optionset 'landuseForm' 'dcpEntiretycommunity' 'code' 'NO')
+                          )}}
+                            <Ui::Question
+                            as |dcpNotaxblockQ|>
+                              <dcpNotaxblockQ.Label>
+                                Do <em>all</em> Actions being sought apply to
+                                land or land underwater that is not associated
+                                with a Tax Block or Lot?
+                              </dcpNotaxblockQ.Label>
+
+                              <form.Field
+                                @attribute="dcpNotaxblock"
+                                @type="radio-group"
+                              as |DcpNotaxblockRadioGroup|>
+                                <DcpNotaxblockRadioGroup
+                                  @options={{optionset 'landuseForm' 'dcpNotaxblock' 'list'}}
+                                as |dcpNotaxblock|>
+                                  {{#if (eq
+                                    dcpNotaxblock
+                                    (optionset 'landuseForm' 'dcpNotaxblock' 'code' 'YES')
+                                  )}}
+                                    <Ui::Question
+                                    as |dcpSitedatapropertydescriptionQ|>
+                                        <dcpSitedatapropertydescriptionQ.Label>
+                                          Describe Non-Tax Lots by cross streets
+                                          bounding streets, dimensions, etc.
+                                        </dcpSitedatapropertydescriptionQ.Label>
+
+                                        <form.Field
+                                          @type="text-area"
+                                          @attribute="dcpSitedatapropertydescription"
+                                          @maxlength="500"
+                                          @showCounter={{true}}
+                                          id={{dcpSitedatapropertydescriptionQ.questionId}}
+                                        />
+                                    </Ui::Question>
+                                  {{/if}}
+                                </DcpNotaxblockRadioGroup>
+                              </form.Field>
+                            </Ui::Question>
+                          {{/if}}
+                        </DcpEntiretycommunityRadioGroup>
+                      </form.Field>
+                    </Ui::Question>
+                  {{/if}}
+                </DcpEntiretyboroughsRadioGroup>
+              </form.Field>
+            </Ui::Question>
+          {{/if}}
+        </DcpWholeCityRadioGroup>
+      </form.Field>
+    </Ui::Question>
+  </form.Section>
+{{/let}}

--- a/client/app/components/packages/landuse-form/project-area.js
+++ b/client/app/components/packages/landuse-form/project-area.js
@@ -1,0 +1,41 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class PackagesLanduseFormProjectAreaComponent extends Component {
+  // The following four properties represent lists of fields
+  // dependent on the value of a respective radio group.
+  // For a radio group property (such as dcpEntiretycommunity),
+  // the associated list of fields are those which should be
+  // cleared (reset) when the dcpEntiretycommunity value changes.
+  dcpNotaxblock = [
+    'dcpSitedatapropertydescription',
+  ]
+
+  dcpEntiretycommunity = [
+    ...this.dcpNotaxblock,
+    'dcpNotaxblock',
+    'dcpCommunity',
+  ];
+
+  dcpEntiretyboroughs = [
+    ...this.dcpEntiretycommunity,
+    'dcpEntiretycommunity',
+    'dcpBoroughs',
+  ];
+
+  dcpWholecity = [
+    ...this.dcpEntiretyboroughs,
+    'dcpEntiretyboroughs',
+  ];
+
+  get landuseForm() {
+    return this.args.form.data;
+  }
+
+  @action
+  resetDependentFields(fields) {
+    fields.forEach((field) => {
+      this.landuseForm.set(field, null);
+    });
+  }
+}

--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -58,6 +58,10 @@ const OPTIONSET_LOOKUP = {
   },
   landuseForm: {
     dcpCeqrtype: CEQR_TYPE,
+    dcpWholecity: YES_NO,
+    dcpEntiretyboroughs: YES_NO,
+    dcpEntiretycommunity: YES_NO,
+    dcpNotaxblock: YES_NO,
   },
   rwcdsForm: {
     dcpHasprojectchangedsincesubmissionofthepas: YES_NO,

--- a/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
@@ -51,6 +51,111 @@ module('Acceptance | user can click landuse form edit', function(hooks) {
     assert.equal(currentURL(), '/landuse-form/1/edit');
   });
 
+  test('User can reveal Project Area conditional questions', async function(assert) {
+    this.server.create('project', 1, {
+      packages: [this.server.create('package', 'toDo', 'landuseForm')],
+    });
+
+    await visit('/landuse-form/1/edit');
+
+    assert.dom('[data-test-radio="dcpEntiretyboroughs"]').doesNotExist();
+
+    await click('[data-test-radio="dcpWholecity"][data-test-radio-option="Yes"]');
+
+    assert.dom('[data-test-radio="dcpEntiretyboroughs"]').doesNotExist();
+
+    await click('[data-test-radio="dcpWholecity"][data-test-radio-option="No"]');
+
+    assert.dom('[data-test-radio="dcpEntiretyboroughs"]').exists();
+
+
+    assert.dom('[data-test-input="dcpBoroughs"]').doesNotExist();
+    assert.dom('[data-test-radio="dcpEntiretycommunity"]').doesNotExist();
+
+    await click('[data-test-radio="dcpEntiretyboroughs"][data-test-radio-option="Yes"]');
+
+    assert.dom('[data-test-input="dcpBoroughs"]').exists();
+    assert.dom('[data-test-radio="dcpEntiretycommunity"]').doesNotExist();
+
+    await click('[data-test-radio="dcpEntiretyboroughs"][data-test-radio-option="No"]');
+
+    assert.dom('[data-test-input="dcpBoroughs"]').doesNotExist();
+    assert.dom('[data-test-radio="dcpEntiretycommunity"]').exists();
+
+
+    assert.dom('[data-test-input="dcpCommunity"]').doesNotExist();
+    assert.dom('[data-test-radio="dcpNotaxblock"]').doesNotExist();
+
+    await click('[data-test-radio="dcpEntiretycommunity"][data-test-radio-option="Yes"]');
+
+    assert.dom('[data-test-input="dcpCommunity"]').exists();
+    assert.dom('[data-test-radio="dcpNotaxblock"]').doesNotExist();
+
+    await click('[data-test-radio="dcpEntiretycommunity"][data-test-radio-option="No"]');
+
+    assert.dom('[data-test-input="dcpCommunity"]').doesNotExist();
+    assert.dom('[data-test-radio="dcpNotaxblock"]').exists();
+
+
+    assert.dom('[data-test-input="dcpSitedatapropertydescription"]').doesNotExist();
+
+    await click('[data-test-radio="dcpNotaxblock"][data-test-radio-option="Yes"]');
+
+    assert.dom('[data-test-input="dcpSitedatapropertydescription"]').exists();
+
+    await click('[data-test-radio="dcpNotaxblock"][data-test-radio-option="No"]');
+
+    assert.dom('[data-test-input="dcpSitedatapropertydescription"]').doesNotExist();
+
+    assert.equal(currentURL(), '/landuse-form/1/edit');
+  });
+
+  test('User resets values of all radio descendants when changing radio answer', async function(assert) {
+    this.server.create('project', 1, {
+      packages: [this.server.create('package', 'toDo', 'landuseForm')],
+    });
+
+    await visit('/landuse-form/1/edit');
+
+    await click('[data-test-radio="dcpWholecity"][data-test-radio-option="No"]');
+    await click('[data-test-radio="dcpEntiretyboroughs"][data-test-radio-option="No"]');
+    await click('[data-test-radio="dcpEntiretycommunity"][data-test-radio-option="No"]');
+    await click('[data-test-radio="dcpNotaxblock"][data-test-radio-option="Yes"]');
+    await fillIn('[data-test-input="dcpSitedatapropertydescription"]', 'Planning');
+
+    await assert.dom('[data-test-input="dcpSitedatapropertydescription"]').hasValue('Planning');
+
+    await click('[data-test-radio="dcpNotaxblock"][data-test-radio-option="No"]');
+    await click('[data-test-radio="dcpNotaxblock"][data-test-radio-option="Yes"]');
+
+    await assert.dom('[data-test-input="dcpSitedatapropertydescription"]').hasNoValue();
+
+    await fillIn('[data-test-input="dcpSitedatapropertydescription"]', 'Planning');
+
+    await assert.dom('[data-test-input="dcpSitedatapropertydescription"]').hasValue('Planning');
+
+    await click('[data-test-radio="dcpWholecity"][data-test-radio-option="Yes"]');
+    await click('[data-test-radio="dcpWholecity"][data-test-radio-option="No"]');
+
+    assert.dom('[data-test-radio="dcpEntiretycommunity"]').doesNotExist();
+
+    await click('[data-test-radio="dcpEntiretyboroughs"][data-test-radio-option="No"]');
+
+    assert.dom('[data-test-radio="dcpNotaxblock"]').doesNotExist();
+
+    await click('[data-test-radio="dcpEntiretycommunity"][data-test-radio-option="No"]');
+
+    assert.dom('[data-test-input="dcpSitedatapropertydescription"]').doesNotExist();
+
+    await click('[data-test-radio="dcpNotaxblock"][data-test-radio-option="Yes"]');
+
+    assert.dom('[data-test-input="dcpSitedatapropertydescription"]').exists();
+
+    await assert.dom('[data-test-input="dcpSitedatapropertydescription"]').hasNoValue();
+
+    assert.equal(currentURL(), '/landuse-form/1/edit');
+  });
+
   test('User can add an applicant on the landuse form', async function(assert) {
     this.server.create('project', 1, {
       packages: [this.server.create('package', 'toDo', 'landuseForm')],


### PR DESCRIPTION
### Summary
This PR sets up the Project Area section in the Land Use Form
Fixes [AB#12254](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12254)

### Major feature
Land Use Form -- Project Area

### Technical details:
#### Nested radio group questions
Due to the series of cascading questions and the current pattern/design of our form and fields, this component does get rather gnarly. In order to reference the value of a previous radio group question, currently our form pattern calls for the previous radio value to be yielded within the block-form rendering of a radio-group component. The subsequent radio group must sit within the previous group's block so that it can be conditionally displayed based on the yielded value. Since there is a chain of radio groups, each depending on the value of the previous group, there is heavy nesting in this component. 

Aesthetically, the Project Area component is made a bit more gnarly by the use of the Ui::Question component to help with section and label formatting 

#### Clearing radio-group descendant/nested form fields 
The PR also introduces a pattern for clearing all fields downstream to (nested within) a radio group when the value of the radio group changed.  Each radio group is passed a simple action which clears a user-specified list of fields. JavaScript list spreading is used to sort of extend lists of dependencies. 

A potentially better solution we can explore later is to not clear the nested values from the templates, but conditionally patch form values during save/submit.