### PR TITLE
12354: fix bug where deleted records were not being saved

### DIFF
--- a/client/app/components/packages/landuse-form/edit.hbs
+++ b/client/app/components/packages/landuse-form/edit.hbs
@@ -43,6 +43,7 @@
 
       <Packages::LanduseForm::ProjectTaxLots
         @form={{saveableForm}}
+        @removeBbl={{this.removeBbl}}
       />
 
       <Packages::LanduseForm::EnvironmentalReview
@@ -64,7 +65,7 @@
     <div class="cell large-4 sticky-sidebar">
       <saveableForm.PageNav>
         <saveableForm.SaveButton
-          @isEnabled={{or @package.isDirty saveableForm.isSaveable}}
+          @isEnabled={{or this.packageIsDirtyOrRecordsDeleted saveableForm.isSaveable}}
           @onClick={{this.savePackage}}
           data-test-save-button
         />

--- a/client/app/components/packages/landuse-form/edit.js
+++ b/client/app/components/packages/landuse-form/edit.js
@@ -37,10 +37,15 @@ export default class LandUseFormComponent extends Component {
     return this.package.landuseForm || {};
   }
 
+  get packageIsDirtyOrRecordsDeleted() {
+    return this.package.isDirty || this.recordsToDelete.length > 0;
+  }
+
   @action
   async savePackage() {
     try {
       await this.args.package.save(this.recordsToDelete);
+      this.recordsToDelete = [];
     } catch (error) {
       console.log('Save Landuse package error:', error);
     }
@@ -88,5 +93,12 @@ export default class LandUseFormComponent extends Component {
     this.recordsToDelete.push(relatedAction);
 
     relatedAction.deleteRecord();
+  }
+
+  @action
+  removeBbl(bbl) {
+    bbl.deleteRecord();
+    this.recordsToDelete.push(bbl);
+    this.args.package.landuseForm.bbls.removeObject(bbl);
   }
 }

--- a/client/app/components/packages/landuse-form/edit.js
+++ b/client/app/components/packages/landuse-form/edit.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 import SaveableProjectFormValidations from '../../../validations/saveable-project-form';
 import SubmittableProjectFormValidations from '../../../validations/submittable-project-form';
 import SaveableLanduseFormValidations from '../../../validations/saveable-landuse-form';
@@ -23,6 +24,8 @@ export default class LandUseFormComponent extends Component {
     SubmittableRelatedActionFormValidations,
   };
 
+  @tracked recordsToDelete = [];
+
   @service
   store;
 
