### PR TITLE
12393: add zoning permit, authorization, and certification section to landuse-form

### DIFF
--- a/client/app/components/packages/landuse-form/proposed-actions.hbs
+++ b/client/app/components/packages/landuse-form/proposed-actions.hbs
@@ -1,6 +1,91 @@
 {{#let @form as |form|}}
   <form.Section @title="Proposed Actions">
     <div data-test-section="proposed-actions">
+      {{#if this.projectHasRequiredActions}}
+        <h3>Zoning Special Permits, Authorizations, and Certifications</h3>
+        <p>The following questions relate to Zoning Special Permits, Authorizations and Certifications and the following Actions: [ZA, ZR].</p>
+
+        <Ui::Question as |Q|>
+          <Q.Legend>
+            Is the applicant any of the following?
+            <small class="text-weight-normal">(select all that apply)</small>
+          </Q.Legend>
+
+          <ul class="no-bullet no-margin">
+            {{#each (array
+              (hash attr="dcpOwnersubjectproperty" label="Owner of subject property")
+              (hash attr="dcpLeesseesubjectproperty" label="Lessee of subject property")
+              (hash attr="dcpLeaseorbuy" label="In a contract to lease or buy the subject property")
+              (hash attr="dcpIsother" label="Other (explain in attached project description)"))  as |type|
+            }}
+              <li>
+                <form.Field
+                  @attribute={{type.attr}}
+                  @type="checkbox"
+                  as |Checkbox|
+                >
+                  <Checkbox>
+                    {{type.label}}
+                  </Checkbox>
+                </form.Field>
+              </li>
+            {{/each}}
+          </ul>
+        </Ui::Question>
+
+        <Ui::Question
+          class="no-margin-top"
+          data-test-other-parties-radio-group
+          as |Q|
+        >
+
+        <Q.Legend>
+          Are there other owners or long-term lessees of the subject property? 
+        </Q.Legend>
+
+          <form.Field
+            @attribute="dcpOtherparties"
+            @type="radio"
+            as |RadioButton|
+          >
+            <RadioButton
+              @targetValue={{true}}
+              data-test-dcpotherparties="true"
+            >
+              Yes
+            </RadioButton>
+            <RadioButton
+              @targetValue={{false}}
+              data-test-dcpotherparties="false"
+            >
+              No
+            </RadioButton>
+          </form.Field>
+
+        </Ui::Question>
+      {{/if}}
+
+      <h3>All Proposed Project Actions</h3>
+      <Ui::Question
+        data-test-dcplegalinstrument-radio-group
+        as |Q|
+      >
+        <Q.Label>
+          Does this Project require a Legal Instrument to be recorded against the subject property?
+        </Q.Label>
+
+        <form.Field
+          @attribute="dcpLegalinstrument"
+          @type="radio-group"
+          id={{Q.questionId}}
+          as |RadioGroup|
+        >
+          <RadioGroup
+            @options={{optionset 'landuseForm' 'dcpLegalinstrument' 'list'}}
+          />
+        </form.Field>
+      </Ui::Question>
+
       {{#each @form.data.landuseActions as |landuseAction|}}
         <form.SaveableForm
           @model={{landuseAction}}

--- a/client/app/components/packages/landuse-form/proposed-actions.js
+++ b/client/app/components/packages/landuse-form/proposed-actions.js
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+
+export default class PackagesLanduseFormProposedActionsComponent extends Component {
+  requiredActionCodes = ['ZS', 'ZA', 'ZC', 'CM', 'LD', 'RA', 'RC', 'RS', 'SD', 'SA', 'SC'];
+
+  get projectHasRequiredActions() {
+    const projectActions = this.args.form.data.landuseActions;
+    const projectActionCodes = projectActions.map((action) => action.dcpActioncode);
+    const matchingActions = this.requiredActionCodes.filter((actionCode) => projectActionCodes.includes(actionCode));
+    return matchingActions.length > 0;
+  }
+}

--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -81,6 +81,7 @@ const OPTIONSET_LOOKUP = {
     dcpNewfacilityopt: COMMON_OPTIONSETS.YES_NO_INTEGER,
     dcpIsprojectlistedinstatementofneedsopt: COMMON_OPTIONSETS.YES_NO_INTEGER,
     dcpDidboroughpresidentproposealternativesite: COMMON_OPTIONSETS.YES_NO_INTEGER,
+    dcpLegalinstrument: LANDUSE_FORM_OPTIONSETS.DCPLEGALINSTRUMENT,
   },
   rwcdsForm: {
     dcpHasprojectchangedsincesubmissionofthepas: YES_NO,

--- a/client/app/models/landuse-form.js
+++ b/client/app/models/landuse-form.js
@@ -134,6 +134,18 @@ export default class LanduseFormModel extends Model {
 
   @attr dcpForfiscalyrs;
 
+  @attr dcpOwnersubjectproperty;
+
+  @attr dcpLeesseesubjectproperty;
+
+  @attr dcpLeaseorbuy;
+
+  @attr dcpIsother;
+
+  @attr dcpOtherparties;
+
+  @attr dcpLegalinstrument;
+
   async save() {
     await this.saveDirtyLanduseActions();
     await this.saveDirtyRelatedActions();

--- a/client/app/optionsets/landuse-form.js
+++ b/client/app/optionsets/landuse-form.js
@@ -96,6 +96,17 @@ export const DCPINDICATETYPEOFFACILITY = {
   },
 };
 
+export const DCPLEGALINSTRUMENT = {
+  YES: {
+    code: 717170000,
+    label: 'Yes',
+  },
+  NO: {
+    code: 717170001,
+    label: 'No',
+  },
+};
+
 const LANDUSE_FORM_OPTIONSETS = {
   CEQR_TYPE,
   DCPDEVSIZE,
@@ -105,6 +116,7 @@ const LANDUSE_FORM_OPTIONSETS = {
   DCPPROJECTHOUSINGPLANUDAAP,
   DCPDISPOSITION,
   DCPINDICATETYPEOFFACILITY,
+  DCPLEGALINSTRUMENT,
 };
 
 export default LANDUSE_FORM_OPTIONSETS;

--- a/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
@@ -558,7 +558,22 @@ module('Acceptance | user can click landuse form edit', function(hooks) {
     await fillIn('[data-test-input="dcpLastname"]', 'Ter');
     await fillIn('[data-test-input="dcpEmail"]', 'tesster@planning.nyc.gov');
 
+    // filling out Zoning Special Permit, Authorization, and Certification section
+    await click('[data-test-checkbox="dcpOwnersubjectproperty"]');
+    await click('[data-test-checkbox="dcpLeesseesubjectproperty"]');
+
+    await click('[data-test-dcpotherparties="true"]');
+
+    await click('[data-test-save-button]');
+
+    assert.equal(this.server.db.landuseForms.firstObject.dcpOwnersubjectproperty, true);
+    assert.equal(this.server.db.landuseForms.firstObject.dcpLeesseesubjectproperty, true);
+    assert.equal(this.server.db.landuseForms.firstObject.dcpIsother, undefined);
+    assert.equal(this.server.db.landuseForms.firstObject.dcpLeaseorbuy, undefined);
+    assert.equal(this.server.db.landuseForms.firstObject.dcpOtherparties, true);
+
     // filling out the proposed actions section
+    await click('[data-test-radio="dcpLegalinstrument"][data-test-radio-option="Yes"]');
     await selectChoose('[data-test-dcpPreviouslyapprovedactioncode-picker="ZC"]', 'BF');
     await selectChoose('[data-test-dcpPreviouslyapprovedactioncode-picker="ZA"]', 'LD');
     await click('[data-test-radio="dcpApplicantispublicagencyactions"][data-test-action="ZC"][data-test-radio-option="Yes"]');
@@ -566,6 +581,7 @@ module('Acceptance | user can click landuse form edit', function(hooks) {
 
     await click('[data-test-save-button]');
 
+    assert.equal(this.server.db.landuseForms.firstObject.dcpLegalinstrument, 717170000);
     assert.equal(this.server.db.landuseActions[0].dcpPreviouslyapprovedactioncode, 717170016);
     assert.equal(this.server.db.landuseActions[1].dcpPreviouslyapprovedactioncode, 717170013);
     assert.equal(this.server.db.landuseActions[0].dcpApplicantispublicagencyactions, true);


### PR DESCRIPTION
- New section added to landuse-form for "Zoning Special Permit, Authorization, and Certification"
- These questions were just added to the `proposed-action.hbs` file

Closes [AB#12393](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12393)

<img width="637" alt="Screen Shot 2020-09-23 at 12 25 21 PM" src="https://user-images.githubusercontent.com/26672885/94053761-fcb79480-fd97-11ea-8173-16a1a8e4959e.png">
