### PR TITLE
Adds an extra condition to ensure email exact match

### DIFF
--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -126,8 +126,14 @@ export class AuthService {
       dcp_nycid_guid: GUID,
     });
 
+    const nycIdEmailRegEx = new RegExp(`^${mail}$`, 'gi');
+
     // if their e-mail is validated, associate the NYCID guid
-    if (nycExtEmailValidationFlag && contact.dcp_nycid_guid !== GUID) {
+    if (
+      nycExtEmailValidationFlag
+      && contact.dcp_nycid_guid !== GUID
+      && contact.emailaddress1.match(nycIdEmailRegEx)
+    ) {
       await this.contactService.update(contact.contactid, {
         dcp_nycid_guid: GUID,
         firstname: givenName,


### PR DESCRIPTION
This adds an extra condition to ensure an “exact” but case-insensitive e-mail match before overwriting the previously-stored GUID.

# Big Picture Summary
Because users will have to re-register, they will have new GUIDs. This change makes sure that the e-mail on the NYC.ID at least also matches before overwriting the GUID (in case something goes wrong or "creeper mode" is enabled).

### Which major feature does this fit into?
Auth

