### PR TITLE
12249: user can edit project name on landuse form

### DIFF
--- a/client/app/components/packages/landuse-form/edit.hbs
+++ b/client/app/components/packages/landuse-form/edit.hbs
@@ -11,6 +11,11 @@
         <h1 class="header-large">
           Land Use
         </h1>
+
+        <Packages::LanduseForm::ProjectInformation
+          @form={{saveableForm}}
+          @validations={{this.validations}}
+        />
       </section>
 
       <Packages::LanduseForm::PrimaryContact

--- a/client/app/components/packages/landuse-form/edit.js
+++ b/client/app/components/packages/landuse-form/edit.js
@@ -1,6 +1,8 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import SaveableProjectFormValidations from '../../../validations/saveable-project-form';
+import SubmittableProjectFormValidations from '../../../validations/submittable-project-form';
 import SaveableLanduseFormValidations from '../../../validations/saveable-landuse-form';
 import SubmittableLanduseFormValidations from '../../../validations/submittable-landuse-form';
 import SaveableApplicantFormValidations from '../../../validations/saveable-applicant-form';
@@ -11,6 +13,8 @@ import { addToHasMany, removeFromHasMany } from '../../../utils/ember-changeset'
 
 export default class PasFormComponent extends Component {
   validations = {
+    SaveableProjectFormValidations,
+    SubmittableProjectFormValidations,
     SaveableLanduseFormValidations,
     SubmittableLanduseFormValidations,
     SaveableApplicantFormValidations,

--- a/client/app/components/packages/landuse-form/project-information.hbs
+++ b/client/app/components/packages/landuse-form/project-information.hbs
@@ -1,0 +1,18 @@
+{{#let @form as |form|}}
+  <form.SaveableForm
+    @model={{@form.data.package.project}}
+    @validators={{array @validations.SaveableProjectFormValidations @validations.SubmittableProjectFormValidations}}
+    as |projectForm|
+  >
+    <Ui::Question @required={{false}} as |Q|>
+      <Q.Label>
+        Project Name
+      </Q.Label>
+
+      <projectForm.Field
+        @attribute="dcpProjectname"
+        id={{Q.questionId}}
+      />
+    </Ui::Question>
+  </form.SaveableForm>
+{{/let}}

--- a/client/app/models/landuse-form.js
+++ b/client/app/models/landuse-form.js
@@ -84,6 +84,7 @@ export default class LanduseFormModel extends Model {
     await this.saveDirtyRelatedActions();
     await this.saveDirtyApplicants();
     await this.saveDirtyBbls();
+    await this.saveDirtyProject();
     await super.save();
   }
 
@@ -109,6 +110,12 @@ export default class LanduseFormModel extends Model {
         .filter((bbl) => bbl.hasDirtyAttributes)
         .map((bbl) => bbl.save()),
     );
+  }
+
+  async saveDirtyProject() {
+    if (this.isProjectDirty) {
+      this.package.project.save();
+    }
   }
 
   async saveDirtyApplicants() {
@@ -142,5 +149,9 @@ export default class LanduseFormModel extends Model {
     const dirtyApplicants = this.applicants.filter((applicant) => applicant.hasDirtyAttributes);
 
     return dirtyApplicants.length > 0;
+  }
+
+  get isProjectDirty() {
+    return this.package.project.hasDirtyAttributes;
   }
 }

--- a/client/app/models/package.js
+++ b/client/app/models/package.js
@@ -121,7 +121,8 @@ export default class PackageModel extends Model {
         || this.landuseForm.isBblsDirty
         || this.landuseForm.isApplicantsDirty
         || this.landuseForm.isLanduseActionsDirty
-        || this.landuseForm.isRelatedActionsDirty;
+        || this.landuseForm.isRelatedActionsDirty
+        || this.landuseForm.isProjectDirty;
     }
 
     return isPackageDirty;

--- a/client/app/validations/saveable-project-form.js
+++ b/client/app/validations/saveable-project-form.js
@@ -1,0 +1,13 @@
+import {
+  validateLength,
+} from 'ember-changeset-validations/validators';
+
+export default {
+  dcpProjectname: [
+    validateLength({
+      min: 0,
+      max: 50,
+      message: 'Text is too long (max {max} characters)',
+    }),
+  ],
+};

--- a/client/app/validations/submittable-project-form.js
+++ b/client/app/validations/submittable-project-form.js
@@ -1,0 +1,5 @@
+import SaveableProjectForm from './saveable-project-form';
+
+export default {
+  ...SaveableProjectForm,
+};

--- a/client/mirage/config.js
+++ b/client/mirage/config.js
@@ -22,6 +22,7 @@ export default function() {
 
   this.get('/projects');
   this.get('/contacts', (schema) => schema.contacts.first());
+  this.patch('/projects/:id');
   this.get('/contacts');
 
   this.get('/projects/:id');

--- a/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
@@ -168,4 +168,27 @@ module('Acceptance | user can click landuse form edit', function(hooks) {
 
     assert.equal(currentURL(), '/landuse-form/1/edit');
   });
+
+  test('User can update the project name on the landuse form', async function(assert) {
+    this.server.create('project', 1, {
+      packages: [this.server.create('package', 'toDo', 'landuseForm')],
+    });
+
+    await visit('/landuse-form/1/edit');
+
+    // filling out necessary information in order to save
+    await click('[data-test-add-applicant-button]');
+    await fillIn('[data-test-input="dcpFirstname"]', 'Tess');
+    await fillIn('[data-test-input="dcpLastname"]', 'Ter');
+    await fillIn('[data-test-input="dcpEmail"]', 'tesster@planning.nyc.gov');
+
+    // filling out the project name information
+    await fillIn('[data-test-input="dcpProjectname"]', 'new project name');
+
+    await click('[data-test-save-button]');
+
+    assert.equal(this.server.db.projects.firstObject.dcpProjectname, 'new project name');
+
+    assert.equal(currentURL(), '/landuse-form/1/edit');
+  });
 });

--- a/server/src/projects/projects.controller.ts
+++ b/server/src/projects/projects.controller.ts
@@ -1,19 +1,25 @@
 import {
   Controller,
   Get,
+  Patch,
+  Body,
   Query,
   HttpException,
   HttpStatus,
   Session,
   UseInterceptors,
   UseGuards,
+  UsePipes,
   Param,
 } from '@nestjs/common';
 import { ProjectsService } from './projects.service';
 import { ConfigService } from '../config/config.service';
 import { ContactService } from '../contact/contact.service';
+import { CrmService } from '../crm/crm.service';
 import { JsonApiSerializeInterceptor } from '../json-api-serialize.interceptor';
 import { AuthenticateGuard } from '../authenticate.guard';
+import { JsonApiDeserializePipe } from '../json-api-deserialize.pipe';
+import { pick } from 'underscore';
 import { PROJECT_ATTRS } from './projects.attrs';
 import { PACKAGE_ATTRS } from '../packages/packages.attrs';
 import { PROJECTAPPLICANT_ATTRS } from './project-applicants/project-applicants.attrs';
@@ -72,7 +78,8 @@ import { CONTACT_ATTRS } from '../contact/contacts.attrs';
   },
 }))
 @UseGuards(AuthenticateGuard)
