### PR TITLE
12414 QP to list lu projs under awaiting submission

### DIFF
--- a/client/app/controllers/project.js
+++ b/client/app/controllers/project.js
@@ -6,6 +6,10 @@ import { optionset } from '../helpers/optionset';
 import { STATECODE, STATUSCODE } from '../optionsets/contact';
 
 export default class ProjectController extends Controller {
+  queryParams = ['landuse'];
+
+  @tracked landuse = false;
+
   @tracked contactMgmtOpen = false;
 
   @tracked addEditorModalOpen;

--- a/client/app/controllers/projects.js
+++ b/client/app/controllers/projects.js
@@ -27,7 +27,10 @@ export default class ProjectsController extends Controller {
   get toDoProjects () {
     // Check that at least ONE of the packages is currently editable
     return this.model.filter((project) =>
-      packageIsToDo(project.pasPackages) || packageIsToDo(project.rwcdsPackages));
+      packageIsToDo(project.pasPackages)
+      || packageIsToDo(project.rwcdsPackages)
+      || packageIsToDo(project.landusePackages)
+    );
   }
 
   // Projects in NYC Planning's hands

--- a/client/app/controllers/projects.js
+++ b/client/app/controllers/projects.js
@@ -1,5 +1,6 @@
 import Controller from '@ember/controller';
 import { sort } from '@ember/object/computed';
+import { tracked } from '@glimmer/tracking';
 import {
   STATUSCODE,
   DCPVISIBILITY,
@@ -20,23 +21,24 @@ export function packageIsToDo(projectPackages) {
 }
 
 export default class ProjectsController extends Controller {
+  queryParams = ['landuse'];
+
+  @tracked landuse = false;
   // TODO: organize this business logic as computed properties on the projects model
 
   // Projects awaiting the applicant's submission
   // (includes active projects with packages that haven't been submitted)
-  get toDoProjects () {
+  get toDoProjects() {
     // Check that at least ONE of the packages is currently editable
-    return this.model.filter((project) =>
-      packageIsToDo(project.pasPackages)
+    return this.model.filter((project) => packageIsToDo(project.pasPackages)
       || packageIsToDo(project.rwcdsPackages)
-      || packageIsToDo(project.landusePackages)
-    );
+      || (packageIsToDo(project.landusePackages) && this.landuse));
   }
 
   // Projects in NYC Planning's hands
   // These are all other returned projects that are not in toDoProjects
   // (includes projects under review, on hold, with no packages, etc)
-  get doneProjects () {
+  get doneProjects() {
     return this.model.filter((project) => !this.toDoProjects.includes(project));
   }
 
@@ -45,12 +47,12 @@ export default class ProjectsController extends Controller {
   // addresses should first be sorted alphabetically by their street name,
   // and secondly by their house number. (Currently, the sort is alphabetical
   // even across the house number, so "123" < "8" === true)
-  @sort('toDoProjects', function(projectA, projectB) {
+  @sort('toDoProjects', function (projectA, projectB) {
     return projectA.dcpProjectname.localeCompare(projectB.dcpProjectname);
   })
   sortedToDoProjects;
 
-  @sort('doneProjects', function(projectA, projectB) {
+  @sort('doneProjects', function (projectA, projectB) {
     return projectA.dcpProjectname.localeCompare(projectB.dcpProjectname);
   })
   sortedDoneProjects;

--- a/client/app/templates/project.hbs
+++ b/client/app/templates/project.hbs
@@ -36,15 +36,17 @@
 
     </section>
 
-    {{#if @model.landusePackages.length}}
-      <h2>Draft Land Use Form</h2>
-      <ol class="no-bullet">
-        {{#each @model.landusePackages as |landusePackage|}}
-          <Project::PackageListItem
-            @package={{landusePackage}}
-          />
-        {{/each}}
-      </ol>
+    {{#if this.landuse}}
+      {{#if @model.landusePackages.length}}
+        <h2>Draft Land Use Form</h2>
+        <ol class="no-bullet">
+          {{#each @model.landusePackages as |landusePackage|}}
+            <Project::PackageListItem
+              @package={{landusePackage}}
+            />
+          {{/each}}
+        </ol>
+      {{/if}}
     {{/if}}
 
     {{#if @model.rwcdsPackages.length}}


### PR DESCRIPTION
### Summary
Defaults to hiding Land Use packages on the Project page, and to
list Projects with active Land Use packages under "other". 

A user can append `?landuse=true` to the `/projects` and `/project/<project_id>` routes to
show LU packages and see Projects with active LU packages under
"Await submission"

Fixes [AB#12414](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12414)
