### PR TITLE
Update when GUID mismatch, not falsey

### DIFF
--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -127,7 +127,7 @@ export class AuthService {
     });
 
     // if their e-mail is validated, associate the NYCID guid
-    if (nycExtEmailValidationFlag && !contact.dcp_nycid_guid) {
+    if (nycExtEmailValidationFlag && contact.dcp_nycid_guid !== GUID) {
       await this.contactService.update(contact.contactid, {
         dcp_nycid_guid: GUID,
         firstname: givenName,


### PR DESCRIPTION
Prefer updating the contact record when the GUID is a mismatch (including an empty GUID field). This is so that the accounts can update when we switch environments.