### PR TITLE
12255 proposed development site

### DIFF
--- a/client/app/components/packages/landuse-form/edit.hbs
+++ b/client/app/components/packages/landuse-form/edit.hbs
@@ -30,6 +30,10 @@
         @form={{saveableForm}}
       />
 
+      <Packages::LanduseForm::ProposedDevelopmentSite
+        @form={{saveableForm}}
+      />
+
       <Packages::ApplicantTeam
         @form={{saveableForm}}
         @addApplicant={{this.addApplicant}}

--- a/client/app/components/packages/landuse-form/proposed-development-site.hbs
+++ b/client/app/components/packages/landuse-form/proposed-development-site.hbs
@@ -1,0 +1,87 @@
+{{#let @form as |form|}}
+  <form.Section @title="Proposed Development Site">
+    <p>
+      The <b>Development Site</b> is the specific parcel(s) that the Applicant is seeking to develop.
+      A Project Area and Development Site can be the same parcels of land or different,
+      depending on the Actions being sought. For instance, a Special District may be mapped
+      over a portion of a neighborhood (Project Area), but only certain parcels within it may
+      be proposed for immediate development by the Applicant (Development Site).
+    </p>
+
+    <Ui::Question
+    as |dcp500kpluszoneQ|>
+      <dcp500kpluszoneQ.Label>
+        Does the Application result in the development of 500,000+ ZSF of floor area?
+      </dcp500kpluszoneQ.Label>
+
+      <form.Field
+        @attribute="dcp500kpluszone"
+        @type="radio-group"
+      as |Dcp500kpluszoneRadioGroup|>
+        <Dcp500kpluszoneRadioGroup
+          @options={{optionset 'landuseForm' 'dcp500kpluszone' 'list'}}
+          @onChange={{fn (mut @form.data.dcpDevsize) null}}
+        as |dcp500kpluszone|>
+          {{#if (eq
+            dcp500kpluszone
+            (optionset 'landuseForm' 'dcp500kpluszone' 'code' 'YES')
+          )}}
+            <Ui::Question
+              @required={{true}}
+            as |dcpDevsizeQ|>
+              <dcpDevsizeQ.Label>
+                Development size
+              </dcpDevsizeQ.Label>
+
+              <form.Field
+                @attribute="dcpDevsize"
+                @type="radio-group"
+              as |DcpDevsizeRadioGroup|>
+                <DcpDevsizeRadioGroup
+                  @options={{optionset 'landuseForm' 'dcpDevsize' 'list'}}
+                />
+              </form.Field>
+            </Ui::Question>
+          {{/if}}
+        </Dcp500kpluszoneRadioGroup>
+      </form.Field>
+    </Ui::Question>
+
+    <Ui::Question
+    as |dcpSitedatasiteisinnewyorkcityQ|>
+      <dcpSitedatasiteisinnewyorkcityQ.Label>
+        Is the Development Site a Landmark (New York City or other) or within a Historic District?
+      </dcpSitedatasiteisinnewyorkcityQ.Label>
+
+      <form.Field
+        @attribute="dcpSitedatasiteisinnewyorkcity"
+        @type="radio-group"
+      as |DcpSitedatasiteisinnewyorkcityRadioGroup|>
+        <DcpSitedatasiteisinnewyorkcityRadioGroup
+          @options={{optionset 'landuseForm' 'dcpSitedatasiteisinnewyorkcity' 'list'}}
+          @onChange={{fn (mut @form.data.dcpSitedataidentifylandmark) ""}}
+        as |dcpSitedatasiteisinnewyorkcity|>
+          {{#if (eq
+            dcpSitedatasiteisinnewyorkcity
+            (optionset 'landuseForm' 'dcpSitedatasiteisinnewyorkcity' 'code' 'YES')
+          )}}
+            <Ui::Question
+              @required={{true}}
+            as |dcpSitedataidentifylandmarkQ|>
+              <dcpSitedataidentifylandmarkQ.Label>
+                Landmark or Historic District name
+              </dcpSitedataidentifylandmarkQ.Label>
+
+              <form.Field
+                @attribute="dcpSitedataidentifylandmark"
+                @maxlength="100"
+                @showCounter={{true}}
+                id={{dcpSitedataidentifylandmarkQ.id}}
+              />
+            </Ui::Question>
+          {{/if}}
+        </DcpSitedatasiteisinnewyorkcityRadioGroup>
+      </form.Field>
+    </Ui::Question>
+  </form.Section>
+{{/let}}

