### PR TITLE
Show invitation button when user isn’t registered

### DIFF
--- a/client/app/components/project/project-editor-list-item.hbs
+++ b/client/app/components/project/project-editor-list-item.hbs
@@ -9,7 +9,7 @@
       <a href="mailto:{{@emailAddress}}">{{@emailAddress}}</a>
     </p>
 
-    {{#if @isRegistered}}
+    {{#unless @isRegistered}}
       <button
         class="button secondary tiny no-margin" {{on 'click' (toggle 'inviteTeamMemberModal' this)}}
         type="button"
@@ -17,7 +17,7 @@
         <FaIcon @icon="envelope" @prefix="fas" @fixedWidth={{true}} />
         SEND INVITATION
       </button>
-    {{/if}}
+    {{/unless}}
   </div>
 
   {{#if @canDelete}}


### PR DESCRIPTION
Not when they’re already registered

Addresses [AB#12455](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12455)

Change it back to `unless` bc lint prefers that? IDC as long as it's not a double negative!
