### PR TITLE
Use NYC.ID oauth user endpoint; create synchronize method

### DIFF
--- a/client/app/authenticators/zap-api-authenticator.js
+++ b/client/app/authenticators/zap-api-authenticator.js
@@ -17,15 +17,12 @@ export default class ZAPAuthenticator extends OAuth2ImplicitGrantAuthenticator {
     }
 
     let attemptedLoginEmail = '';
+    const NYCIDUser = jwtDecode(accessToken);
 
     // attempt to decode the token to include email address for debugging
-    try {
-      const { mail } = jwtDecode(accessToken);
+    const { mail } = NYCIDUser;
 
-      attemptedLoginEmail = mail;
-    } catch (e) {
-      console.log('Failed to decode the JWT', e);
-    }
+    attemptedLoginEmail = mail;
 
     // Pass the NYCIDToken to backend /login endpoint.
     // Server should provide an access_token used for signing
@@ -39,6 +36,9 @@ export default class ZAPAuthenticator extends OAuth2ImplicitGrantAuthenticator {
     // Returning the session data's "authenticated" property and marks
     // the session as authenticated.
     // See: https://ember-simple-auth.com/api/classes/SessionService.html
-    return body;
+    return {
+      ...body,
+      ...NYCIDUser,
+    };
   }
 }

--- a/client/app/components/auth/user-badge.js
+++ b/client/app/components/auth/user-badge.js
@@ -10,15 +10,17 @@ export default class UserBadgeComponent extends Component {
 
   @service router;
 
-  get currentHref() {
-    return window.location.href;
+  get redirectTarget() {
+    const { origin } = window.location;
+
+    return `${origin}/auth/sync?to=${window.location.pathname}`;
   }
 
   get userProfileURI() {
     const { origin } = new URL(ENV.NYCIDLocation || 'https://accounts-nonprd.nyc.gov');
 
     // base64 is a requirement of NYC.ID — target value must be Base64-encoded
-    return `${origin}/account/user/profile.htm?returnOnSave=true&target=${encodeToBase64(this.currentHref)}`;
+    return `${origin}/account/user/profile.htm?returnOnSave=true&target=${encodeToBase64(this.redirectTarget)}`;
   }
 
   @action

--- a/client/app/router.js
+++ b/client/app/router.js
@@ -29,5 +29,6 @@ Router.map(function() {
     this.route('login');
     this.route('register');
     this.route('validate');
+    this.route('sync');
   });
 });

--- a/client/app/routes/auth/sync.js
+++ b/client/app/routes/auth/sync.js
@@ -1,0 +1,23 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class AuthSyncRoute extends Route {
+  @service
+  session;
+
+  queryParams = {
+    to: {},
+  };
+
+  async model({ to }) {
+    const { authenticated } = this.session.data;
+
+    const contact = await this.store.findRecord('contact', authenticated.contactId);
+
+    if (document.referrer.includes('/account/user/profile.htm?returnOnSave=true')) {
+      await contact.save();
+
+      this.transitionTo(to);
+    }
+  }
+}

