### PR TITLE
12412 add missing project area fields

### DIFF
--- a/client/app/components/packages/landuse-form/edit.hbs
+++ b/client/app/components/packages/landuse-form/edit.hbs
@@ -26,14 +26,6 @@
         @form={{saveableForm}}
       />
 
-      <Packages::LanduseForm::ProjectArea
-        @form={{saveableForm}}
-      />
-
-      <Packages::LanduseForm::ProposedDevelopmentSite
-        @form={{saveableForm}}
-      />
-
       <Packages::ApplicantTeam
         @form={{saveableForm}}
         @addApplicant={{this.addApplicant}}
@@ -41,10 +33,25 @@
         @validations={{this.validations}}
       />
 
-      <Packages::LanduseForm::ProjectTaxLots
+      <Packages::LanduseForm::ProjectArea
         @form={{saveableForm}}
-        @removeBbl={{this.removeBbl}}
       />
+
+      {{#if (and
+        (eq saveableForm.data.dcpWholecity (optionset 'landuseForm' 'dcpWholecity' 'code' 'NO'))
+        (eq saveableForm.data.dcpEntiretyboroughs (optionset 'landuseForm' 'dcpEntiretyboroughs' 'code' 'NO'))
+        (eq saveableForm.data.dcpEntiretycommunity (optionset 'landuseForm' 'dcpEntiretycommunity' 'code' 'NO'))
+        (eq saveableForm.data.dcpNotaxblock (optionset 'landuseForm' 'dcpNotaxblock' 'code' 'NO'))
+      )}}
+        <Packages::LanduseForm::ProposedDevelopmentSite
+          @form={{saveableForm}}
+        />
+
+        <Packages::LanduseForm::ProjectTaxLots
+          @form={{saveableForm}}
+          @removeBbl={{this.removeBbl}}
+        />
+      {{/if}}
 
       <Packages::LanduseForm::EnvironmentalReview
         @form={{saveableForm}}

--- a/client/app/components/packages/landuse-form/project-area.hbs
+++ b/client/app/components/packages/landuse-form/project-area.hbs
@@ -153,72 +153,79 @@
       </form.Field>
     </Ui::Question>
 
-    <Ui::Question
-    as |dcpZonesspecialdistrictsQ|>
-      <dcpZonesspecialdistrictsQ.Label>
-        What are the existing Zoning Districts and Special Districts?
-      </dcpZonesspecialdistrictsQ.Label>
+    {{#if (and
+      (eq form.data.dcpWholecity (optionset 'landuseForm' 'dcpWholecity' 'code' 'NO'))
+      (eq form.data.dcpEntiretyboroughs (optionset 'landuseForm' 'dcpEntiretyboroughs' 'code' 'NO'))
+      (eq form.data.dcpEntiretycommunity (optionset 'landuseForm' 'dcpEntiretycommunity' 'code' 'NO'))
+      (eq form.data.dcpNotaxblock (optionset 'landuseForm' 'dcpNotaxblock' 'code' 'NO'))
+    )}}
+      <Ui::Question
+      as |dcpZonesspecialdistrictsQ|>
+        <dcpZonesspecialdistrictsQ.Label>
+          What are the existing Zoning Districts and Special Districts?
+        </dcpZonesspecialdistrictsQ.Label>
 
-      <form.Field
-        @attribute="dcpZonesspecialdistricts"
-        @maxlength="300"
-        @showCounter={{true}}
-        id={{dcpZonesspecialdistrictsQ.questionId}}
-      />
-    </Ui::Question>
-
-    <Ui::Question
-    as |dcpStateczmQ|>
-      <dcpStateczmQ.Label>
-        Is any portion of the proposed Project Area located
-        within the State Designated Coastal Zone Management
-        (CZM) Area?
-      </dcpStateczmQ.Label>
-
-      <form.Field
-        @attribute="dcpStateczm"
-        @type="radio-group"
-      as |DcpStateczmRadioGroup|>
-        <DcpStateczmRadioGroup
-          @options={{optionset 'landuseForm' 'dcpStateczm' 'list'}}
+        <form.Field
+          @attribute="dcpZonesspecialdistricts"
+          @maxlength="300"
+          @showCounter={{true}}
+          id={{dcpZonesspecialdistrictsQ.questionId}}
         />
