### PR TITLE
Display email in login attempt

### DIFF
--- a/client/app/authenticators/zap-api-authenticator.js
+++ b/client/app/authenticators/zap-api-authenticator.js
@@ -1,6 +1,7 @@
 import fetch from 'fetch';
 import OAuth2ImplicitGrantAuthenticator from 'ember-simple-auth/authenticators/oauth2-implicit-grant';
 import { InvalidError } from '@ember-data/adapter/error';
+import jwtDecode from 'jwt-decode';
 import ENV from '../config/environment';
 
 export default class ZAPAuthenticator extends OAuth2ImplicitGrantAuthenticator {
@@ -15,10 +16,21 @@ export default class ZAPAuthenticator extends OAuth2ImplicitGrantAuthenticator {
       throw new InvalidError([{ detail: e.toString() }]);
     }
 
+    let attemptedLoginEmail = '';
+
+    // attempt to decode the token to include email address for debugging
+    try {
+      const { mail } = jwtDecode(accessToken);
+
+      attemptedLoginEmail = mail;
+    } catch (e) {
+      console.log('Failed to decode the JWT', e);
+    }
+
     // Pass the NYCIDToken to backend /login endpoint.
     // Server should provide an access_token used for signing
     // requests using the Authorization header
-    const response = await fetch(`${ENV.host}/login?accessToken=${accessToken}`);
+    const response = await fetch(`${ENV.host}/login?accessToken=${accessToken}&DEBUG_useremail=${attemptedLoginEmail}`);
     const body = await response.json();
 
     if (!response.ok) throw body;

--- a/client/package.json
+++ b/client/package.json
@@ -90,5 +90,8 @@
   },
   "ember": {
     "edition": "octane"
+  },
+  "dependencies": {
+    "jwt-decode": "^3.0.0-beta.2"
   }
 }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -9855,6 +9855,11 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+jwt-decode@^3.0.0-beta.2:
+  version "3.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.0.0-beta.2.tgz#5d928dd0d582caab47b252a5f12ad1721f2f6eef"
+  integrity sha512-AnENY5syz7PzgpTzos9sxkqKTmHU0JeJOXZFHUc41bDyybC2yzZ+1r43ZLhk7+JCwF0yjISPuVK9ZWfA1nCUPA==
+
 keyv@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.0.0.tgz#44923ba39e68b12a7cec7df6c3268c031f2ef373"


### PR DESCRIPTION
# Big Picture Summary
Proposing we add this so that the email is included in server logs when attempting to debug login attempts for a specific user

### Which major feature does this fit into?
Error-handling!

## Technical Explanation — How does it work?
Adds a jwt decoder lib. Decodes (but not validates) the jwt client-side, extracts the email associated, and sends with the login request. This appears in Papertrail alerts and logs for better debugging experience.
