### PR TITLE
Creeper mode: Force token spoofing to include a null NYC.ID GUID

### DIFF
--- a/server/src/auth.middleware.ts
+++ b/server/src/auth.middleware.ts
@@ -61,6 +61,10 @@ export class AuthMiddleware implements NestMiddleware {
     // these simulate the flow of authentication for the app
     const spoofedNycIdToken = jwt.sign({
       ...validatedToken,
+      // because #generateNewToken uses GUID to search for a user first, we should
+      // make this null so that the method then opts for e-mail-based search
+      // REDO: Remove implicit contact-search behavior from auth into separate methods
+      GUID: null,
       mail: creeperEmail,
     }, NYCID_TOKEN_SECRET);
     const spoofedZapToken = await this.authService.generateNewToken(spoofedNycIdToken);


### PR DESCRIPTION
Before, it was using the real user’s GUID, which is what the auth#generateNewToken method prefers. Now, this sets that as null
