### PR TITLE
12257: create environmental review component on landuse-form

### DIFF
--- a/client/app/components/packages/landuse-form/edit.hbs
+++ b/client/app/components/packages/landuse-form/edit.hbs
@@ -37,6 +37,10 @@
         @form={{saveableForm}}
       />
 
+      <Packages::LanduseForm::EnvironmentalReview
+        @form={{saveableForm}}
+      />
+
       <Packages::RelatedAction
         @form={{saveableForm}}
         @addRelatedAction={{this.addRelatedAction}}

--- a/client/app/components/packages/landuse-form/environmental-review.hbs
+++ b/client/app/components/packages/landuse-form/environmental-review.hbs
@@ -1,0 +1,52 @@
+{{#let @form as |form|}}
+  <form.Section @title="Environmental Review">
+
+    <Ui::Question as |Q|>
+      <Q.Label>
+        What is the CEQR number?
+      </Q.Label>
+        
+      <form.Field
+        @attribute="dcpCeqrnumber"
+        @maxlength="100"
+        id={{Q.questionId}}
+      />
+    </Ui::Question>
+
+    <Ui::Question
+      data-test-ceqr-type-radio-group
+      as |Q|
+    >
+      <Q.Label>
+        What is the CEQR type?
+      </Q.Label>
+
+      <form.Field
+        @attribute="dcpCeqrtype"
+        @type="radio-group"
+        id={{Q.questionId}}
+        as |RadioGroup|
+      >
+        <RadioGroup
+          @options={{optionset 'landuseForm' 'dcpCeqrtype' 'list'}}
+        />
+      </form.Field>
+    </Ui::Question>
+
+    <Ui::Question as |Q|>
+      <Q.Label>
+        What is the Type II Category?
+      </Q.Label>
+        
+      <form.Field
+        @attribute="dcpTypecategory"
+        @maxlength="100"
+        id={{Q.questionId}}
+      />     
+    </Ui::Question>
+
+  {{!NOTE: "What is the date of determination?" question here}}
+  {{! this will be implemented when we have a standardized date component}}
+
+  </form.Section>
+{{/let}}

--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -16,6 +16,9 @@ import {
 } from '../optionsets/affected-zoning-resolution';
 import PACKAGE_OPTIONSETS from '../optionsets/package';
 import {
+  CEQR_TYPE,
+} from '../optionsets/landuse-form';
+import {
   DCPCONSTRUCTIONPHASING,
 } from '../optionsets/rwcds-form';
 import {
@@ -52,6 +55,9 @@ const OPTIONSET_LOOKUP = {
     dcpPublicstatus: PROJECT_OPTIONSETS.DCPPUBLICSTATUS,
     dcpVisibility: PROJECT_OPTIONSETS.DCPVISIBILITY,
     statuscode: PROJECT_OPTIONSETS.STATUSCODE,
+  },
+  landuseForm: {
+    dcpCeqrtype: CEQR_TYPE,
   },
   rwcdsForm: {
     dcpHasprojectchangedsincesubmissionofthepas: YES_NO,

--- a/client/app/optionsets/landuse-form.js
+++ b/client/app/optionsets/landuse-form.js
@@ -1,0 +1,14 @@
+export const CEQR_TYPE = {
+  TYPE_I: {
+    code: 717170000,
+    label: 'Type I',
+  },
+  TYPE_II: {
+    code: 717170001,
+    label: 'Type II',
+  },
+  UNLISTED: {
+    code: 717170002,
+    label: 'Unlisted',
+  },
+};

--- a/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
@@ -191,4 +191,31 @@ module('Acceptance | user can click landuse form edit', function(hooks) {
 
     assert.equal(currentURL(), '/landuse-form/1/edit');
   });
+
+  test('User can update the environmental review information on the landuse form', async function(assert) {
+    this.server.create('project', 1, {
+      packages: [this.server.create('package', 'toDo', 'landuseForm')],
+    });
+
+    await visit('/landuse-form/1/edit');
+
+    // filling out necessary information in order to save
+    await click('[data-test-add-applicant-button]');
+    await fillIn('[data-test-input="dcpFirstname"]', 'Tess');
+    await fillIn('[data-test-input="dcpLastname"]', 'Ter');
+    await fillIn('[data-test-input="dcpEmail"]', 'tesster@planning.nyc.gov');
+
+    // filling out the primary contact information
+    await fillIn('[data-test-input="dcpCeqrnumber"]', '12345');
+    await click('[data-test-radio="dcpCeqrtype"][data-test-radio-option="Type II"]');
+    await fillIn('[data-test-input="dcpTypecategory"]', 'type category');
+
+    await click('[data-test-save-button]');
+
+    assert.equal(this.server.db.landuseForms.firstObject.dcpCeqrnumber, '12345');
+    assert.equal(this.server.db.landuseForms.firstObject.dcpCeqrtype, 717170001);
+    assert.equal(this.server.db.landuseForms.firstObject.dcpTypecategory, 'type category');
+
+    assert.equal(currentURL(), '/landuse-form/1/edit');
+  });
 });


### PR DESCRIPTION
**Big Picture Summary**
User can edit Environmental Review information on the landuse form.

**Which major feature does this fit into?**
The landuse form

**Technical Explanation — How does it work?**
This PR adds a new component that allows users to enter information on the landuse form for the Environmental Review section. The fields in this section are on the `dcp_landuse` entity (the `landuse-form` model)

Closes [AB#12257](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12257)

**NOTE**: This implementation differs from the wireframes, two input boxes were left out
- `dcp_leadagency` was originally assumed to be a direct string field on the `dcp_landuse` entity, but it requires an `expand` and includes an entire object of data. In CRM the input for `dcp_leadagency` on the landuse form is a lookup, not a text input as originally noted in the wireframe. This will be handled in a separate PR since it will require updating wireframes and an updated technical approach ([AB#12382](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12382))
- We currently do not have a standardized component for inputting date information. The date field, `dcp_determinationdate` was left out of this PR and will be implemented after a standardized date component has been created. ([AB#12383](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12383))