### PR TITLE
Prefers and adds env variable for domains

### DIFF
--- a/client/config/environment.js
+++ b/client/config/environment.js
@@ -79,7 +79,7 @@ function getHost(environment) {
 }
 
 function getOAuthDomain(environment) {
-  const { HOST } = process.env;
+  const { HOST, NYCID_DOMAIN } = process.env;
 
   // plain local development, no local backing server
   if (environment === 'development' && !HOST) {
@@ -92,7 +92,9 @@ function getOAuthDomain(environment) {
   }
 
   if (environment === 'production') {
-    return 'https://www1.nyc.gov';
+    // prefer the environment variable.
+    // "staging" and "develop" deploys need a different non-production form of this.
+    return NYCID_DOMAIN || 'https://www1.nyc.gov';
   }
 
   if (environment === 'test') {

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,12 +13,12 @@
 
 # qa team
 [context.qa]
-  environment = { HOST="https://applicant-portal-qa.herokuapp.com", NYCID_CLIENT_ID='applicant-portal-qa' }
+  environment = { HOST="https://applicant-portal-qa.herokuapp.com", NYCID_CLIENT_ID='applicant-portal-qa', NYCID_DOMAIN='https://accounts-nonprd.nyc.gov' }
 
 # training
 [context.training]
-  environment = { HOST="https://applicant-portal-training.herokuapp.com", NYCID_CLIENT_ID='applicant-portal-training' }
+  environment = { HOST="https://applicant-portal-training.herokuapp.com", NYCID_CLIENT_ID='applicant-portal-training', NYCID_DOMAIN='https://accounts-nonprd.nyc.gov' }
 
 # develop
 [context.develop]
-  environment = { HOST="https://applicant-portal-develop.herokuapp.com", NYCID_CLIENT_ID='applicant-portal-develop' }
+  environment = { HOST="https://applicant-portal-develop.herokuapp.com", NYCID_CLIENT_ID='applicant-portal-develop', NYCID_DOMAIN='https://accounts-nonprd.nyc.gov' }


### PR DESCRIPTION
When deployed to any environment, Ember's internal setting is always "production."

When I switched the NYC.ID domain to prod, it caused non production environments to break because they were pulling NYC.ID guids from the non-prod environment and using those to query the prod env.

This change provies an env variable to override that domain to non-prod.