-      </form.Field>
-    </Ui::Question>
+      </Ui::Question>
 
-    <Ui::Question
-    as |dcpHistoricdistrictQ|>
-      <dcpHistoricdistrictQ.Legend>
-        Is any portion of the Proposed Project Area located within a Historic District?
-      </dcpHistoricdistrictQ.Legend>
+      <Ui::Question
+      as |dcpStateczmQ|>
+        <dcpStateczmQ.Label>
+          Is any portion of the proposed Project Area located
+          within the State Designated Coastal Zone Management
+          (CZM) Area?
+        </dcpStateczmQ.Label>
 
-      <form.Field
-        @attribute="dcpHistoricdistrict"
-        @type="radio-group"
-      as |DcpHistoricdistrictRadioGroup|>
-        <DcpHistoricdistrictRadioGroup
-          @options={{optionset 'landuseForm' 'dcpHistoricdistrict' 'list'}}
-          @onChange={{fn (mut @form.data.dcpSitedatarenewalarea) ""}}
-        as |dcpHistoricdistrict|>
-          {{#if (eq
-            dcpHistoricdistrict
-            (optionset 'landuseForm' 'dcpHistoricdistrict' 'code' 'YES')
-          )}}
-            <Ui::Question
-            as |dcpSitedatarenewalareaQ|>
-              <dcpSitedatarenewalareaQ.Label>
-                Historic District Name
-              </dcpSitedatarenewalareaQ.Label>
+        <form.Field
+          @attribute="dcpStateczm"
+          @type="radio-group"
+        as |DcpStateczmRadioGroup|>
+          <DcpStateczmRadioGroup
+            @options={{optionset 'landuseForm' 'dcpStateczm' 'list'}}
+          />
+        </form.Field>
+      </Ui::Question>
 
-              <form.Field
-                @attribute="dcpSitedatarenewalarea"
-                @maxlength="60"
-                @showCounter={{true}}
-                id={{dcpSitedatarenewalareaQ.questionId}}
-              />
-            </Ui::Question>
-          {{/if}}
-        </DcpHistoricdistrictRadioGroup>
-      </form.Field>
-    </Ui::Question>
+      <Ui::Question
+      as |dcpHistoricdistrictQ|>
+        <dcpHistoricdistrictQ.Legend>
+          Is any portion of the Proposed Project Area located within a Historic District?
+        </dcpHistoricdistrictQ.Legend>
+
+        <form.Field
+          @attribute="dcpHistoricdistrict"
+          @type="radio-group"
+        as |DcpHistoricdistrictRadioGroup|>
+          <DcpHistoricdistrictRadioGroup
+            @options={{optionset 'landuseForm' 'dcpHistoricdistrict' 'list'}}
+            @onChange={{fn (mut @form.data.dcpSitedatarenewalarea) ""}}
+          as |dcpHistoricdistrict|>
+            {{#if (eq
+              dcpHistoricdistrict
+              (optionset 'landuseForm' 'dcpHistoricdistrict' 'code' 'YES')
+            )}}
+              <Ui::Question
+              as |dcpSitedatarenewalareaQ|>
+                <dcpSitedatarenewalareaQ.Label>
+                  Historic District Name
+                </dcpSitedatarenewalareaQ.Label>
+
+                <form.Field
+                  @attribute="dcpSitedatarenewalarea"
+                  @maxlength="60"
+                  @showCounter={{true}}
+                  id={{dcpSitedatarenewalareaQ.questionId}}
+                />
+              </Ui::Question>
+            {{/if}}
+          </DcpHistoricdistrictRadioGroup>
+        </form.Field>
+      </Ui::Question>
+    {{/if}}
   </form.Section>
 {{/let}}

