### PR TITLE
💄 Contact MGMT UI

### DIFF
--- a/client/app/controllers/project.js
+++ b/client/app/controllers/project.js
@@ -6,6 +6,8 @@ import { optionset } from '../helpers/optionset';
 import { STATECODE, STATUSCODE } from '../optionsets/contact';
 
 export default class ProjectController extends Controller {
+  @tracked contactMgmtOpen = false;
+
   @tracked addEditorModalOpen;
 
   @tracked emailAddress;
@@ -20,6 +22,11 @@ export default class ProjectController extends Controller {
   get matchingCurrentApplicant() {
     const currentApplicants = this.project.projectApplicants;
     return currentApplicants.find((applicant) => applicant.emailaddress === this.emailAddress);
+  }
+
+  @action
+  toggleContactMgmt() {
+    this.contactMgmtOpen = !this.contactMgmtOpen;
   }
 
   @action

--- a/client/app/templates/project.hbs
+++ b/client/app/templates/project.hbs
@@ -58,79 +58,75 @@
     {{/if}}
 
   </div>{{! end left/main column }}
-  <div class="cell large-4 sticky-sidebar">
+  <div class="cell large-4">
 
     <h3>
       Project Editors
       <FaIcon @icon='users-cog' @fixedWidth={{true}} />
     </h3>
+
     <ul class="no-bullet">
       {{#each this.project.projectApplicants as |projectApplicant|}}
         {{#if (and (eq projectApplicant.contact.statuscode this.contactActiveStatusCode) (eq projectApplicant.contact.statecode this.contactActiveStateCode))}}
-          <Project::ProjectEditorListItem 
+          <Project::ProjectEditorListItem
             @name={{projectApplicant.displayName}}
             @emailAddress={{projectApplicant.email}}
             @isRegistered={{projectApplicant.contact.dcpNycidGuid}}
             @projectName={{this.project.dcpProjectname}}
-            @canDelete={{not projectApplicant.isPrimaryApplicantOrContact}}
+            @canDelete={{and (not projectApplicant.isPrimaryApplicantOrContact) this.contactMgmtOpen}}
             @onDelete={{fn this.removeEditor projectApplicant}}
           />
         {{/if}}
       {{/each}}
     </ul>
 
-    <Ui::Question
-      class="fieldset relative"
-      ...attributes
-      as |Q|
-    >
+    {{#if this.contactMgmtOpen}}
+      <h4>Add Project Editor:</h4>
 
-      <div class="grid-x grid-margin-x">
-        <div class="cell medium-6">
-          <Q.Label class="middle">
-            First Name
-          </Q.Label>
+      <fieldset class="--fieldset">
+        <label>
+          First Name
           <Input
             @type="text"
             autocomplete="off"
             @value={{this.firstName}}
           />
-        </div>
-      </div>
+        </label>
 
-      <div class="grid-x grid-margin-x">
-        <div class="cell medium-6">
-          <Q.Label class="middle">
-            Last Name
-          </Q.Label>
+        <label>
+          Last Name
           <Input
             @type="text"
             autocomplete="off"
             @value={{this.lastName}}
           />
-        </div>
-      </div>
+        </label>
 
-      <div class="grid-x grid-margin-x">
-        <div class="cell medium-6">
-          <Q.Label class="middle">
-            Email Address
-          </Q.Label>
+        <label>
+          Email Address
           <Input
             @type="text"
             autocomplete="off"
             @value={{this.emailAddress}}
           />
-        </div>
-      </div>
-    </Ui::Question>
+        </label>
+
+        <button
+          class="button expanded text-weight-bold"
+          type="button"
+          {{on "click" (fn this.addEditor) }}
+        >
+          Add Project Editor
+        </button>
+      </fieldset>
+    {{/if}}
 
     <button
-      class="button expanded secondary no-margin"
       type="button"
-      {{on "click" (fn this.addEditor) }}
+      class="button expanded secondary"
+      {{on "click" (fn this.toggleContactMgmt) }}
     >
-      <strong>Add Project Editor</strong>
+      {{if this.contactMgmtOpen 'Cancel' 'Manage Project Editors'}}
     </button>
 
     <Ui::ConfirmationModal
@@ -142,7 +138,7 @@
         <h4>A Project Editor with the email address you entered already exists on this project.</h4>
       {{else}}
         <h4>Are you sure you want to add...</h4>
-        <Project::ProjectEditorListItem 
+        <Project::ProjectEditorListItem
           @name="{{this.firstName}} {{this.lastName}}"
           @emailAddress={{this.emailAddress}}
         />


### PR DESCRIPTION
This PR… 
- Cleans up the Contact MGMT UI
- Adds a `contactMgmtOpen` var, a `toggleContactMgmt()` function, and a button to enable/disable editing Project Editors
- Make the sidebar scroll with page (not sticky like form menus)
- Removes crufty grid and Q markup from "Add Project Editors" form