### PR TITLE
Add team member model; extract data from CRM; expands on proejct service

### DIFF
--- a/client/app/models/project.js
+++ b/client/app/models/project.js
@@ -30,6 +30,9 @@ export default class ProjectModel extends Model {
   @hasMany('project-applicant', { async: false })
   projectApplicants;
 
+  @hasMany('team-member', { async: false })
+  teamMembers;
+
   get publicStatusGeneralPublicProject() {
     const isGeneralPublic = this.dcpVisibility === optionset(['project', 'dcpVisibility', 'code', 'GENERAL_PUBLIC']);
     return this.dcpPublicstatus && isGeneralPublic;

--- a/client/app/models/team-member.js
+++ b/client/app/models/team-member.js
@@ -1,0 +1,18 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class TeamMemberModel extends Model {
+  @attr
+  name;
+
+  @attr
+  role;
+
+  @attr
+  email;
+
+  @attr
+  phone;
+
+  @belongsTo('project', { async: false })
+  project;
+}

--- a/client/app/routes/project.js
+++ b/client/app/routes/project.js
@@ -7,7 +7,7 @@ export default class ProjectRoute extends Route.extend(AuthenticatedRouteMixin) 
   async model(params) {
     const project = await this.store.findRecord('project', params.id, {
       reload: true,
-      include: 'packages.pasForm,packages.rwcdsForm,projectApplicants.contacts',
+      include: 'packages.pasForm,packages.rwcdsForm,projectApplicants.contacts,teamMembers',
       ...params,
     });
 

--- a/client/app/templates/project.hbs
+++ b/client/app/templates/project.hbs
@@ -159,6 +159,31 @@
 
     <Messages::Assistance class="large-margin-top" />
 
+    <h3>
+      City Planning Staff
+    </h3>
+    <ul class="no-bullet">
+      {{#each this.project.teamMembers as |teamMember|}}
+        <li class="grid-x medium-margin-bottom">
+          <div class="cell shrink small-padding-right">
+            <FaIcon @icon='user' @fixedWidth={{true}} @transform='down-1' class="text-gray" />
+          </div>
+          <div class="cell auto">
+            <h5 class="no-margin">{{teamMember.name}}</h5>
+            <p class="text-small tiny-margin-bottom">
+              <i>{{teamMember.role}}</i>
+            </p>
+            <p class="text-small tiny-margin-bottom">
+              <a href="mailto:{{teamMember.email}}">{{teamMember.email}}</a>
+            </p>
+            <p class="text-small tiny-margin-bottom">
+              {{teamMember.phone}}
+            </p>
+          </div>
+        </li>
+      {{/each}}
+    </ul>
+
   </div>
 </div>
 

--- a/client/mirage/models/project.js
+++ b/client/mirage/models/project.js
@@ -3,5 +3,6 @@ import { Model, hasMany } from 'ember-cli-mirage';
 export default Model.extend({
   packages: hasMany('package'),
   projectApplicants: hasMany('project-applicant'),
+  teamMembers: hasMany('team-member'),
   contacts: hasMany('contact'),
 });

--- a/client/mirage/models/team-member.js
+++ b/client/mirage/models/team-member.js
@@ -1,0 +1,5 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  project: belongsTo('project'),
+});

--- a/client/tests/unit/models/team-member-test.js
+++ b/client/tests/unit/models/team-member-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | team member', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('team-member', {});
+    assert.ok(model);
+  });
+});

--- a/server/src/projects/projects.controller.ts
+++ b/server/src/projects/projects.controller.ts
@@ -17,6 +17,7 @@ import { AuthenticateGuard } from '../authenticate.guard';
 import { PROJECT_ATTRS } from './projects.attrs';
 import { PACKAGE_ATTRS } from '../packages/packages.attrs';
 import { PROJECTAPPLICANT_ATTRS } from './project-applicants/project-applicants.attrs';
