### PR TITLE
12654: fix typo in POST for applicant representative

### DIFF
--- a/server/src/packages/pas-form/applicants/applicants.controller.ts
+++ b/server/src/packages/pas-form/applicants/applicants.controller.ts
@@ -124,7 +124,7 @@ export class ApplicantsController {
           },
         );
       } else if (body.landuse_form) {
-        return this.crmService.create('dcp_applicantinformations', {
+        return this.crmService.create('dcp_applicantrepresentativeinformations', {
           ...allowedAttrs,
           'dcp_dcp_applicantrepinformation_dcp_landuse@odata.bind': [
             `/dcp_landuses(${body.landuse_form})`,


### PR DESCRIPTION
**What was wrong and how does this fix the problem?**
User was unable to save applicants on the Other Team Member section of the applicants component on the landuse-form. This was due to a typo in the POST on the `applicants.controller.ts`, where the incorrect entity was listed. This PR fixes the typo so that users can save to the correct entity. 

Closes [AB#12654](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12654)
