### PR TITLE
Contact MGMT improvements

### DIFF
--- a/client/app/components/project/project-editor-list-item.hbs
+++ b/client/app/components/project/project-editor-list-item.hbs
@@ -1,6 +1,17 @@
 <li class="grid-x medium-margin-bottom">
   <div class="cell shrink small-padding-right">
-    <FaIcon @icon='user' @fixedWidth={{true}} @transform='down-1' class="text-gray" />
+    {{#if @canDelete}}
+      <button
+        type="button"
+        class="text-red-dim"
+        {{on "click" this.tryRemoveEditor}}
+      >
+        <FaIcon @icon="times" @prefix="fas" @fixedWidth={{true}} />
+        <EmberTooltip @isShown={{true}} @duration={{1000}} @side="left">Remove</EmberTooltip>
+      </button>
+    {{else}}
+      <FaIcon @icon='user' @fixedWidth={{true}} @transform='down-1' class="text-gray" />
+    {{/if}}
   </div>
   <div class="cell auto">
     <h5 class="no-margin">{{@name}}</h5>
@@ -25,18 +36,6 @@
       </button>
     {{/unless}}
   </div>
-
-  {{#if @canDelete}}
-    <div class="cell shrink medium-padding-left">
-      <button
-        type="button"
-        class="text-red-dim"
-        {{on "click" this.tryRemoveEditor}}
-      >
-        <FaIcon @icon="times" @prefix="fas" @fixedWidth={{true}} />
-      </button>
-    </div>
-  {{/if}}
 </li>
 
 <Ui::GenericModal

--- a/client/app/controllers/project.js
+++ b/client/app/controllers/project.js
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { optionset } from '../helpers/optionset';
 import { STATECODE, STATUSCODE } from '../optionsets/contact';
+import ENV from '../config/environment';
 
 export default class ProjectController extends Controller {
   @tracked contactMgmtOpen = false;
@@ -15,6 +16,8 @@ export default class ProjectController extends Controller {
   @tracked firstName;
 
   @tracked lastName;
+
+  contactMgmtEnabled = ENV.APP.contactMgmtEnabled;
 
   @service
   store;

--- a/client/app/templates/project.hbs
+++ b/client/app/templates/project.hbs
@@ -5,181 +5,213 @@
 
 <div class="grid-x grid-padding-x">
   <div class="cell large-8">
-    <h1>
-      {{@model.dcpProjectname}}
-    </h1>
+    <section class="large-padding-top large-margin-bottom ruled-adjacent">
+      <h1>
+        {{@model.dcpProjectname}}
+      </h1>
 
-    <p>
-      <strong>Project Number:</strong> {{@model.dcpName}}
-    </p>
+      <p>
+        <strong>Project Number:</strong> {{@model.dcpName}}
+      </p>
 
-    <p>
-      <strong>Primary Applicant:</strong> {{@model.dcpApplicantCustomerValue}}
-    </p>
+      <p>
+        <strong>Primary Applicant:</strong> {{@model.dcpApplicantCustomerValue}}
+      </p>
 
-    <p>
-      <strong>Project Status:</strong> {{optionset 'project' 'statuscode' 'label' @model.statuscode}}
-      <span class="text-gray"> | </span>
-      <strong>Public Status:</strong>
-      <FaIcon @icon={{if @model.publicStatusGeneralPublicProject 'eye' 'eye-slash'}} @prefix="far" class="text-gray"/>
-      {{#if @model.publicStatusGeneralPublicProject}}
-        <Ui::ExternalLink @href="https://zap.planning.nyc.gov/projects/{{@model.dcpName}}"> {{optionset 'project' 'dcpPublicstatus' 'label' @model.dcpPublicstatus}} </Ui::ExternalLink>
-      {{else}}
-        {{optionset 'project' 'dcpPublicstatus' 'label' @model.dcpPublicstatus}}
-      {{/if}}
-    </p>
+      <p>
+        <strong>Project Status:</strong> {{optionset 'project' 'statuscode' 'label' @model.statuscode}}
+        <span class="text-gray"> | </span>
+        <strong>Public Status:</strong>
+        <FaIcon @icon={{if @model.publicStatusGeneralPublicProject 'eye' 'eye-slash'}} @prefix="far" class="text-gray"/>
+        {{#if @model.publicStatusGeneralPublicProject}}
+          <Ui::ExternalLink @href="https://zap.planning.nyc.gov/projects/{{@model.dcpName}}"> {{optionset 'project' 'dcpPublicstatus' 'label' @model.dcpPublicstatus}} </Ui::ExternalLink>
+        {{else}}
+          {{optionset 'project' 'dcpPublicstatus' 'label' @model.dcpPublicstatus}}
+        {{/if}}
+      </p>
 
-    <p>
-      <strong>Project Brief:</strong> {{@model.dcpProjectbrief}}
-    </p>
+      <p>
+        <strong>Project Brief:</strong> {{@model.dcpProjectbrief}}
+      </p>
 
-    <hr>
+    </section>
 
     {{#if @model.rwcdsPackages.length}}
-      <h2>Reasonable Worst Case Development Scenario</h2>
-      <ol class="no-bullet">
-        {{#each @model.rwcdsPackages as |rwcdsPackage|}}
-          <Project::PackageListItem
-            @package={{rwcdsPackage}}
-          />
-        {{/each}}
-      </ol>
+      <section class="large-padding-top large-margin-bottom ruled-adjacent">
+        <h2>Reasonable Worst Case Development Scenario</h2>
+        <ol class="no-bullet">
+          {{#each @model.rwcdsPackages as |rwcdsPackage|}}
+            <Project::PackageListItem
+              @package={{rwcdsPackage}}
+            />
+          {{/each}}
+        </ol>
+      </section>
     {{/if}}
 
     {{#if @model.pasPackages.length}}
-      <h2>Pre-Application Statement</h2>
-      <ol class="no-bullet">
-        {{#each @model.pasPackages as |pasPackage|}}
-          <Project::PackageListItem
-            @package={{pasPackage}}
-          />
-        {{/each}}
-      </ol>
+      <section class="large-padding-top large-margin-bottom ruled-adjacent">
+        <h2>Pre-Application Statement</h2>
+        <ol class="no-bullet">
+          {{#each @model.pasPackages as |pasPackage|}}
+            <Project::PackageListItem
+              @package={{pasPackage}}
+            />
+          {{/each}}
+        </ol>
+      </section>
     {{/if}}
 
   </div>{{! end left/main column }}
   <div class="cell large-4">
 
-    <h3>
-      Project Editors
-      <FaIcon @icon='users-cog' @fixedWidth={{true}} />
-    </h3>
+    {{#if this.contactMgmtEnabled}}
+      <section class="xlarge-margin-bottom">
 
-    <ul class="no-bullet">
-      {{#each this.project.projectApplicants as |projectApplicant|}}
-        {{#if (and (eq projectApplicant.contact.statuscode this.contactActiveStatusCode) (eq projectApplicant.contact.statecode this.contactActiveStateCode))}}
-          <Project::ProjectEditorListItem
-            @name={{projectApplicant.displayName}}
-            @emailAddress={{projectApplicant.email}}
-            @phone={{projectApplicant.contact.telephone1}}
-            @isRegistered={{projectApplicant.contact.dcpNycidGuid}}
-            @projectName={{this.project.dcpProjectname}}
-            @canDelete={{and (not projectApplicant.isPrimaryApplicantOrContact) this.contactMgmtOpen}}
-            @onDelete={{fn this.removeEditor projectApplicant}}
-          />
+        <h3 class="clearfix">
+          Project Editors
+          <button
+            type="button"
+            class="button secondary small float-right no-margin"
+            {{on "click" (fn this.toggleContactMgmt) }}
+          >
+            {{if this.contactMgmtOpen 'Cancel' 'Manage'}}
+            <FaIcon @icon='users-cog' @fixedWidth={{true}} />
+          </button>
+        </h3>
+
+        <ul class="no-bullet">
+          {{#each this.project.projectApplicants as |projectApplicant|}}
+            {{#if (and (eq projectApplicant.contact.statuscode this.contactActiveStatusCode) (eq projectApplicant.contact.statecode this.contactActiveStateCode))}}
+              <Project::ProjectEditorListItem
+                @name={{projectApplicant.displayName}}
+                @emailAddress={{projectApplicant.email}}
+                @phone={{projectApplicant.contact.telephone1}}
+                @isRegistered={{projectApplicant.contact.dcpNycidGuid}}
+                @projectName={{this.project.dcpProjectname}}
+                @canDelete={{and (not projectApplicant.isPrimaryApplicantOrContact) this.contactMgmtOpen}}
+                @onDelete={{fn this.removeEditor projectApplicant}}
+              />
+            {{/if}}
+          {{/each}}
+        </ul>
+
+        {{#if this.contactMgmtOpen}}
+          <fieldset class="fieldset">
+            <legend class="text-weight-bold">
+              <FaIcon @icon='user-plus' @fixedWidth={{true}} @transform='down-1' class="text-gray" />
+              Add Project Editor
+            </legend>
+
+            <div class="grid-x grid-margin-x">
+              <div class="cell medium-6">
+                <label class="text-small">
+                  First Name
+                  <Input
+                    @type="text"
+                    autocomplete="off"
+                    @value={{this.firstName}}
+                  />
+                </label>
+              </div>
+              <div class="cell medium-6">
+                <label class="text-small">
+                  Last Name
+                  <Input
+                    @type="text"
+                    autocomplete="off"
+                    @value={{this.lastName}}
+                  />
+                </label>
+              </div>
+            </div>
+
+            <label class="text-small">
+              Email Address
+              <Input
+                @type="text"
+                autocomplete="off"
+                @value={{this.emailAddress}}
+              />
+            </label>
+
+            <button
+              class="button expanded no-margin text-weight-bold"
+              type="button"
+              {{on "click" (fn this.addEditor) }}
+            >
+              Add Project Editor
+            </button>
+          </fieldset>
         {{/if}}
-      {{/each}}
-    </ul>
 
-    {{#if this.contactMgmtOpen}}
-      <h4>Add Project Editor:</h4>
-
-      <fieldset class="--fieldset">
-        <label>
-          First Name
-          <Input
-            @type="text"
-            autocomplete="off"
-            @value={{this.firstName}}
-          />
-        </label>
-
-        <label>
-          Last Name
-          <Input
-            @type="text"
-            autocomplete="off"
-            @value={{this.lastName}}
-          />
-        </label>
-
-        <label>
-          Email Address
-          <Input
-            @type="text"
-            autocomplete="off"
-            @value={{this.emailAddress}}
-          />
-        </label>
-
-        <button
-          class="button expanded text-weight-bold"
-          type="button"
-          {{on "click" (fn this.addEditor) }}
+        <Ui::GenericModal
+          @show={{this.addEditorModalOpen}}
+          @closeButtonAction={{fn (mut this.addEditorModalOpen) false}}
         >
-          Add Project Editor
-        </button>
-      </fieldset>
+          {{#if this.matchingCurrentApplicant}}
+            <h4>A Project Editor with the email address you entered already exists on this project.</h4>
+          {{else}}
+            <h4>Are you sure you want to add...</h4>
+            <Project::ProjectEditorListItem
+              @name="{{this.firstName}} {{this.lastName}}"
+              @emailAddress={{this.emailAddress}}
+            />
+            <p>If you add this Editor, they will be able to view and edit this Project.</p>
+            <div class="grid-x">
+              <div class="cell large-6 small-padding-right">
+                <button
+                  class="button expanded large"
+                  type="button"
+                  {{on "click" (fn this.saveEditor) }}
+                >
+                  <strong>Add Editor</strong>
+                </button>
+              </div>
+              <div class="cell large-6 small-padding-left">
+                <button
+                  type="button"
+                  class="button expanded large secondary"
+                  {{on "click" (fn (mut this.addEditorModalOpen) false)}}
+                  >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          {{/if}}
+        </Ui::GenericModal>
+
+      </section>
     {{/if}}
 
-    <button
-      type="button"
-      class="button expanded secondary"
-      {{on "click" (fn this.toggleContactMgmt) }}
-    >
-      {{if this.contactMgmtOpen 'Cancel' 'Manage Project Editors'}}
-    </button>
+    <section class="xlarge-margin-bottom">
+      <h3>
+        City Planning Staff
+      </h3>
+      <ul class="no-bullet">
+        {{#each this.project.teamMembers as |teamMember|}}
+          <li class="grid-x medium-margin-bottom">
+            <div class="cell shrink small-padding-right">
+              <FaIcon @icon='user' @fixedWidth={{true}} @transform='down-1' class="text-gray" />
+            </div>
+            <div class="cell auto">
+              <h5 class="no-margin">{{teamMember.name}}</h5>
+              <p class="text-small tiny-margin-bottom">
+                <i>{{teamMember.role}}</i>
+              </p>
+              <p class="text-small tiny-margin-bottom">
+                <a href="mailto:{{teamMember.email}}">{{teamMember.email}}</a>
+              </p>
+              <p class="text-small tiny-margin-bottom">
+                {{teamMember.phone}}
+              </p>
+            </div>
+          </li>
+        {{/each}}
+      </ul>
+    </section>
 
-    <Ui::ConfirmationModal
-      @show={{this.addEditorModalOpen}}
-      @toggle={{fn (mut this.addEditorModalOpen) false}}
-      @continueButtonTitle="Cancel"
-    >
-      {{#if this.matchingCurrentApplicant}}
-        <h4>A Project Editor with the email address you entered already exists on this project.</h4>
-      {{else}}
-        <h4>Are you sure you want to add...</h4>
-        <Project::ProjectEditorListItem
-          @name="{{this.firstName}} {{this.lastName}}"
-          @emailAddress={{this.emailAddress}}
-        />
-        <p>If you add this Editor, they will be able to view and edit this Project.</p>
-        <button
-          class="button expanded no-margin"
-          type="button"
-          {{on "click" (fn this.saveEditor) }}
-        >
-          <strong>Add Editor</strong>
-        </button>
-      {{/if}}
-    </Ui::ConfirmationModal>
-
-    <Messages::Assistance class="large-margin-top" />
-
-    <h3>
-      City Planning Staff
-    </h3>
-    <ul class="no-bullet">
-      {{#each this.project.teamMembers as |teamMember|}}
-        <li class="grid-x medium-margin-bottom">
-          <div class="cell shrink small-padding-right">
-            <FaIcon @icon='user' @fixedWidth={{true}} @transform='down-1' class="text-gray" />
-          </div>
-          <div class="cell auto">
-            <h5 class="no-margin">{{teamMember.name}}</h5>
-            <p class="text-small tiny-margin-bottom">
-              <i>{{teamMember.role}}</i>
-            </p>
-            <p class="text-small tiny-margin-bottom">
-              <a href="mailto:{{teamMember.email}}">{{teamMember.email}}</a>
-            </p>
-            <p class="text-small tiny-margin-bottom">
-              {{teamMember.phone}}
-            </p>
-          </div>
-        </li>
-      {{/each}}
-    </ul>
+    <Messages::Assistance />
 
   </div>
 </div>

--- a/client/config/environment.js
+++ b/client/config/environment.js
@@ -28,6 +28,7 @@ module.exports = function(environment) {
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
+      contactMgmtEnabled: true,
     },
 
     'labs-search': {
@@ -61,6 +62,7 @@ module.exports = function(environment) {
 
   if (environment === 'production') {
     // here you can enable a production-specific feature
+    ENV.APP.contactMgmtEnabled = false;
   }
 
   return ENV;


### PR DESCRIPTION
This PR… 

- Adds a config var to enable the Contact MGMT features (`true` be default, `false` in production environment) 
- Improves the UI of the Contact MGMT section by 
  - Associating the "Manage/Cancel" button w/ the section header (it seemed like part of the "Add Editor" form)
  - Replaces the user icon with an X if `@canDelete` (so it's more direct association w/ user instead of aligned to the far right)
  - Adds tooltips that show when you enable editing to highlight what's editable
  - Condenses the "Add Editor" form 
  - Uses the `<Ui::GenericModal>` instead of the confirmation modal
- Improves the spacing and dividing rules of sections of the page (e.g. horizontal line between packages, appropriate spacing between sidebar sections)

![2020-09-21 14 22 30](https://user-images.githubusercontent.com/409279/93805594-f699aa80-fc15-11ea-8c95-d3270ca3b329.gif)
