### PR TITLE
12391 public facilities

### DIFF
--- a/client/app/components/packages/landuse-form/edit.hbs
+++ b/client/app/components/packages/landuse-form/edit.hbs
@@ -87,6 +87,10 @@
         {{/if}}
       {{/let}}
 
+      <Packages::LanduseForm::PublicFacilities
+        @form={{saveableForm}}
+      />
+
       <Packages::LanduseForm::AttachedDocuments
         @form={{saveableForm}}
         @model={{@package.landuseForm}}

--- a/client/app/components/packages/landuse-form/public-facilities.hbs
+++ b/client/app/components/packages/landuse-form/public-facilities.hbs
@@ -1,0 +1,340 @@
+{{#let @form as |form|}}
+  {{#let (intersect
+    (map-by "dcpActioncode" form.data.data.landuseActions)
+    (array 'PC' 'PQ' 'PS' 'PX')
+  ) as |publicFacilitiesActions|}}
+    {{#if (gt publicFacilitiesActions.length 0)}}
+      <form.Section @title="Public Facilities">
+        <p>
+          The following questions relate to Office Space Lease,
+          Public Facility Site Selection or Acquisition and the
+          following Actions: PC, PQ, PS, PX. These Actions require
+          additional Attachments as noted in the Attachments section.
+        </p>
+
+        <Ui::Question
+        as |proposedActionsQ|>
+          <proposedActionsQ.Label>
+            Which action(s) is/are being proposed? (select all that apply)
+          </proposedActionsQ.Label>
+
+          <Input
+            type="checkbox"
+            id="dcpOfficespaceleaseopt"
+            data-test-checkbox="dcpOfficespaceleaseopt"
+            checked={{if
+              (eq
+                form.data.dcpOfficespaceleaseopt
+                (optionset 'landuseForm' 'dcpOfficespaceleaseopt' 'code' 'Yes')
+              ) "checked"}}
+            onClick={{fn (mut form.data.dcpOfficespaceleaseopt)
+              (if form.data.dcpOfficespaceleaseopt
+                (optionset 'landuseForm' 'dcpOfficespaceleaseopt' 'code' 'No')
+                (optionset 'landuseForm' 'dcpOfficespaceleaseopt' 'code' 'Yes')
+              )
+            }}
+          />
+          <label for="dcpOfficespaceleaseopt">
+            Office Space Lease
+          </label>
+
+          <br>
+
+          <Input
+            type="checkbox"
+            id="dcpAcquisitionopt"
+            data-test-checkbox="dcpAcquisitionopt"
+            checked={{if
+              (eq
+                form.data.dcpAcquisitionopt
+                (optionset 'landuseForm' 'dcpAcquisitionopt' 'code' 'Yes')
+              ) "checked"}}
+            onClick={{fn (mut form.data.dcpAcquisitionopt)
+              (if form.data.dcpAcquisitionopt
+                (optionset 'landuseForm' 'dcpAcquisitionopt' 'code' 'No')
+                (optionset 'landuseForm' 'dcpAcquisitionopt' 'code' 'Yes')
+              )
+            }}
+          />
+          <label for="dcpAcquisitionopt">
+            Public Facility Acquisition
+          </label>
+
+          <br>
+
+          <Input
+            type="checkbox"
+            id="dcpSiteselectionopt"
+            data-test-checkbox="dcpSiteselectionopt"
+            checked={{if
+              (eq
+                form.data.dcpSiteselectionopt
+                (optionset 'landuseForm' 'dcpSiteselectionopt' 'code' 'Yes')
+              ) "checked"}}
+            onClick={{fn (mut form.data.dcpSiteselectionopt)
+              (if form.data.dcpSiteselectionopt
+                (optionset 'landuseForm' 'dcpSiteselectionopt' 'code' 'No')
+                (optionset 'landuseForm' 'dcpSiteselectionopt' 'code' 'Yes')
+              )
+            }}
+          />
+          <label for="dcpSiteselectionopt">
+            Public Facility Site Acquisition
+          </label>
+        </Ui::Question>
+
+        <Ui::Question
+        as |dcpIndicatetypeoffacilityQ|>
+          <dcpIndicatetypeoffacilityQ.Label>
+            What is the type of facility?
+          </dcpIndicatetypeoffacilityQ.Label>
+
+          <form.Field
+            @attribute="dcpIndicatetypeoffacility"
+            @type="radio-group"
+          as |DcpIndicatetypeoffacilityRadioGroup|>
+            <DcpIndicatetypeoffacilityRadioGroup
+              @options={{optionset 'landuseForm' 'dcpIndicatetypeoffacility' 'list'}}
+            />
+          </form.Field>
+        </Ui::Question>
+
+        <Ui::Question
+        as |dcpExistingfacilityproposedtoremainoptQ|>
+          <dcpExistingfacilityproposedtoremainoptQ.Label>
+            Will the existing facility remain?
+          </dcpExistingfacilityproposedtoremainoptQ.Label>
+
+          <form.Field
+            @attribute="dcpExistingfacilityproposedtoremainopt"
+            @type="radio-group"
+          as |DcpExistingfacilityproposedtoremainoptRadioGroup|>
+            <DcpExistingfacilityproposedtoremainoptRadioGroup
+              @options={{optionset 'landuseForm' 'dcpExistingfacilityproposedtoremainopt' 'list'}}
+              @onChange={{fn this.resetDependentFields this.dependantsOf.dcpExistingfacilityproposedtoremainopt}}
+            as |dcpExistingfacilityproposedtoremainopt|>
+                {{#if (eq
+                  dcpExistingfacilityproposedtoremainopt
+                  (optionset 'landuseForm' 'dcpExistingfacilityproposedtoremainopt' 'code' 'Yes')
+                )}}
+                  <Ui::Question
+                  as |dcpTextexistingfacilityQ|>
+                    <dcpTextexistingfacilityQ.Label>
+                      How long has the existing facility been at this location?
+                    </dcpTextexistingfacilityQ.Label>
+
+                    <form.Field
+                      @attribute="dcpTextexistingfacility"
+                      @maxlength="100"
+                      @showCounter={{true}}
+                      id={{dcpTextexistingfacilityQ.id}}
+                    />
+                  </Ui::Question>
+                {{/if}}
+
+                {{#if (eq
+                  dcpExistingfacilityproposedtoremainopt
+                  (optionset 'landuseForm' 'dcpExistingfacilityproposedtoremainopt' 'code' 'No')
+                )}}
+                  <Ui::Question
+                  as |dcpExistingfacilityreplacementinanewlocationQ|>
+                    <dcpExistingfacilityreplacementinanewlocationQ.Label>
+                      Will the existing facility be replaced in a new location?
+                    </dcpExistingfacilityreplacementinanewlocationQ.Label>
+
+                    <form.Field
+                      @attribute="dcpExistingfacilityreplacementinanewlocation"
+                      @type="radio-group"
+                    as |DcpExistingfacilityreplacementinanewlocationRadioGroup|>
+                      <DcpExistingfacilityreplacementinanewlocationRadioGroup
+                        @options={{optionset 'landuseForm' 'dcpExistingfacilityreplacementinanewlocation' 'list'}}
+                      as |dcpExistingfacilityreplacementinanewlocation|>
+                        {{#if (eq
+                          dcpExistingfacilityreplacementinanewlocation
+                          (optionset 'landuseForm' 'dcpExistingfacilityreplacementinanewlocation' 'code' 'Yes')
+                        )}}
+                          <Ui::Question
+                          as |dcpCurrentfacilitylocationQ|>
+                            <dcpCurrentfacilitylocationQ.Label>
+                              Where is the current facility located?
+                            </dcpCurrentfacilitylocationQ.Label>
+
+                            <form.Field
+                              @attribute="dcpCurrentfacilitylocation"
+                              @maxlength="50"
+                              @showCounter={{true}}
+                              id={{dcpCurrentfacilitylocationQ.id}}
+                            />
+                          </Ui::Question>
+                        {{/if}}
+                      </DcpExistingfacilityreplacementinanewlocationRadioGroup>
+                    </form.Field>
+                  </Ui::Question>
+                {{/if}}
+            </DcpExistingfacilityproposedtoremainoptRadioGroup>
+          </form.Field>
+        </Ui::Question>
+
+        <Ui::Question
+        as |dcpExistingfacilityproposedtoremainandexpandQ|>
+          <dcpExistingfacilityproposedtoremainandexpandQ.Label>
+            Will the existing facility remain and be expanded?
+          </dcpExistingfacilityproposedtoremainandexpandQ.Label>
+
+          <form.Field
+            @attribute="dcpExistingfacilityproposedtoremainandexpand"
+            @type="radio-group"
+          as |DcpExistingfacilityproposedtoremainandexpandRadioGroup|>
+            <DcpExistingfacilityproposedtoremainandexpandRadioGroup
+              @options={{optionset 'landuseForm' 'dcpExistingfacilityproposedtoremainandexpand' 'list'}}
+              @onChange={{fn this.resetDependentFields this.dependantsOf.dcpExistingfacilityproposedtoremainandexpand}}
+            as |dcpExistingfacilityproposedtoremainandexpand|>
+              {{#if (eq
+                dcpExistingfacilityproposedtoremainandexpand
+                (optionset 'landuseForm' 'dcpExistingfacilityproposedtoremainandexpand' 'code' 'Yes')
+              )}}
+                <Ui::Question
+                as |dcpHowlonghasexistingfacilitybeenatthislocatQ|>
+                  <dcpHowlonghasexistingfacilitybeenatthislocatQ.Label>
+                    How long has the existing facility been at this location?
+                  </dcpHowlonghasexistingfacilitybeenatthislocatQ.Label>
+
+                  <form.Field
+                    @attribute="dcpHowlonghasexistingfacilitybeenatthislocat"
+                    @maxlength="2000"
+                    @showCounter={{true}}
+                    id={{dcpHowlonghasexistingfacilitybeenatthislocatQ.id}}
+                  />
+                </Ui::Question>
+              {{/if}}
+            </DcpExistingfacilityproposedtoremainandexpandRadioGroup>
+          </form.Field>
+        </Ui::Question>
+
+        <Ui::Question
+        as |dcpNewfacilityoptQ|>
+          <dcpNewfacilityoptQ.Label>
+            Is this a new facility?
+          </dcpNewfacilityoptQ.Label>
+
+          <form.Field
+            @attribute="dcpNewfacilityopt"
+            @type="radio-group"
+          as |DcpNewfacilityoptRadioGroup|>
+            <DcpNewfacilityoptRadioGroup
+              @options={{optionset 'landuseForm' 'dcpNewfacilityopt' 'list'}}
+            />
+          </form.Field>
+        </Ui::Question>
+
+        <Ui::Question
+        as |dcpIsprojectlistedinstatementofneedsoptQ|>
+          <dcpIsprojectlistedinstatementofneedsoptQ.Label>
+            Is project listed in Citywide Statement of Needs? 
+          </dcpIsprojectlistedinstatementofneedsoptQ.Label>
+
+          <form.Field
+            @attribute="dcpIsprojectlistedinstatementofneedsopt"
+            @type="radio-group"
+          as |DcpIsprojectlistedinstatementofneedsoptRadioGroup|>
+            <DcpIsprojectlistedinstatementofneedsoptRadioGroup
+              @options={{optionset 'landuseForm' 'dcpIsprojectlistedinstatementofneedsopt' 'list'}}
+              @onChange={{fn (mut @form.data.dcpIndicatefiscalyears) ""}}
+            as |dcpIsprojectlistedinstatementofneedsopt|>
+              {{#if (eq
+                dcpIsprojectlistedinstatementofneedsopt
+                (optionset 'landuseForm' 'dcpIsprojectlistedinstatementofneedsopt' 'code' 'Yes')
+              )}}
+                <Ui::Question
+                as |dcpIndicatefiscalyearsQ|>
+                  <dcpIndicatefiscalyearsQ.Label>
+                    In what fiscal year was the project listed in Citywide Statement?
+                  </dcpIndicatefiscalyearsQ.Label>
+
+                  <form.Field
+                    @attribute="dcpIndicatefiscalyears"
+                    @maxlength="100"
+                    @showCounter={{true}}
+                    id={{dcpIndicatefiscalyearsQ.id}}
+                  />
+                </Ui::Question>
+
+                <Ui::Question
+                as |dcpIndicatepgnoQ|>
+                  <dcpIndicatepgnoQ.Label>
+                    What page in Citywide Statement?
+                  </dcpIndicatepgnoQ.Label>
+
+                  <form.Field
+                    @attribute="dcpIndicatepgno"
+                    @maxlength="100"
+                    @showCounter={{true}}
+                    id={{dcpIndicatepgnoQ.id}}
+                  />
+                </Ui::Question>
+              {{/if}}
+            </DcpIsprojectlistedinstatementofneedsoptRadioGroup>
+          </form.Field>
+        </Ui::Question>
+
+        <Ui::Question
+        as |dcpDidboroughpresidentproposealternativesiteQ|>
+          <dcpDidboroughpresidentproposealternativesiteQ.Label>
+            Did Borough President propose alternate site pursuant to charter section 204(f) or (g)?
+          </dcpDidboroughpresidentproposealternativesiteQ.Label>
+
+          <form.Field
+            @attribute="dcpDidboroughpresidentproposealternativesite"
+            @type="radio-group"
+          as |DcpDidboroughpresidentproposealternativesiteRadioGroup|>
+            <DcpDidboroughpresidentproposealternativesiteRadioGroup
+              @options={{optionset 'landuseForm' 'dcpDidboroughpresidentproposealternativesite' 'list'}}
+            />
+          </form.Field>
+        </Ui::Question>
+
+        <Ui::Question
+        as |dcpWhatsiteQ|>
+          <dcpWhatsiteQ.Label>
+            What and where was the alternate site?
+          </dcpWhatsiteQ.Label>
+
+          <form.Field
+            @attribute="dcpWhatsite"
+            @maxlength="100"
+            @showCounter={{true}}
+            id={{dcpWhatsiteQ.id}}
+          />
+        </Ui::Question>
+
+        <Ui::Question
+        as |dcpCapitalbudgetlineQ|>
+          <dcpCapitalbudgetlineQ.Label>
+            What is the capital budget line?
+          </dcpCapitalbudgetlineQ.Label>
+
+          <form.Field
+            @attribute="dcpCapitalbudgetline"
+            @maxlength="100"
+            @showCounter={{true}}
+            id={{dcpCapitalbudgetlineQ.id}}
+          />
+        </Ui::Question>
+
+        <Ui::Question
+        as |dcpForfiscalyrsQ|>
+          <dcpForfiscalyrsQ.Label>
+            For which capital budget fiscal years?
+          </dcpForfiscalyrsQ.Label>
+
+          <form.Field
+            @attribute="dcpForfiscalyrs"
+            @maxlength="100"
+            @showCounter={{true}}
+            id={{dcpForfiscalyrsQ.id}}
+          />
+        </Ui::Question>
+      </form.Section>
+    {{/if}}
+  {{/let}}
+{{/let}}