--- a/client/app/components/packages/landuse-form/project-area.hbs
+++ b/client/app/components/packages/landuse-form/project-area.hbs
@@ -152,5 +152,73 @@
         </DcpWholeCityRadioGroup>
       </form.Field>
     </Ui::Question>
+
+    <Ui::Question
+    as |dcpZonesspecialdistrictsQ|>
+      <dcpZonesspecialdistrictsQ.Label>
+        What are the existing Zoning Districts and Special Districts?
+      </dcpZonesspecialdistrictsQ.Label>
+
+      <form.Field
+        @attribute="dcpZonesspecialdistricts"
+        @maxlength="300"
+        @showCounter={{true}}
+        id={{dcpZonesspecialdistrictsQ.questionId}}
+      />
+    </Ui::Question>
+
+    <Ui::Question
+    as |dcpStateczmQ|>
+      <dcpStateczmQ.Label>
+        Is any portion of the proposed Project Area located
+        within the State Designated Coastal Zone Management
+        (CZM) Area?
+      </dcpStateczmQ.Label>
+
+      <form.Field
+        @attribute="dcpStateczm"
+        @type="radio-group"
+      as |DcpStateczmRadioGroup|>
+        <DcpStateczmRadioGroup
+          @options={{optionset 'landuseForm' 'dcpStateczm' 'list'}}
+        />
+      </form.Field>
+    </Ui::Question>
+
+    <Ui::Question
+    as |dcpHistoricdistrictQ|>
+      <dcpHistoricdistrictQ.Legend>
+        Is any portion of the Proposed Project Area located within a Historic District?
+      </dcpHistoricdistrictQ.Legend>
+
+      <form.Field
+        @attribute="dcpHistoricdistrict"
+        @type="radio-group"
+      as |DcpHistoricdistrictRadioGroup|>
+        <DcpHistoricdistrictRadioGroup
+          @options={{optionset 'landuseForm' 'dcpHistoricdistrict' 'list'}}
+          @onChange={{fn (mut @form.data.dcpSitedatarenewalarea) ""}}
+        as |dcpHistoricdistrict|>
+          {{#if (eq
+            dcpHistoricdistrict
+            (optionset 'landuseForm' 'dcpHistoricdistrict' 'code' 'YES')
+          )}}
+            <Ui::Question
+            as |dcpSitedatarenewalareaQ|>
+              <dcpSitedatarenewalareaQ.Label>
+                Historic District Name
+              </dcpSitedatarenewalareaQ.Label>
+
+              <form.Field
+                @attribute="dcpSitedatarenewalarea"
+                @maxlength="60"
+                @showCounter={{true}}
+                id={{dcpSitedatarenewalareaQ.questionId}}
+              />
+            </Ui::Question>
+          {{/if}}
+        </DcpHistoricdistrictRadioGroup>
+      </form.Field>
+    </Ui::Question>
   </form.Section>
 {{/let}}

