### PR TITLE
12366 Set up Land Use "show" page, wire up Submit button

### DIFF
--- a/client/app/components/packages/landuse-form/edit.hbs
+++ b/client/app/components/packages/landuse-form/edit.hbs
@@ -76,6 +76,31 @@
           data-test-submit-button
         />
       </saveableForm.PageNav>
+
+      <saveableForm.ConfirmationModal
+        @action={{component saveableForm.SubmitButton
+          onClick=this.submitPackage
+          isEnabled=saveableForm.isSubmittable
+          class="no-margin"
+        }}
+        @footer={{component 'packages/landuse-form/landuse-form-error'
+          package=@package
+        }}
+        @continueButtonTitle="Continue Editing"
+        data-test-confirm-submit-button={{true}}
+      >
+        <h6>Confirm Draft Land Use Form Submission</h6>
+        <p class="header-large medium-margin-top small-margin-bottom">
+          Are you sure?
+        </p>
+        <p>
+          Before submitting, ensure that your answers are accurate and complete,
+          and that necessary attachments have been uploaded.
+          If NYC Planning does not receive enough accurate information,
+          the Lead Planner will notify you and request that this form be
+          resubmitted with necessary materials, corrections, or clarifications.
+        </p>
+      </saveableForm.ConfirmationModal>
     </div>
   </div>
 </SaveableForm>

--- a/client/app/components/packages/landuse-form/edit.js
+++ b/client/app/components/packages/landuse-form/edit.js
@@ -27,6 +27,9 @@ export default class LandUseFormComponent extends Component {
   @tracked recordsToDelete = [];
 
   @service
+  router;
+
+  @service
   store;
 
   get package() {
@@ -55,7 +58,7 @@ export default class LandUseFormComponent extends Component {
   async submitPackage() {
     await this.args.package.submit();
 
-    this.router.transitionTo('land-use.show', this.args.package.id);
+    this.router.transitionTo('landuse-form.show', this.args.package.id);
   }
 
   @action

--- a/client/app/components/packages/landuse-form/landuse-form-error.hbs
+++ b/client/app/components/packages/landuse-form/landuse-form-error.hbs
@@ -1,0 +1,21 @@
+{{#if (or @package.landuseForm.adapterError @package.adapterError)}}
+  <div class="callout alert" data-test-error-saving>
+    <h5 class="text-red-dark">
+      <FaIcon
+      @icon="exclamation-circle"
+      @size="2x"
+      class="text-red float-left medium-margin-right tiny-margin-top"
+      />
+        There was a problem saving your information.
+    </h5>
+      <Errors::List
+        @errors={{@package.landuseForm.adapterError.errors}}
+      />
+      <Errors::List
+        @errors={{@package.adapterError.errors}}
+      />
+      <p class="text-red-dark text-small">
+        Please try again. If the problem persists, please contact NYC Planning at <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or <a href="tel:212-720-3300" class="nowrap">212-720-3300</a>.
+      </p>
+  </div>
+{{/if}}

--- a/client/app/components/packages/landuse-form/show.hbs
+++ b/client/app/components/packages/landuse-form/show.hbs
@@ -1,0 +1,35 @@
+<div class="grid-x grid-margin-x">
+  <div class="cell large-8">
+
+    <section class="form-section">
+      <h1 class="header-large">
+        <span id="project-info" class="section-anchor"></span>
+        Draft Land Use Form
+        <small class="text-weight-normal">
+          {{if @package.dcpPackageversion (concat '(V' @package.dcpPackageversion ')')}}
+        </small>
+      </h1>
+
+      <h2
+        class="no-margin"
+        data-test-show="dcpProjectname"
+      >
+        {{@package.landuseForm.dcpProjectname}}
+        <small class="text-weight-normal">
+          {{if @package.project.dcpName (concat '(' @package.project.dcpName ')')}}
+        </small>
+      </h2>
+
+      <p class="text-large text-dark-gray">
+        {{optionset 'bbl' 'boroughs' 'label' @package.project.dcpBorough}} |
+        {{optionset 'package' 'statuscode' 'label' @package.statuscode}}
+      </p>
+    </section>
+
+  </div>{{! end left/main column }}
+  <div class="cell large-4 sticky-sidebar">
+
+  </div>{{! end right/sidebar column }}
+</div>
+
+{{yield}}

--- a/client/app/components/packages/rwcds-form/edit.hbs
+++ b/client/app/components/packages/rwcds-form/edit.hbs
@@ -76,7 +76,7 @@
         @footer={{component 'packages/rwcds-form/rwcds-form-error'
           package=@package
         }}
-        @continuteButtonTitle="Continue Editing"
+        @continueButtonTitle="Continue Editing"
         data-test-confirm-submit-button={{true}}
       >
         <h6>Confirm Reasonable Worst Case Development Scenario Submission</h6>

--- a/client/app/templates/landuse-form/show.hbs
+++ b/client/app/templates/landuse-form/show.hbs
@@ -1,0 +1,11 @@
+<Ui::Breadcrumbs as |Crumb|>
+  <Crumb @text="My Projects" @route='projects' />
+  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb @text="Land Use" @disabled={{true}} />
+</Ui::Breadcrumbs>
+
+<Packages::LanduseForm::Show
+  @package={{@model}}
+/>
+
+{{outlet}}

--- a/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
@@ -5,6 +5,7 @@ import {
   currentURL,
   settled,
   fillIn,
+  waitFor,
 } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -23,6 +24,30 @@ module('Acceptance | user can click landuse form edit', function(hooks) {
     authenticateSession({
       emailaddress1: 'me@me.com',
     });
+  });
+
+  test('User can edit, save and submit landuse form', async function(assert) {
+    this.server.create('project', 1, {
+      packages: [this.server.create('package', 'toDo', 'landuseForm')],
+    });
+
+    await visit('/landuse-form/1/edit');
+
+    await click('[data-test-add-applicant-button]');
+    await fillIn('[data-test-input="dcpFirstname"]', 'Tess');
+    await fillIn('[data-test-input="dcpLastname"]', 'Ter');
+    await fillIn('[data-test-input="dcpEmail"]', 'tesster@planning.nyc.gov');
+    await click('[data-test-save-button]');
+
+    await waitFor('[data-test-submit-button]:not([disabled])');
+    await click('[data-test-submit-button]');
+    await click('[data-test-confirm-submit-button]');
+
+    await settled();
+
+    await waitFor('[data-test-show="dcpProjectname"]');
+
+    assert.equal(currentURL(), '/landuse-form/1');
   });
 
   test('User can edit Site Information on the landuse form', async function(assert) {


### PR DESCRIPTION
### Summary
Set up a blank Land use form "Show" page and route, along with associated error templates.
Also sets up the Land Use form Submit button and confirmation modal. Most language in the confirmation modal copied
from RWCDS form. Clicking Confirm on the modal triggers transition to the Show page.

### Which major feature does this fit into?
Land use form submission 
Fixes [AB#12366](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12366)

### Technical details
- The new `packages/landuse-form/landuse-form-error.hbs` component template is to support the confirmation modal footer.
- Also fixes the a typo with the `@ continueButtonTitle` argument on rwcds form confirmation modal
- Fixes typo (`land-use.show`) in route name passed to submit button transitionTo 