### PR TITLE
12355 Conditionally display housing-related Land Use sections

### DIFF
--- a/client/app/components/packages/landuse-form/edit.hbs
+++ b/client/app/components/packages/landuse-form/edit.hbs
@@ -69,9 +69,16 @@
         @validations={{this.validations}}
       />
 
-      <Packages::LanduseForm::HousingPlans
-        @form={{saveableForm}}
-      />
+      {{#let (intersect
+        (map-by "dcpActioncode" this.landuseForm.landuseActions)
+        (array 'HA' 'HC' 'HD' 'HG' 'HN' 'HO' 'HP' 'HU')
+      ) as |projectHousingActions|}}
+        {{#if (gt projectHousingActions.length 0)}}
+          <Packages::LanduseForm::HousingPlans
+            @form={{saveableForm}}
+          />
+        {{/if}}
+      {{/let}}
 
       <Packages::LanduseForm::AttachedDocuments
         @form={{saveableForm}}


### PR DESCRIPTION
### Summary 
Only display the Housing Plans and Subject Sites (to be set up in future PR) sections if the Project Land Use Actions includes a certain set of action codes.

### Feature
Land Use - Housing Plans and Subject Sites 
[AB#12355](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12355) 

### Technical Details
We write the logic in `landuse-form/edit.hbs` because multiple sections/components (Housing Plans and Subject Sites) will be toggled based on the condition.