--- a/client/app/routes/auth/sync.js
+++ b/client/app/routes/auth/sync.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import window from 'ember-window-mock';
 
 export default class AuthSyncRoute extends Route {
   @service
@@ -9,12 +10,12 @@ export default class AuthSyncRoute extends Route {
     to: {},
   };
 
-  async model({ to }) {
+  async model({ to = '/' }) {
     const { authenticated } = this.session.data;
 
     const contact = await this.store.findRecord('contact', authenticated.contactId);
 
-    if (document.referrer.includes('/account/user/profile.htm?returnOnSave=true')) {
+    if (window.document.referrer.includes('/account/user/profile.htm?returnOnSave=true')) {
       await contact.save();
 
       this.transitionTo(to);

--- a/client/tests/acceptance/user-can-login-test.js
+++ b/client/tests/acceptance/user-can-login-test.js
@@ -13,6 +13,8 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { currentSession } from 'ember-simple-auth/test-support';
 import { Response } from 'ember-cli-mirage';
 
+const DUMMY_TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+
 module('Acceptance | user can login', function(hooks) {
   setupApplicationTest(hooks);
   setupWindowMock(hooks);
@@ -23,10 +25,10 @@ module('Acceptance | user can login', function(hooks) {
 
     this.server.create('contact');
     this.server.get('/login', (schema, request) => {
-      assert.equal(request.queryParams.accessToken, 'a-valid-jwt');
+      assert.equal(request.queryParams.accessToken, DUMMY_TOKEN);
     });
 
-    window.location.hash = '#access_token=a-valid-jwt';
+    window.location.hash = `#access_token=${DUMMY_TOKEN}`;
     await visit('/login');
 
     assert.equal(currentSession().isAuthenticated, true);
@@ -37,7 +39,7 @@ module('Acceptance | user can login', function(hooks) {
 
     this.server.create('contact');
 
-    window.location.hash = '#access_token=a-valid-jwt';
+    window.location.hash = `#access_token=${DUMMY_TOKEN}`;
     await visit('/login');
     await focus('[data-test-auth="menu-button"]');
     await click('[data-test-auth="logout"]');
@@ -47,7 +49,7 @@ module('Acceptance | user can login', function(hooks) {
   });
 
   test('User sees error message if no CRM contact is found for their email', async function (assert) {
-    const accessToken = 'a-valid-jwt';
+    const accessToken = DUMMY_TOKEN;
     this.server.create('contact');
     this.server.get('/login', () => new Response(401, { some: 'header' }, {
       errors: [{
@@ -69,9 +71,9 @@ module('Acceptance | user can login', function(hooks) {
     // user logs in
     this.server.create('contact');
     this.server.get('/login', (schema, request) => {
-      assert.equal(request.queryParams.accessToken, 'a-valid-jwt');
+      assert.equal(request.queryParams.accessToken, DUMMY_TOKEN);
     });
-    window.location.hash = '#access_token=a-valid-jwt';
+    window.location.hash = `#access_token=${DUMMY_TOKEN}`;
     await visit('/login');
 
     // because user is already logged in, route should redirect to /projects
@@ -102,7 +104,7 @@ module('Acceptance | user can login', function(hooks) {
       isNycidEmailRegistered: true,
     });
 
-    window.location.hash = '#access_token=a-valid-jwt';
+    window.location.hash = `#access_token=${DUMMY_TOKEN}`;
     try {
       await visit('/login');
     } catch (e) {

--- a/client/tests/unit/routes/auth/sync-test.js
+++ b/client/tests/unit/routes/auth/sync-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | auth/sync', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:auth/sync');
+    assert.ok(route);
+  });
+});

--- a/server/src/app.controller.ts
+++ b/server/src/app.controller.ts
@@ -27,6 +27,7 @@ export class AppController {
       res.send({
         access_token: ZAPToken,
         emailaddress1,
+        contactId,
       });
     } catch (e) {
       if (e instanceof HttpException) {

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -4,7 +4,6 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import * as jwt from 'jsonwebtoken';
-import * as moment from 'moment';
 import { ConfigService } from '../config/config.service';
 import { ContactService } from '../contact/contact.service';
 
@@ -41,16 +40,7 @@ export class AuthService {
     nycIdAccount: any = {},
   ): string {
     const { ZAP_TOKEN_SECRET } = this;
-    const {
-      nycExtTOUVersion,
-      mail,
-      scope,
-      nycExtEmailValidationFlag,
-      GUID,
-      userType,
-      exp,
-      jti,
-    } = nycIdAccount;
+    const { exp, ...everythingElse } = nycIdAccount;
 
     return jwt.sign({
       // JWT standard name for expiration - see https://github.com/auth0/node-jsonwebtoken#token-expiration-exp-claim
@@ -60,13 +50,7 @@ export class AuthService {
       contactId,
 
       // additional NYC.ID account information
-      nycExtTOUVersion,
-      mail,
-      scope,
-      nycExtEmailValidationFlag,
-      GUID,
-      userType,
-      jti,
+      ...everythingElse
     }, ZAP_TOKEN_SECRET);
   }
 
@@ -160,7 +144,10 @@ export class AuthService {
       });
     }
 
-    return this.signNewToken(contact.contactid, nycIdAccount);
+    return this.signNewToken(contact.contactid, {
+      NYCIDToken, // include the token for later authorization
+      ...nycIdAccount,
+    });
   }
 
   /**

--- a/server/src/contact/contact.service.ts
+++ b/server/src/contact/contact.service.ts
@@ -139,6 +139,18 @@ export class ContactService {
     return this.crmService.update('contacts', id, allowedAttrs);
   }
 
+  public async synchronize(contactId, accessToken) {
+    const {
+      firstName,
+      lastName,
+    } = await this.nycid.getNycidOAuthUser(accessToken);
+
+    return this.update(contactId, {
+      firstname: firstName,
+      lastname: lastName,
+    });
+  }
+
   public async create(body: object) {
     const allowedAttrs = pick(body, CONTACT_ATTRS);
 

--- a/server/src/crm/crm.service.ts
+++ b/server/src/crm/crm.service.ts
@@ -344,7 +344,7 @@ export class CrmService {
 
           }
         }
-        else resolve();
+        else resolve(body);
       })
     });
   }


### PR DESCRIPTION
Addresses [AB#12365](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12365) 

This PR makes sure that the first and last names of CRM contacts are synced to the respective values in NYCID, after a user has edited their profile on NYCID. 

Includes a new client auth route, "sync", which is the redirect location after a user updates the profile on NYCID. 
The route infers that the user has updated their profile if the browser "referrer" is the NYC.ID user profile edit page. If so, it triggers new backend methods to request the updated user first and last name from NYCID, and then send the info to CRM.

The sync route does so by triggering the save() method on the contact model. The save() method hits a new backend Contact PATCH endpoint, which eventually calls a new backend method `getNycidOAuthUser`.  That method calling the OAuth-based "user" endpoint, which returns an updated user profile. It requires the user's accessToken to authenticate the request. So, we include this with the session information, which itself is encrypted.

After acquiring the updated user profile, the info is sent to CRM via the CRM Web API. 