@@ -37,7 +40,7 @@ export default class LandUseFormComponent extends Component {
   @action
   async savePackage() {
     try {
-      await this.args.package.save();
+      await this.args.package.save(this.recordsToDelete);
     } catch (error) {
       console.log('Save Landuse package error:', error);
     }
@@ -64,6 +67,8 @@ export default class LandUseFormComponent extends Component {
   removeApplicant(applicant, changeset) {
     removeFromHasMany(changeset, 'applicants', applicant);
 
+    this.recordsToDelete.push(applicant);
+
     applicant.deleteRecord();
   }
 
@@ -79,6 +84,8 @@ export default class LandUseFormComponent extends Component {
   @action
   removeRelatedAction(relatedAction, changeset) {
     removeFromHasMany(changeset, 'relatedActions', relatedAction);
+
+    this.recordsToDelete.push(relatedAction);
 
     relatedAction.deleteRecord();
   }

--- a/client/app/components/packages/landuse-form/project-tax-lots.hbs
+++ b/client/app/components/packages/landuse-form/project-tax-lots.hbs
@@ -9,6 +9,7 @@
         @form={{@form}}
         @bbls={{@form.data.bbls}}
         @project={{@form.data.package.project}}
+        @removeBbl={{@removeBbl}}
       />
     </div>
   </form.Section>

--- a/client/app/components/packages/pas-form/edit.hbs
+++ b/client/app/components/packages/pas-form/edit.hbs
@@ -41,7 +41,10 @@
           @validations={{this.validations}}
         />
 
-        <Packages::PasForm::ProjectGeography @form={{saveablePasForm}} />
+        <Packages::PasForm::ProjectGeography
+          @form={{saveablePasForm}}
+          @removeBbl={{this.removeBbl}}
+        />
 
         <Packages::PasForm::ProposedLandUseActions @form={{saveablePasForm}} />
 
@@ -61,7 +64,7 @@
 
         <saveablePasForm.PageNav>
           <saveablePackageForm.SaveButton
-            @isEnabled={{or @package.isDirty saveablePackageForm.isSaveable}}
+            @isEnabled={{or this.packageIsDirtyOrRecordsDeleted saveablePackageForm.isSaveable}}
             @onClick={{this.savePackage}}
             data-test-save-button
           />

--- a/client/app/components/packages/pas-form/edit.js
+++ b/client/app/components/packages/pas-form/edit.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 import SaveablePasFormValidations from '../../../validations/saveable-pas-form';
 import SubmittablePasFormValidations from '../../../validations/submittable-pas-form';
 
@@ -21,6 +22,8 @@ export default class PasFormComponent extends Component {
     SubmittablePackageFormValidations,
   };
 
+  @tracked recordsToDelete = [];
+
   @service
   router;
 
@@ -38,7 +41,7 @@ export default class PasFormComponent extends Component {
   @action
   async savePackage() {
     try {
-      await this.args.package.save();
+      await this.args.package.save(this.recordsToDelete);
     } catch (error) {
       console.log('Save PAS package error:', error);
     }
@@ -64,6 +67,8 @@ export default class PasFormComponent extends Component {
   @action
   removeApplicant(applicant, changeset) {
     removeFromHasMany(changeset, 'applicants', applicant);
+
+    this.recordsToDelete.push(applicant);
 
     applicant.deleteRecord();
   }

--- a/client/app/components/packages/pas-form/edit.js
+++ b/client/app/components/packages/pas-form/edit.js
@@ -38,10 +38,15 @@ export default class PasFormComponent extends Component {
     return this.package.pasForm || {};
   }
 
+  get packageIsDirtyOrRecordsDeleted() {
+    return this.package.isDirty || this.recordsToDelete.length > 0;
+  }
+
   @action
   async savePackage() {
     try {
       await this.args.package.save(this.recordsToDelete);
+      this.recordsToDelete = [];
     } catch (error) {
       console.log('Save PAS package error:', error);
     }
@@ -71,5 +76,12 @@ export default class PasFormComponent extends Component {
     this.recordsToDelete.push(applicant);
 
     applicant.deleteRecord();
+  }
+
+  @action
+  removeBbl(bbl) {
+    bbl.deleteRecord();
+    this.recordsToDelete.push(bbl);
+    this.args.package.pasForm.bbls.removeObject(bbl);
   }
 }

--- a/client/app/components/packages/pas-form/project-geography.hbs
+++ b/client/app/components/packages/pas-form/project-geography.hbs
@@ -14,6 +14,7 @@
         @form={{@form}}
         @bbls={{@form.data.bbls}}
         @project={{@form.data.package.project}}
+        @removeBbl={{@removeBbl}}
       />
     </div>
 

--- a/client/app/components/packages/project-geography.hbs
+++ b/client/app/components/packages/project-geography.hbs
@@ -84,7 +84,7 @@
         <button
           type="button"
           class="delete-fieldset"
-          {{on "click" (fn this.removeBbl bbl)}}
+          {{on "click" (fn @removeBbl bbl)}}
           data-test-button-remove-bbl="{{bbl.dcpBblnumber}}"
         >
           Delete BBL

--- a/client/app/components/packages/project-geography.js
+++ b/client/app/components/packages/project-geography.js
@@ -50,12 +50,4 @@ export default class ProjectGeographyComponent extends Component {
     // bottom of the screen where they will be unable to see it
     this.args.bbls.unshiftObject(bblObjectToPush);
   }
-
-  // Remove bbl object from list of bbls
-  @action
-  removeBbl(bblObjectToBeRemoved) {
-    // this.store.deleteRecord(bblObjectToBeRemoved);
-    bblObjectToBeRemoved.destroyRecord();
-    this.args.bbls.removeObject(bblObjectToBeRemoved);
-  }
 }

--- a/client/app/models/package.js
+++ b/client/app/models/package.js
@@ -68,15 +68,17 @@ export default class PackageModel extends Model {
     this.statecode = STATECODE.INACTIVE.code;
   }
 
-  async save() {
+  async save(recordsToDelete) {
     await this.fileManager.save();
     if (this.dcpPackagetype === DCPPACKAGETYPE.PAS_PACKAGE.code) {
+      await this.saveDeletedRecords(recordsToDelete);
       await this.pasForm.save();
     }
     if (this.dcpPackagetype === DCPPACKAGETYPE.RWCDS.code) {
       await this.rwcdsForm.save();
     }
     if (this.dcpPackagetype === DCPPACKAGETYPE.DRAFT_LU_PACKAGE.code) {
+      await this.saveDeletedRecords(recordsToDelete);
       await this.landuseForm.save();
     }
     await super.save();
@@ -90,6 +92,15 @@ export default class PackageModel extends Model {
     this.setAttrsForSubmission();
 
     await this.save();
+  }
+
+  async saveDeletedRecords(recordsToDelete) {
+    if (recordsToDelete) {
+      return Promise.all(
+        recordsToDelete
+          .map((record) => record.save()),
+      );
+    }
   }
 
   // deprecate

--- a/client/app/validations/submittable-landuse-form.js
+++ b/client/app/validations/submittable-landuse-form.js
@@ -1,3 +1,6 @@
+import {
+  validateLength,
+} from 'ember-changeset-validations/validators';
 import SaveableLanduseForm from './saveable-landuse-form';
 import validatePresenceIf from '../validators/required-if-selected';
 
@@ -36,6 +39,12 @@ export default {
       on: 'dcpSitedatasiteisinnewyorkcity',
       withValue: true,
       message: 'This field is required',
+    }),
+  ],
+  applicants: [
+    validateLength({
+      min: 1,
+      message: 'One or more applicant team members is required.',
     }),
   ],
 };

--- a/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
@@ -162,6 +162,14 @@ module('Acceptance | user can click landuse form edit', function(hooks) {
     });
 
     await visit('/landuse-form/1/edit');
+
+    // fill out other necessary fields for saving
+    await click('[data-test-add-applicant-button]');
+    await fillIn('[data-test-input="dcpFirstname"]', 'Tess');
+    await fillIn('[data-test-input="dcpLastname"]', 'Ter');
+    await fillIn('[data-test-input="dcpEmail"]', 'tesster@planning.nyc.gov');
+    await click('[data-test-save-button]');
+
     assert.dom('[data-test-submit-button]').hasNoAttribute('disabled');
 
     await click('[data-test-radio="dcp500kpluszone"][data-test-radio-option="No"]');


### PR DESCRIPTION
**Big Picture Summary**
Previously, users had to click save twice in order to properly DELETE `relatedActions` and `applicants`. 

**Which major feature does this fit into?**
PAS form and Land Use Form -- the applicants and related actions sections

**Technical Explanation — How does it work?**
A while back, we switched from `destroyRecord` to `deleteRecord`. Since then, when we looped through the records with dirty attributes and only saved those records, we were not taking into account records that had been deleted -- these records did not show up in the array and were therefore not saved. This PR passes the records that are currently being "removed" to the package model to be saved. 

Closes [AB#12354](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12354)