--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -17,6 +17,7 @@ import {
 import PACKAGE_OPTIONSETS from '../optionsets/package';
 import {
   CEQR_TYPE,
+  DCPDEVSIZE,
 } from '../optionsets/landuse-form';
 import {
   DCPCONSTRUCTIONPHASING,
@@ -62,6 +63,9 @@ const OPTIONSET_LOOKUP = {
     dcpEntiretyboroughs: YES_NO,
     dcpEntiretycommunity: YES_NO,
     dcpNotaxblock: YES_NO,
+    dcp500kpluszone: YES_NO,
+    dcpDevsize: DCPDEVSIZE,
+    dcpSitedatasiteisinnewyorkcity: YES_NO,
   },
   rwcdsForm: {
     dcpHasprojectchangedsincesubmissionofthepas: YES_NO,

--- a/client/app/optionsets/landuse-form.js
+++ b/client/app/optionsets/landuse-form.js
@@ -12,3 +12,18 @@ export const CEQR_TYPE = {
     label: 'Unlisted',
   },
 };
+
+export const DCPDEVSIZE = {
+  HALF_TO_LT_ONE_MIL: {
+    code: 717170000,
+    label: '500,000 to 999,999 zoning sq ft',
+  },
+  ONE_TO_LT_TWENTYFIVE_MIL: {
+    code: 717170001,
+    label: '1,000,000 - 2,499,999 zoning sq ft',
+  },
+  GTE_TWENTYFIVE_MIL: {
+    code: 717170002,
+    label: 'At least 2,500,000 zoning sq ft',
+  },
+};

--- a/client/app/validations/submittable-landuse-form.js
+++ b/client/app/validations/submittable-landuse-form.js
@@ -21,4 +21,21 @@ export default {
       message: 'This field is required',
     }),
   ],
+  dcpDevsize: [
+    validatePresenceIf({
+      presence: true,
+      on: 'dcp500kpluszone',
+      withValue: true,
+      message: 'This field is required',
+    }),
+  ],
+  dcpSitedataidentifylandmark: [
+    ...SaveableLanduseForm.dcpSitedataidentifylandmark,
+    validatePresenceIf({
+      presence: true,
+      on: 'dcpSitedatasiteisinnewyorkcity',
+      withValue: true,
+      message: 'This field is required',
+    }),
+  ],
 };

--- a/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
@@ -110,7 +110,7 @@ module('Acceptance | user can click landuse form edit', function(hooks) {
     assert.equal(currentURL(), '/landuse-form/1/edit');
   });
 
-  test('User resets values of all radio descendants when changing radio answer', async function(assert) {
+  test('User resets values of all radio descendants when changing radio answers in Project Area', async function(assert) {
     this.server.create('project', 1, {
       packages: [this.server.create('package', 'toDo', 'landuseForm')],
     });
@@ -154,6 +154,45 @@ module('Acceptance | user can click landuse form edit', function(hooks) {
     await assert.dom('[data-test-input="dcpSitedatapropertydescription"]').hasNoValue();
 
     assert.equal(currentURL(), '/landuse-form/1/edit');
+  });
+
+  test('User is required to fill out Proposed Development Site conditional fields', async function(assert) {
+    this.server.create('project', 1, {
+      packages: [this.server.create('package', 'toDo', 'landuseForm')],
+    });
+
+    await visit('/landuse-form/1/edit');
+    assert.dom('[data-test-submit-button]').hasNoAttribute('disabled');
+
+    await click('[data-test-radio="dcp500kpluszone"][data-test-radio-option="No"]');
+
+    assert.dom('[data-test-submit-button]').hasNoAttribute('disabled');
+    assert.dom('[data-test-validation-message="dcpDevsize"]').doesNotExist();
+
+    await click('[data-test-radio="dcp500kpluszone"][data-test-radio-option="Yes"]');
+
+    assert.dom('[data-test-submit-button]').hasAttribute('disabled');
+    assert.dom('[data-test-validation-message="dcpDevsize"]').containsText('required');
+
+    await click('[data-test-radio="dcpDevsize"][data-test-radio-option="500,000 to 999,999 zoning sq ft"]');
+
+    assert.dom('[data-test-submit-button]').hasNoAttribute('disabled');
+    assert.dom('[data-test-validation-message="dcpDevsize"]').doesNotExist();
+
+    await click('[data-test-radio="dcpSitedatasiteisinnewyorkcity"][data-test-radio-option="No"]');
+
+    assert.dom('[data-test-submit-button]').hasNoAttribute('disabled');
+    assert.dom('[data-test-validation-message="dcpSitedataidentifylandmark"]').doesNotExist();
+
+    await click('[data-test-radio="dcpSitedatasiteisinnewyorkcity"][data-test-radio-option="Yes"]');
+
+    assert.dom('[data-test-submit-button]').hasAttribute('disabled');
+    assert.dom('[data-test-validation-message="dcpSitedataidentifylandmark"]').exists();
+
+    await fillIn('[data-test-input="dcpSitedataidentifylandmark"]', 'Douglas Fir');
+
+    assert.dom('[data-test-submit-button]').hasNoAttribute('disabled');
+    assert.dom('[data-test-validation-message="dcpSitedataidentifylandmark"]').doesNotExist();
   });
 
   test('User can add an applicant on the landuse form', async function(assert) {


### PR DESCRIPTION
### Summary
This sets up the Proposed Development Site section for the Land Use form

### Which major feature does this fit into?
Land use - proposed development site
Fixes [AB#12255](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12255)

### Technical Details
The component design is similar to that for Project Area. 
We use component nesting to implement conditional/cascading questions.