### PR TITLE
Prefer NYC.ID firstname,lastname for contact records

### DIFF
--- a/client/app/templates/auth/register.hbs
+++ b/client/app/templates/auth/register.hbs
@@ -14,7 +14,7 @@
 </p>
 
 <a
-  href="{{get-env-variable 'NYCIDDomain'}}/account/register.htm?emailAddress={{this.loginEmail}}&hideSecurityQuestionFields=true&target={{nycid-target url=(get-env-variable 'NYCIDLocation')}}"
+  href="{{get-env-variable 'NYCIDDomain'}}/account/register.htm?emailAddress={{this.loginEmail}}&hideSecurityQuestionFields=true&target={{nycid-target url=(get-env-variable 'NYCIDLocation')}}&showNameFields=true"
   class="button text-weight-bold"
   target="_blank"
   rel="noreferrer noopener"

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -118,7 +118,13 @@ export class AuthService {
     const nycIdAccount = this.verifyNYCIDToken(NYCIDToken);
 
     // need the email to lookup a CRM contact.
-    const { mail, nycExtEmailValidationFlag, GUID } = nycIdAccount;
+    const {
+      mail,
+      nycExtEmailValidationFlag,
+      GUID,
+      givenName,
+      sn,
+    } = nycIdAccount;
 
     // REDO: all of this "has_crm_contact" stuff is confusing. these methods should just return null
     // if not found, and we need to find a better way to deal with missing crm records + nycid status
@@ -140,6 +146,16 @@ export class AuthService {
     if (nycExtEmailValidationFlag && !contact.dcp_nycid_guid) {
       await this.contactService.update(contact.contactid, {
         dcp_nycid_guid: GUID,
+        firstname: givenName,
+        lastname: sn,
+      });
+    }
+
+    // if the GUIDs match, prefer NYC.ID profile information
+    if (contact.dcp_nycid_guid === GUID && givenName && sn) {
+      await this.contactService.update(contact.contactid, {
+        firstname: givenName,
+        lastname: sn,
       });
     }
 


### PR DESCRIPTION
This change syncs the NYC.ID firstname/lastname information with CRM only if the GUIDs match.

This is to prevent any “mixing” issues that might happen with creeper mode.

A later refactor should find a safer way to deal with information synchronization, among other auth issues...

Closes [AB#12365](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12365)