--- a/client/app/components/packages/landuse-form/public-facilities.js
+++ b/client/app/components/packages/landuse-form/public-facilities.js
@@ -1,0 +1,37 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class PackagesLanduseFormPublicFacilitiesComponent extends Component {
+  // The following properties represent lists of fields
+  // dependent on the value of a respective radio group.
+  // For a radio group property,
+  // the associated list of fields are those which should be
+  // cleared (reset) when the radio-group value changes.
+  dependantsOf = {
+    dcpExistingfacilityproposedtoremainopt: [
+      'dcpTextexistingfacility',
+      'dcpExistingfacilityreplacementinanewlocation',
+      'dcpCurrentfacilitylocation',
+    ],
+    dcpExistingfacilityreplacementinanewlocation: [
+      'dcpCurrentfacilitylocation',
+    ],
+    dcpExistingfacilityproposedtoremainandexpand: [
+      'dcpHowlonghasexistingfacilitybeenatthislocat',
+    ],
+    dcpIsprojectlistedinstatementofneedsopt: [
+      'dcpIndicatefiscalyears',
+    ],
+  }
+
+  get landuseForm() {
+    return this.args.form.data;
+  }
+
+  @action
+  resetDependentFields(fields) {
+    fields.forEach((field) => {
+      this.landuseForm.set(field, null);
+    });
+  }
+}

