### PR TITLE
12355 Set up LU Housing Plans section

### DIFF
--- a/client/app/components/packages/landuse-form/edit.hbs
+++ b/client/app/components/packages/landuse-form/edit.hbs
@@ -64,6 +64,10 @@
         @validations={{this.validations}}
       />
 
+      <Packages::LanduseForm::HousingPlans
+        @form={{saveableForm}}
+      />
+
       <Packages::LanduseForm::AttachedDocuments
         @form={{saveableForm}}
         @model={{@package.landuseForm}}

--- a/client/app/components/packages/landuse-form/housing-plans.hbs
+++ b/client/app/components/packages/landuse-form/housing-plans.hbs
@@ -1,0 +1,103 @@
+{{#let @form as |form|}}
+  <form.Section
+    @title="Housing Plans"
+    data-test-section="housing-plans"
+  >
+    <p>
+      The following questions relate to Housing Plans,
+      Urban Renewal Areas, and Urban Development Action
+      Areas Program (UDAAP) and the follwoing Actions: HA,
+      HC, HD, HG, HN, HO, HP, HU
+
+    </p>
+
+    <Ui::Question
+    as |dcpDesignationQ|>
+      <dcpDesignationQ.Label>
+        Is a Designation being proposed?
+      </dcpDesignationQ.Label>
+
+      <form.Field
+        @attribute="dcpDesignation"
+        @type="radio-group"
+      as |DcpDesignationRadioGroup|>
+        <DcpDesignationRadioGroup
+          @options={{optionset 'landuseForm' 'dcpDesignation' 'list'}}
+        />
+      </form.Field>
+    </Ui::Question>
+
+    <Ui::Question
+    as |dcpProjecthousingplanudaapQ|>
+      <dcpProjecthousingplanudaapQ.Label>
+        Is a Housing Project Plan being proposed?
+      </dcpProjecthousingplanudaapQ.Label>
+
+      <form.Field
+        @attribute="dcpProjecthousingplanudaap"
+        @type="radio-group"
+      as |DcpProjecthousingplanudaapRadioGroup|>
+        <DcpProjecthousingplanudaapRadioGroup
+          @options={{optionset 'landuseForm' 'dcpProjecthousingplanudaap' 'list'}}
+        />
+      </form.Field>
+    </Ui::Question>
+
+    <Ui::Question
+    as |dcpDispositionQ|>
+      <dcpDispositionQ.Label>
+        Is a Disposition being proposed?
+      </dcpDispositionQ.Label>
+
+      <form.Field
+        @attribute="dcpDisposition"
+        @type="radio-group"
+      as |DcpDispositionRadioGroup|>
+        <DcpDispositionRadioGroup
+          @options={{optionset 'landuseForm' 'dcpDisposition' 'list'}}
+        as |dcpDisposition|>
+          {{#if (eq
+            dcpDisposition
+            (optionset 'landuseForm' 'dcpDisposition' 'code' 'YES')
+          )}}
+            <Ui::Question
+            as |dcpMannerofdispositionQ|>
+              <dcpMannerofdispositionQ.Label>
+                Manner of Disposition
+              </dcpMannerofdispositionQ.Label>
+
+              <form.Field
+                @attribute="dcpMannerofdisposition"
+                @type="radio-group"
+              as |DcpMannerofdispositionRadioGroup|>
+                <DcpMannerofdispositionRadioGroup
+                  @options={{optionset 'landuseForm' 'dcpMannerofdisposition' 'list'}}
+                />
+              </form.Field>
+            </Ui::Question>
+
+            <Ui::Question
+            as |dcpRestrictandconditionQ|>
+              <dcpRestrictandconditionQ.Label>
+                Restrictions and Conditions
+              </dcpRestrictandconditionQ.Label>
+              <p class="text-small">
+                If there are restrictions, attach a project description
+                in the documents section that describes the restrictions.
+              </p>
+
+              <form.Field
+                @attribute="dcpRestrictandcondition"
+                @type="radio-group"s
+              as |DcpRestrictandconditionRadioGroup|>
+                <DcpRestrictandconditionRadioGroup
+                  @options={{optionset 'landuseForm' 'dcpRestrictandcondition' 'list'}}
+                />
+              </form.Field>
+            </Ui::Question>
+          {{/if}}
+        </DcpDispositionRadioGroup>
+      </form.Field>
+    </Ui::Question>
+  </form.Section>
+{{/let}}

--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -15,10 +15,7 @@ import {
   AFFECTED_ZONING_RESOLUTION_ACTION,
 } from '../optionsets/affected-zoning-resolution';
 import PACKAGE_OPTIONSETS from '../optionsets/package';
-import {
-  CEQR_TYPE,
-  DCPDEVSIZE,
-} from '../optionsets/landuse-form';
+import LANDUSE_FORM_OPTIONSETS from '../optionsets/landuse-form';
 import {
   DCPCONSTRUCTIONPHASING,
 } from '../optionsets/rwcds-form';
@@ -58,16 +55,21 @@ const OPTIONSET_LOOKUP = {
     statuscode: PROJECT_OPTIONSETS.STATUSCODE,
   },
   landuseForm: {
-    dcpCeqrtype: CEQR_TYPE,
+    dcpCeqrtype: LANDUSE_FORM_OPTIONSETS.CEQR_TYPE,
     dcpWholecity: YES_NO,
     dcpEntiretyboroughs: YES_NO,
     dcpEntiretycommunity: YES_NO,
     dcpNotaxblock: YES_NO,
     dcp500kpluszone: YES_NO,
-    dcpDevsize: DCPDEVSIZE,
+    dcpDevsize: LANDUSE_FORM_OPTIONSETS.DCPDEVSIZE,
     dcpSitedatasiteisinnewyorkcity: YES_NO,
     dcpStateczm: YES_NO,
     dcpHistoricdistrict: YES_NO,
+    dcpDesignation: LANDUSE_FORM_OPTIONSETS.DCPDESIGNATION,
+    dcpDisposition: LANDUSE_FORM_OPTIONSETS.DCPDISPOSITION,
+    dcpProjecthousingplanudaap: LANDUSE_FORM_OPTIONSETS.DCPPROJECTHOUSINGPLANUDAAP,
+    dcpMannerofdisposition: LANDUSE_FORM_OPTIONSETS.DCPMANNEROFDISPOSITION,
+    dcpRestrictandcondition: LANDUSE_FORM_OPTIONSETS.DCPRESTRICTANDCONDITION,
   },
   rwcdsForm: {
     dcpHasprojectchangedsincesubmissionofthepas: YES_NO,

--- a/client/app/models/landuse-form.js
+++ b/client/app/models/landuse-form.js
@@ -69,6 +69,16 @@ export default class LanduseFormModel extends Model {
 
   @attr dcpSitedataidentifylandmark;
 
+  @attr dcpDesignation;
+
+  @attr dcpProjecthousingplanudaap;
+
+  @attr dcpDisposition;
+
+  @attr dcpMannerofdisposition;
+
+  @attr dcpRestrictandcondition;
+
   @attr dcpLeadagency;
 
   @attr dcpCeqrnumber;

--- a/client/app/optionsets/common.js
+++ b/client/app/optionsets/common.js
@@ -38,3 +38,11 @@ export const YES_NO_DONT_KNOW = {
     label: 'Don\u2019t Know',
   },
 };
+
+const COMMON_OPTIONSETS = {
+  YES_NO,
+  YES_NO_UNSURE,
+  YES_NO_DONT_KNOW,
+};
+
+export default COMMON_OPTIONSETS;

--- a/client/app/optionsets/landuse-form.js
+++ b/client/app/optionsets/landuse-form.js
@@ -1,3 +1,5 @@
+import COMMON_OPTIONSETS from './common';
+
 export const CEQR_TYPE = {
   TYPE_I: {
     code: 717170000,
@@ -27,3 +29,70 @@ export const DCPDEVSIZE = {
     label: 'At least 2,500,000 zoning sq ft',
   },
 };
+
+export const DCPMANNEROFDISPOSITION = {
+  GENERAL: {
+    code: 717170000,
+    label: 'General',
+  },
+  DIRECT: {
+    code: 717170001,
+    label: 'Direct',
+  },
+};
+
+const DCPRESTRICTANDCONDITION = {
+  NONE: {
+    code: 717170000,
+    label: 'None (Pursuant to Zoning)',
+  },
+  RESTRICTED: {
+    code: 717170001,
+    label: 'Restricted',
+  },
+};
+
+export const DCPDESIGNATION = {
+  YES: {
+    code: COMMON_OPTIONSETS.YES_NO.YES.code,
+    label: 'Yes (HA, HN, HG, possibly HU)',
+  },
+  NO: {
+    code: COMMON_OPTIONSETS.YES_NO.NO.code,
+    label: 'No (HC, HD, HO, HP, possibly HU)',
+  },
+};
+
+export const DCPPROJECTHOUSINGPLANUDAAP = {
+  YES: {
+    code: COMMON_OPTIONSETS.YES_NO.YES.code,
+    label: 'Yes (HA, HN, HG)',
+  },
+  NO: {
+    code: COMMON_OPTIONSETS.YES_NO.NO.code,
+    label: 'No (HC, HD, HO, HP, HU)',
+  },
+};
+
+export const DCPDISPOSITION = {
+  YES: {
+    code: COMMON_OPTIONSETS.YES_NO.YES.code,
+    label: 'Yes (HA, HD)',
+  },
+  NO: {
+    code: COMMON_OPTIONSETS.YES_NO.NO.code,
+    label: 'No (HC, HD, HG, HN, HO, HP, HU)',
+  },
+};
+
+const LANDUSE_FORM_OPTIONSETS = {
+  CEQR_TYPE,
+  DCPDEVSIZE,
+  DCPMANNEROFDISPOSITION,
+  DCPRESTRICTANDCONDITION,
+  DCPDESIGNATION,
+  DCPPROJECTHOUSINGPLANUDAAP,
+  DCPDISPOSITION,
+};
+
+export default LANDUSE_FORM_OPTIONSETS;

--- a/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
@@ -292,6 +292,30 @@ module('Acceptance | user can click landuse form edit', function(hooks) {
     assert.equal(this.server.db.relatedActions.firstObject.dcpReferenceapplicationno, '12345678');
   });
 
+  test('User can fill out and save first part of Housing Plans', async function(assert) {
+    this.server.create('project', 1, {
+      packages: [this.server.create('package', 'toDo', 'landuseForm')],
+    });
+
+    await visit('/landuse-form/1/edit');
+
+    await click('[data-test-radio="dcpDesignation"][data-test-radio-option="No (HC, HD, HO, HP, possibly HU)"]');
+    await click('[data-test-radio="dcpDesignation"][data-test-radio-option="Yes (HA, HN, HG, possibly HU)"]');
+
+    await click('[data-test-radio="dcpProjecthousingplanudaap"][data-test-radio-option="No (HC, HD, HO, HP, HU)"]');
+    await click('[data-test-radio="dcpProjecthousingplanudaap"][data-test-radio-option="Yes (HA, HN, HG)"]');
+
+    await click('[data-test-radio="dcpDisposition"][data-test-radio-option="No (HC, HD, HG, HN, HO, HP, HU)"]');
+
+    assert.dom('[data-test-radio="dcpMannerofdisposition"]').doesNotExist();
+    assert.dom('[data-test-radio="dcpRestrictandcondition"]').doesNotExist();
+
+    await click('[data-test-radio="dcpDisposition"][data-test-radio-option="Yes (HA, HD)"]');
+
+    assert.dom('[data-test-radio="dcpMannerofdisposition"]').exists();
+    assert.dom('[data-test-radio="dcpRestrictandcondition"]').exists();
+  });
+
   test('user can remove applicants on landuse form', async function(assert) {
     const project = this.server.create('project', 1, {
       packages: [this.server.create('package', 'toDo', 'landuseForm')],


### PR DESCRIPTION
### Summary
Sets up the first part of the LU Housing Plans section. This first part only PATCHes to dcp_landuse, and not another entity (like dcp_sitedatahform)

### Which major feature does this fit into?
Land Use -- House Plans
Fixes [AB#12355](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12355)

## Technical Explanation — How does it work?
- Very similar to previous components with cascading forms.
- For these housing plan optionsets, I extended them from COMMON_OPTIONSETS.YES_NO optionsets.
These housing plan optionsets are essentially YES_NO optionsets; they share the same code values but have a slightly customized labels.
