### PR TITLE
12260: add attachments component to landuse form

### DIFF
--- a/client/app/components/packages/landuse-form/attached-documents.hbs
+++ b/client/app/components/packages/landuse-form/attached-documents.hbs
@@ -1,0 +1,13 @@
+{{#let @form as |form|}}
+  <form.Section @title="Attached Documents">
+    <p>
+      Please attach the following required documents. (Additional materials that help to explain the proposed project may also be submitted.)
+    </p>
+
+    <Packages::Attachments
+      @package={{@model.package}}
+      @fileManager={{@model.package.fileManager}}
+      data-test-section="attachments"
+    />
+  </form.Section>
+{{/let}}

--- a/client/app/components/packages/landuse-form/edit.hbs
+++ b/client/app/components/packages/landuse-form/edit.hbs
@@ -38,6 +38,11 @@
         @removeRelatedAction={{this.removeRelatedAction}}
         @validations={{this.validations}}
       />
+
+      <Packages::LanduseForm::AttachedDocuments
+        @form={{saveableForm}}
+        @model={{@package.landuseForm}}
+      />
     </div>
     <div class="cell large-4 sticky-sidebar">
       <saveableForm.PageNav>


### PR DESCRIPTION
**Big Picture Summary**
User can upload/delete files on the landuse form

**Which major feature does this fit into?**
The Land Use Form

**Technical Explanation — How does it work?**
Recycle the `packages/attachments` and `packages/landuse-form/attached-documents` components, render on the landuse form. 

Closes [AB#12260](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12260)