--- a/client/app/components/saveable-form/field/radio.hbs
+++ b/client/app/components/saveable-form/field/radio.hbs
@@ -21,6 +21,8 @@
   <label
     class="ember-radio-button {{if checked checkedClass}} {{joinedClassNames}}"
     for={{radioId}}
+    data-test-checked={{if (eq value targetValue) "true" "false"}}
+    aria-checked={{if (eq value targetValue) "true" "false"}}
     ...attributes
   >
     {{yield}}

--- a/client/app/components/saveable-form/field/radio.js
+++ b/client/app/components/saveable-form/field/radio.js
@@ -3,4 +3,6 @@ import { guidFor } from '@ember/object/internals';
 
 export default class GroupIdentifier extends RadioButtonComponent {
   radioId = `radio-${guidFor(this)}`;
+
+  checkedClass = 'checked'
 }

--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -1,7 +1,7 @@
 import { helper } from '@ember/component/helper';
 // Register Option Sets by importing them and then adding
 // an entry to the OPTIONSET_LOOKUP object.
-import {
+import COMMON_OPTIONSETS, {
   YES_NO,
   YES_NO_UNSURE,
   YES_NO_DONT_KNOW,
@@ -71,6 +71,16 @@ const OPTIONSET_LOOKUP = {
     dcpProjecthousingplanudaap: LANDUSE_FORM_OPTIONSETS.DCPPROJECTHOUSINGPLANUDAAP,
     dcpMannerofdisposition: LANDUSE_FORM_OPTIONSETS.DCPMANNEROFDISPOSITION,
     dcpRestrictandcondition: LANDUSE_FORM_OPTIONSETS.DCPRESTRICTANDCONDITION,
+    dcpOfficespaceleaseopt: COMMON_OPTIONSETS.YES_NO_INTEGER,
+    dcpAcquisitionopt: COMMON_OPTIONSETS.YES_NO_INTEGER,
+    dcpSiteselectionopt: COMMON_OPTIONSETS.YES_NO_INTEGER,
+    dcpIndicatetypeoffacility: LANDUSE_FORM_OPTIONSETS.DCPINDICATETYPEOFFACILITY,
+    dcpExistingfacilityproposedtoremainopt: COMMON_OPTIONSETS.YES_NO_INTEGER,
+    dcpExistingfacilityproposedtoremainandexpand: COMMON_OPTIONSETS.YES_NO_INTEGER,
+    dcpExistingfacilityreplacementinanewlocation: COMMON_OPTIONSETS.YES_NO_INTEGER,
+    dcpNewfacilityopt: COMMON_OPTIONSETS.YES_NO_INTEGER,
+    dcpIsprojectlistedinstatementofneedsopt: COMMON_OPTIONSETS.YES_NO_INTEGER,
+    dcpDidboroughpresidentproposealternativesite: COMMON_OPTIONSETS.YES_NO_INTEGER,
   },
   rwcdsForm: {
     dcpHasprojectchangedsincesubmissionofthepas: YES_NO,

--- a/client/app/models/landuse-form.js
+++ b/client/app/models/landuse-form.js
@@ -30,6 +30,7 @@ export default class LanduseFormModel extends Model {
 
   @attr dcpContactemail;
 
+  // Site Information attrs
   @attr dcpSitedataadress;
 
   @attr dcpCitycouncil;
@@ -42,6 +43,7 @@ export default class LanduseFormModel extends Model {
 
   @attr dcpSpecialdistricts;
 
+  // Proposed Project Area attrs
   @attr dcpWholecity;
 
   @attr dcpEntiretyboroughs;
@@ -64,6 +66,7 @@ export default class LanduseFormModel extends Model {
 
   @attr dcpSitedatarenewalarea;
 
+  // Proposed Development Site attrs
   @attr dcp500kpluszone;
 
   @attr dcpDevsize;
@@ -72,6 +75,18 @@ export default class LanduseFormModel extends Model {
 
   @attr dcpSitedataidentifylandmark;
 
+  // Environmental Review attrs
+  @attr dcpLeadagency;
+
+  @attr dcpCeqrnumber;
+
+  @attr dcpCeqrtype;
+
+  @attr dcpTypecategory;
+
+  @attr dcpDeterminationdate;
+
+  // Housing Plans attrs
   @attr dcpDesignation;
 
   @attr dcpProjecthousingplanudaap;
@@ -82,15 +97,42 @@ export default class LanduseFormModel extends Model {
 
   @attr dcpRestrictandcondition;
 
-  @attr dcpLeadagency;
+  // public facilities attrs
+  @attr dcpOfficespaceleaseopt;
 
-  @attr dcpCeqrnumber;
+  @attr dcpAcquisitionopt;
 
-  @attr dcpCeqrtype;
+  @attr dcpSiteselectionopt;
 
-  @attr dcpTypecategory;
+  @attr dcpIndicatetypeoffacility;
 
-  @attr dcpDeterminationdate;
+  @attr dcpExistingfacilityproposedtoremainopt;
+
+  @attr dcpExistingfacilityproposedtoremainandexpand;
+
+  @attr dcpHowlonghasexistingfacilitybeenatthislocat;
+
+  @attr dcpTextexistingfacility;
+
+  @attr dcpExistingfacilityreplacementinanewlocation;
+
+  @attr dcpCurrentfacilitylocation;
+
+  @attr dcpNewfacilityopt;
+
+  @attr dcpIsprojectlistedinstatementofneedsopt;
+
+  @attr dcpIndicatefiscalyears;
+
+  @attr dcpIndicatepgno;
+
+  @attr dcpDidboroughpresidentproposealternativesite;
+
+  @attr dcpWhatsite;
+
+  @attr dcpCapitalbudgetline;
+
+  @attr dcpForfiscalyrs;
 
   async save() {
     await this.saveDirtyLanduseActions();

--- a/client/app/optionsets/common.js
+++ b/client/app/optionsets/common.js
@@ -9,6 +9,20 @@ export const YES_NO = {
   },
 };
 
+// Ideally we can remove this
+// After CRM is updated so all YES/NO
+// optionsets use True/False values
+export const YES_NO_INTEGER = {
+  YES: {
+    code: 1,
+    label: 'Yes',
+  },
+  NO: {
+    code: 0,
+    label: 'No',
+  },
+};
+
 export const YES_NO_UNSURE = {
   YES: {
     code: 717170000,
@@ -43,6 +57,7 @@ const COMMON_OPTIONSETS = {
   YES_NO,
   YES_NO_UNSURE,
   YES_NO_DONT_KNOW,
+  YES_NO_INTEGER,
 };
 
 export default COMMON_OPTIONSETS;

--- a/client/app/optionsets/landuse-form.js
+++ b/client/app/optionsets/landuse-form.js
@@ -85,6 +85,17 @@ export const DCPDISPOSITION = {
   },
 };
 
+export const DCPINDICATETYPEOFFACILITY = {
+  LOCAL_NEIGHBORHOOD: {
+    code: 804810000,
+    label: 'Local/Neighborhood',
+  },
+  REGIONAL_CITYWIDE: {
+    code: 717170001,
+    label: 'Regional/Citywide',
+  },
+};
+
 const LANDUSE_FORM_OPTIONSETS = {
   CEQR_TYPE,
   DCPDEVSIZE,
@@ -93,6 +104,7 @@ const LANDUSE_FORM_OPTIONSETS = {
   DCPDESIGNATION,
   DCPPROJECTHOUSINGPLANUDAAP,
   DCPDISPOSITION,
+  DCPINDICATETYPEOFFACILITY,
 };
 
 export default LANDUSE_FORM_OPTIONSETS;

--- a/client/app/routes/landuse-form.js
+++ b/client/app/routes/landuse-form.js
@@ -4,19 +4,17 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
 export default class LanduseFormRoute extends Route.extend(AuthenticatedRouteMixin) {
   authenticationRoute = '/';
 
-  packageSideloads = [
-    'landuse-form.bbls',
-    'landuse-form.applicants',
-    'project',
-    'landuse-form.related-actions',
-    'landuse-form.landuse-actions',
-    'landuse-form.sitedatah-forms',
-  ];
-
   async model(params) {
     const landuseFormPackage = await this.store.findRecord('package', params.id, {
       reload: true,
-      include: this.packageSideloads.join(),
+      include: [
+        'landuse-form.bbls',
+        'landuse-form.applicants',
+        'project',
+        'landuse-form.related-actions',
+        'landuse-form.landuse-actions',
+        'landuse-form.sitedatah-forms',
+      ].join(),
     });
 
     // manually generate a file factory

--- a/client/app/validations/saveable-landuse-form.js
+++ b/client/app/validations/saveable-landuse-form.js
@@ -137,4 +137,52 @@ export default {
       message: 'Text is too long (max {max} characters)',
     }),
   ],
+  dcpTextexistingfacility: [
+    validateLength({
+      min: 0,
+      max: 100,
+    }),
+  ],
+  dcpHowlonghasexistingfacilitybeenatthislocat: [
+    validateLength({
+      min: 0,
+      max: 2000,
+    }),
+  ],
+  dcpCurrentfacilitylocation: [
+    validateLength({
+      min: 0,
+      max: 50,
+    }),
+  ],
+  dcpIndicatefiscalyears: [
+    validateLength({
+      min: 0,
+      max: 100,
+    }),
+  ],
+  dcpIndicatepgno: [
+    validateLength({
+      min: 0,
+      max: 100,
+    }),
+  ],
+  dcpWhatsite: [
+    validateLength({
+      min: 0,
+      max: 100,
+    }),
+  ],
+  dcpCapitalbudgetline: [
+    validateLength({
+      min: 0,
+      max: 100,
+    }),
+  ],
+  dcpForfiscalyrs: [
+    validateLength({
+      min: 0,
+      max: 100,
+    }),
+  ],
 };


### PR DESCRIPTION
### Summary 
Sets up Public Facilities section
Fixes [AB#12391](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12391)

### Technical Details
- Introduces the YES_NO_INTEGER optionset to accommodate the unfortunate Yes/No options which map to 1 and 0, instead of true and false. 
- Uses native Ember Input component to render checkboxes tied to integer values, since our Checkbox component assumes boolean values.
- Introduces the `data-test-checked` and `aria-checked` attributes to Radio components so that we can assert their checked state in tests
- Re-use the pattern for clearing dependent fields introduced in the housing-plans section 