### PR TITLE
Auth Middleware should throw unauthenticated

### DIFF
--- a/server/src/auth.middleware.ts
+++ b/server/src/auth.middleware.ts
@@ -1,4 +1,4 @@
-import { Injectable, NestMiddleware } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable, NestMiddleware } from '@nestjs/common';
 import * as jwt from 'jsonwebtoken';
 import { AuthService } from './auth/auth.service';
 import { ConfigService } from './config/config.service';
@@ -48,7 +48,13 @@ export class AuthMiddleware implements NestMiddleware {
 
       next();
     } catch (e) {
-      next();
+      const error = {
+        code: "INVALID_TOKEN",
+        title: "Invalid token",
+        detail: `Could not verify token. ${e}`,
+      };
+      console.log(error);
+      throw new HttpException(error, HttpStatus.UNAUTHORIZED);
     }
   }
 

--- a/server/src/packages/package-access.guard.ts
+++ b/server/src/packages/package-access.guard.ts
@@ -41,10 +41,14 @@ export class PackageAccessGuard implements CanActivate {
       return true;
     }
 
+    // note that this could return either true or false — false would
+    // trigger the default Nest HTTP exception
     if (contactId) {
       return this.isOnApplicantTeam(packageId, contactId);
     }
 
+    // If for some reason, there is no contact ID, it will throw this exception, which is
+    // incorrect — implicitly, no contact ID means it's unauthenticated, not unauthorized
     throw new HttpException({
       code: "NO_PACKAGE_ACCESS",
       title: "No access to package",


### PR DESCRIPTION
@godfreyyeung IDK how much I Like this.

This change makes the auth middleware throw a 401 if the validation step fails, which makes sense.

The problem was that the packages guard was throwing a 403 when the session didn't have a contactId. This is the wrong error code. It should have been throwing a 401 earlier in the lifeceycle (either middleware or a pipe). 