+import { TEAMMEMBER_ATTRS } from './team-members/team-members.attrs';
 import { CONTACT_ATTRS } from '../contact/contacts.attrs';
 
 @UseInterceptors(new JsonApiSerializeInterceptor('projects', {
@@ -26,6 +27,7 @@ import { CONTACT_ATTRS } from '../contact/contacts.attrs';
 
     'packages',
     'project-applicants',
+    'team-members',
     'contacts',
   ],
   packages: {
@@ -47,6 +49,12 @@ import { CONTACT_ATTRS } from '../contact/contacts.attrs';
         ...CONTACT_ATTRS,
       ],
     },
+  },
+  'team-members': {
+    ref: 'dcp_dcpprojectteamid',
+    attributes: [
+      ...TEAMMEMBER_ATTRS,
+    ],
   },
 
   // remap verbose navigation link names to

--- a/server/src/projects/projects.service.ts
+++ b/server/src/projects/projects.service.ts
@@ -23,6 +23,11 @@ const PACKAGE_STATUSCODE = {
   REVIEWED_REVISION_REQUIRED: 717170010,
 }
 
+const DCP_PROJECTROLES = {
+  LEAD_PLANNER: 717170026,
+  BOROUGH_TEAM_LEADER: 717170000,
+};
+
 @Injectable()
 export class ProjectsService {
   constructor(
@@ -84,6 +89,7 @@ export class ProjectsService {
           dcp_dcp_project_dcp_projectapplicant_Project(
             $filter= statuscode eq ${APPLICANT_ACTIVE_STATUS_CODE}
           ),
+          dcp_dcp_project_dcp_dcpprojectteam_project,
           dcp_dcp_project_dcp_package_project(
             $filter= 
             (
@@ -108,6 +114,22 @@ export class ProjectsService {
           dcp_applicant_customer_contact
       `);
 
+      const { records: projectTeamMembers } = await this.crmService.get('dcp_dcpprojectteams', `
+        $select=
+          dcp_projectrole,
+          dcp_name
+        &$filter=
+          _dcp_project_value eq ${projectId}
+          and (
+            dcp_projectrole eq ${DCP_PROJECTROLES.BOROUGH_TEAM_LEADER}
+            or dcp_projectrole eq ${DCP_PROJECTROLES.LEAD_PLANNER}
+          )
+        &$expand=
+          dcp_user(
+            $select=internalemailaddress,address1_telephone1
+          )
+      `);
+
       const projectApplicantsWithContacts = projectApplicants.records.map(applicant => ({ ...applicant, contact: applicant.dcp_applicant_customer_contact }));
 
       const [ project ] = this.overwriteCodesWithLabels(records);
@@ -126,10 +148,19 @@ export class ProjectsService {
       const projectWithContacts = {
         ...project,
         'project-applicants': projectApplicantsWithContacts,
+        'team-members': projectTeamMembers.map(member => ({
+          dcp_dcpprojectteamid: member.dcp_dcpprojectteamid,
+          name: member.dcp_name,
+          role: member['dcp_projectrole@OData.Community.Display.V1.FormattedValue'],
+          email: member.dcp_user.internalemailaddress,
+          phone: member.dcp_user.address1_telephone1,
+        })),
       };
 
       return projectWithContacts;
     } catch(e) {
+      console.log(e);
+
       throw new HttpException({
         "code": "PROJECTS_SERVICE_FAILURE",
         "title": "Could not lookup projects. Something went wrong.",

--- a/server/src/projects/team-members/team-members.attrs.ts
+++ b/server/src/projects/team-members/team-members.attrs.ts
@@ -1,0 +1,7 @@
+export const TEAMMEMBER_ATTRS = [
+  'name',
+  'role',
+  'email',
+  'phone',
+  'dcp_dcpprojectteamid',
+];


### PR DESCRIPTION
# Big Picture Summary
This PR shows the DCP Team in the project page contact management section

### Which major feature does this fit into?
Contact Management

### What was wrong and how does this fix the problem?
It wasn't displaying the DCP team members and this PR displays them in their full glory according to the REQS

## Technical Explanation — How does it work?
It makes another request to the CRM API to add the information about DCP team members alongside the project applicants (think of these entities as siblings). It then does some idiosyncratic munging of that data (sorry, but some of the data is on a separate related entity).

This PR is "pretty bad" in terms of our code standards. There isn't any additional test coverage for this part of contact mgmt (although AFAICT there wasn't any for that feature to begin with), and this makes several assumptions about the data that's being pulled (it's not clear if we're using the correct phone number and e-mail information as the dcp_dcpteammember entity does not have an associated contact record — instead it has a "dcp_user", which is mentioned in the docs)

Closes [AB#12206](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12206)