--- a/client/app/components/packages/landuse-form/project-tax-lots.hbs
+++ b/client/app/components/packages/landuse-form/project-tax-lots.hbs
@@ -1,5 +1,8 @@
 {{#let @form as |form|}}
-  <form.Section @title="Project Area Tax Lots">
+  <form.Section
+    @title="Project Area Tax Lots"
+    data-test-section="project-area-tax-lots"
+  >
     <p>
       Review and edit the Tax Lots listed below.
     </p>

--- a/client/app/components/packages/landuse-form/proposed-development-site.hbs
+++ b/client/app/components/packages/landuse-form/proposed-development-site.hbs
@@ -1,5 +1,8 @@
 {{#let @form as |form|}}
-  <form.Section @title="Proposed Development Site">
+  <form.Section
+    @title="Proposed Development Site"
+    data-test-section="proposed-development-site"
+  >
     <p>
       The <b>Development Site</b> is the specific parcel(s) that the Applicant is seeking to develop.
       A Project Area and Development Site can be the same parcels of land or different,

--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -66,6 +66,8 @@ const OPTIONSET_LOOKUP = {
     dcp500kpluszone: YES_NO,
     dcpDevsize: DCPDEVSIZE,
     dcpSitedatasiteisinnewyorkcity: YES_NO,
+    dcpStateczm: YES_NO,
+    dcpHistoricdistrict: YES_NO,
   },
   rwcdsForm: {
     dcpHasprojectchangedsincesubmissionofthepas: YES_NO,

--- a/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
@@ -128,9 +128,23 @@ module('Acceptance | user can click landuse form edit', function(hooks) {
 
     assert.dom('[data-test-input="dcpSitedatapropertydescription"]').exists();
 
+    assert.dom('[data-test-input="dcpZonesspecialdistricts"]').doesNotExist();
+    assert.dom('[data-test-radio="dcpStateczm"]').doesNotExist();
+    assert.dom('[data-test-radio="dcpHistoricdistrict"]').doesNotExist();
+    assert.dom('[data-test-input="dcpSitedatarenewalarea"]').doesNotExist();
+
     await click('[data-test-radio="dcpNotaxblock"][data-test-radio-option="No"]');
 
     assert.dom('[data-test-input="dcpSitedatapropertydescription"]').doesNotExist();
+
+    assert.dom('[data-test-input="dcpZonesspecialdistricts"]').exists();
+    assert.dom('[data-test-radio="dcpStateczm"]').exists();
+    assert.dom('[data-test-radio="dcpHistoricdistrict"]').exists();
+    assert.dom('[data-test-input="dcpSitedatarenewalarea"]').doesNotExist();
+
+    await click('[data-test-radio="dcpHistoricdistrict"][data-test-radio-option="Yes"]');
+
+    assert.dom('[data-test-input="dcpSitedatarenewalarea"]').exists();
 
     assert.equal(currentURL(), '/landuse-form/1/edit');
   });
@@ -401,12 +415,19 @@ module('Acceptance | user can click landuse form edit', function(hooks) {
     assert.equal(currentURL(), '/landuse-form/1/edit');
   });
 
-  test('User only sees Proposed Development Site and Project Tax Lots when project applies to partial area', async function(assert) {
+  test('User only sees last questions under Project Area, Proposed Development Site, Project Tax Lots when project applies to partial area', async function(assert) {
     this.server.create('project', 1, {
       packages: [this.server.create('package', 'toDo', 'landuseForm')],
     });
 
     await visit('/landuse-form/1/edit');
+
+    assert.dom('[data-test-input="dcpZonesspecialdistricts"]').doesNotExist();
+    assert.dom('[data-test-radio="dcpStateczm"]').doesNotExist();
+    assert.dom('[data-test-radio="dcpHistoricdistrict"]').doesNotExist();
+    assert.dom('[data-test-input="dcpSitedatarenewalarea"]').doesNotExist();
+    assert.dom('[data-test-section="proposed-development-site"]').doesNotExist();
+    assert.dom('[data-test-section="project-area-tax-lots"]').doesNotExist();
 
     assert.dom('[data-test-section="proposed-development-site"]').doesNotExist();
     assert.dom('[data-test-section="project-area-tax-lots"]').doesNotExist();
@@ -415,12 +436,25 @@ module('Acceptance | user can click landuse form edit', function(hooks) {
     await click('[data-test-radio="dcpEntiretyboroughs"][data-test-radio-option="No"]');
     await click('[data-test-radio="dcpEntiretycommunity"][data-test-radio-option="No"]');
 
+    assert.dom('[data-test-input="dcpZonesspecialdistricts"]').doesNotExist();
+    assert.dom('[data-test-radio="dcpStateczm"]').doesNotExist();
+    assert.dom('[data-test-radio="dcpHistoricdistrict"]').doesNotExist();
+    assert.dom('[data-test-input="dcpSitedatarenewalarea"]').doesNotExist();
     assert.dom('[data-test-section="proposed-development-site"]').doesNotExist();
     assert.dom('[data-test-section="project-area-tax-lots"]').doesNotExist();
 
     await click('[data-test-radio="dcpNotaxblock"][data-test-radio-option="No"]');
 
+    assert.dom('[data-test-input="dcpZonesspecialdistricts"]').exists();
+    assert.dom('[data-test-radio="dcpStateczm"]').exists();
+    assert.dom('[data-test-radio="dcpHistoricdistrict"]').exists();
     assert.dom('[data-test-section="proposed-development-site"]').exists();
     assert.dom('[data-test-section="project-area-tax-lots"]').exists();
+
+    assert.dom('[data-test-input="dcpSitedatarenewalarea"]').doesNotExist();
+
+    await click('[data-test-radio="dcpHistoricdistrict"][data-test-radio-option="Yes"]');
+
+    assert.dom('[data-test-input="dcpSitedatarenewalarea"]').exists();
   });
 });

--- a/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
@@ -197,6 +197,11 @@ module('Acceptance | user can click landuse form edit', function(hooks) {
 
     assert.dom('[data-test-submit-button]').hasNoAttribute('disabled');
 
+    await click('[data-test-radio="dcpWholecity"][data-test-radio-option="No"]');
+    await click('[data-test-radio="dcpEntiretyboroughs"][data-test-radio-option="No"]');
+    await click('[data-test-radio="dcpEntiretycommunity"][data-test-radio-option="No"]');
+    await click('[data-test-radio="dcpNotaxblock"][data-test-radio-option="No"]');
+
     await click('[data-test-radio="dcp500kpluszone"][data-test-radio-option="No"]');
 
     assert.dom('[data-test-submit-button]').hasNoAttribute('disabled');
@@ -394,5 +399,28 @@ module('Acceptance | user can click landuse form edit', function(hooks) {
     assert.equal(this.server.db.landuseForms.firstObject.dcpTypecategory, 'type category');
 
     assert.equal(currentURL(), '/landuse-form/1/edit');
+  });
+
+  test('User only sees Proposed Development Site and Project Tax Lots when project applies to partial area', async function(assert) {
+    this.server.create('project', 1, {
+      packages: [this.server.create('package', 'toDo', 'landuseForm')],
+    });
+
+    await visit('/landuse-form/1/edit');
+
+    assert.dom('[data-test-section="proposed-development-site"]').doesNotExist();
+    assert.dom('[data-test-section="project-area-tax-lots"]').doesNotExist();
+
+    await click('[data-test-radio="dcpWholecity"][data-test-radio-option="No"]');
+    await click('[data-test-radio="dcpEntiretyboroughs"][data-test-radio-option="No"]');
+    await click('[data-test-radio="dcpEntiretycommunity"][data-test-radio-option="No"]');
+
+    assert.dom('[data-test-section="proposed-development-site"]').doesNotExist();
+    assert.dom('[data-test-section="project-area-tax-lots"]').doesNotExist();
+
+    await click('[data-test-radio="dcpNotaxblock"][data-test-radio-option="No"]');
+
+    assert.dom('[data-test-section="proposed-development-site"]').exists();
+    assert.dom('[data-test-section="project-area-tax-lots"]').exists();
   });
 });


### PR DESCRIPTION
### Summary
There are four fields at the end of the Project Area section which haven't been added. They also only show up the answers to previous four questions (about applicability to city/borough/community/lot)  are all "No".

### Which major feature does this fit into?
[AB#12412](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12412) 

## Technical Explanation
- Builds off the commits from the PR for [AB#12413](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12413)
- Tests added