-@Controller()
+@UsePipes(JsonApiDeserializePipe)
+@Controller('projects')
 export class ProjectsController {
   CRM_IMPOSTER_ID = '';
 
@@ -80,11 +87,12 @@ export class ProjectsController {
     private readonly projectsService: ProjectsService,
     private readonly contactService: ContactService,
     private readonly config: ConfigService,
+    private readonly crmService: CrmService,
   ) {
     this.CRM_IMPOSTER_ID = this.config.get('CRM_IMPOSTER_ID');
   }
 
-  @Get('/projects')
+  @Get('/')
   async listOfCurrentUserProjects(@Session() session) {
     const { contactId } = session;
 
@@ -105,7 +113,7 @@ export class ProjectsController {
     }
   }
 
-  @Get('/projects/:id')
+  @Get('/:id')
   async projectById(@Param('id') id) {
     try {
       return await this.projectsService.getProject(id);
@@ -120,5 +128,17 @@ export class ProjectsController {
         }, HttpStatus.INTERNAL_SERVER_ERROR);
       }
     }
+  }
+
+  @Patch('/:id')
+  async update(@Body() body, @Param('id') id) {
+    const allowedAttrs = pick(body, PROJECT_ATTRS);
+
+    await this.crmService.update('dcp_projects', id, allowedAttrs);
+
+    return {
+      dcp_projectid: id,
+      ...body
+    };
   }
 }


### PR DESCRIPTION
**Big Picture Summary**
User can edit the associated project name on the landuse form.

**Which major feature does this fit into?**
Land Use Form

**Technical Explanation — How does it work?**
A new component was created `packages/landuse-form/project-information` which is rendered on the landuse form. This component handles renaming a project and PATCHes to the `dcp_project` entity (the `project` model). 

Closes [AB#12249](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12249)
