### PR TITLE
12413 Conditionally show LU dev site and tax lots sections

### DIFF
--- a/client/app/components/packages/landuse-form/edit.hbs
+++ b/client/app/components/packages/landuse-form/edit.hbs
@@ -26,14 +26,6 @@
         @form={{saveableForm}}
       />
 
-      <Packages::LanduseForm::ProjectArea
-        @form={{saveableForm}}
-      />
-
-      <Packages::LanduseForm::ProposedDevelopmentSite
-        @form={{saveableForm}}
-      />
-
       <Packages::ApplicantTeam
         @form={{saveableForm}}
         @addApplicant={{this.addApplicant}}
@@ -41,10 +33,25 @@
         @validations={{this.validations}}
       />
 
-      <Packages::LanduseForm::ProjectTaxLots
+      <Packages::LanduseForm::ProjectArea
         @form={{saveableForm}}
-        @removeBbl={{this.removeBbl}}
       />
+
+      {{#if (and
+        (eq saveableForm.data.dcpWholecity (optionset 'landuseForm' 'dcpWholecity' 'code' 'NO'))
+        (eq saveableForm.data.dcpEntiretyboroughs (optionset 'landuseForm' 'dcpEntiretyboroughs' 'code' 'NO'))
+        (eq saveableForm.data.dcpEntiretycommunity (optionset 'landuseForm' 'dcpEntiretycommunity' 'code' 'NO'))
+        (eq saveableForm.data.dcpNotaxblock (optionset 'landuseForm' 'dcpNotaxblock' 'code' 'NO'))
+      )}}
+        <Packages::LanduseForm::ProposedDevelopmentSite
+          @form={{saveableForm}}
+        />
+
+        <Packages::LanduseForm::ProjectTaxLots
+          @form={{saveableForm}}
+          @removeBbl={{this.removeBbl}}
+        />
+      {{/if}}
 
       <Packages::LanduseForm::EnvironmentalReview
         @form={{saveableForm}}

--- a/client/app/components/packages/landuse-form/project-tax-lots.hbs
+++ b/client/app/components/packages/landuse-form/project-tax-lots.hbs
@@ -1,5 +1,8 @@
 {{#let @form as |form|}}
-  <form.Section @title="Project Area Tax Lots">
+  <form.Section
+    @title="Project Area Tax Lots"
+    data-test-section="project-area-tax-lots"
+  >
     <p>
       Review and edit the Tax Lots listed below.
     </p>

--- a/client/app/components/packages/landuse-form/proposed-development-site.hbs
+++ b/client/app/components/packages/landuse-form/proposed-development-site.hbs
@@ -1,5 +1,8 @@
 {{#let @form as |form|}}
-  <form.Section @title="Proposed Development Site">
+  <form.Section
+    @title="Proposed Development Site"
+    data-test-section="proposed-development-site"
+  >
     <p>
       The <b>Development Site</b> is the specific parcel(s) that the Applicant is seeking to develop.
       A Project Area and Development Site can be the same parcels of land or different,

--- a/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
@@ -197,6 +197,11 @@ module('Acceptance | user can click landuse form edit', function(hooks) {
 
     assert.dom('[data-test-submit-button]').hasNoAttribute('disabled');
 
+    await click('[data-test-radio="dcpWholecity"][data-test-radio-option="No"]');
+    await click('[data-test-radio="dcpEntiretyboroughs"][data-test-radio-option="No"]');
+    await click('[data-test-radio="dcpEntiretycommunity"][data-test-radio-option="No"]');
+    await click('[data-test-radio="dcpNotaxblock"][data-test-radio-option="No"]');
+
     await click('[data-test-radio="dcp500kpluszone"][data-test-radio-option="No"]');
 
     assert.dom('[data-test-submit-button]').hasNoAttribute('disabled');
@@ -394,5 +399,28 @@ module('Acceptance | user can click landuse form edit', function(hooks) {
     assert.equal(this.server.db.landuseForms.firstObject.dcpTypecategory, 'type category');
 
     assert.equal(currentURL(), '/landuse-form/1/edit');
+  });
+
+  test('User only sees Proposed Development Site and Project Tax Lots when project applies to partial area', async function(assert) {
+    this.server.create('project', 1, {
+      packages: [this.server.create('package', 'toDo', 'landuseForm')],
+    });
+
+    await visit('/landuse-form/1/edit');
+
+    assert.dom('[data-test-section="proposed-development-site"]').doesNotExist();
+    assert.dom('[data-test-section="project-area-tax-lots"]').doesNotExist();
+
+    await click('[data-test-radio="dcpWholecity"][data-test-radio-option="No"]');
+    await click('[data-test-radio="dcpEntiretyboroughs"][data-test-radio-option="No"]');
+    await click('[data-test-radio="dcpEntiretycommunity"][data-test-radio-option="No"]');
+
+    assert.dom('[data-test-section="proposed-development-site"]').doesNotExist();
+    assert.dom('[data-test-section="project-area-tax-lots"]').doesNotExist();
+
+    await click('[data-test-radio="dcpNotaxblock"][data-test-radio-option="No"]');
+
+    assert.dom('[data-test-section="proposed-development-site"]').exists();
+    assert.dom('[data-test-section="project-area-tax-lots"]').exists();
   });
 });


### PR DESCRIPTION
### Summary 
Part of the Land use form is shown only when the Project applies to a partial area, and not to entire the city/borough/community or lot (i.e. the four respective LU fields relating to project area all evaluate to "false")


![image](https://user-images.githubusercontent.com/3311663/92803049-e78c4000-f36b-11ea-9fc6-d18f6037d9c2.png)


### Which major feature does this fit into?
Fixes [AB#12413](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12413)

## Technical Explanation — How does it work?
Form inputs are updating the changeset held at `saveableForm.data`, which is made available through the `saveableForm` yield in the `landuse-form/edit` component. Thus to access the responses to the city/borough/community/lot radio questions held in `saveableForm.data`, the conditional business logic for this PR is implemented in `landuse-form/edit.hbs` through template truth helpers (In contrast to through a controller or model file)

**- A subsequent PR will make sure that the last three fields in the Project Area section are similarly conditionally displayed**