### PR TITLE
12401: lead-agency section on landuse form

### DIFF
--- a/client/app/components/packages/landuse-form/edit.hbs
+++ b/client/app/components/packages/landuse-form/edit.hbs
@@ -55,6 +55,7 @@
 
       <Packages::LanduseForm::EnvironmentalReview
         @form={{saveableForm}}
+        @accounts={{@accounts}}
       />
 
       <Packages::LanduseForm::ProposedActions

--- a/client/app/components/packages/landuse-form/environmental-review.hbs
+++ b/client/app/components/packages/landuse-form/environmental-review.hbs
@@ -1,6 +1,11 @@
 {{#let @form as |form|}}
   <form.Section @title="Environmental Review">
 
+    <Packages::LanduseForm::LeadAgency
+      @landuseForm={{form}}
+      @accounts={{@accounts}}
+    />
+
     <Ui::Question as |Q|>
       <Q.Label>
         What is the CEQR number?

--- a/client/app/components/packages/landuse-form/lead-agency.hbs
+++ b/client/app/components/packages/landuse-form/lead-agency.hbs
@@ -1,0 +1,23 @@
+{{#let @landuseForm as |landuseForm|}}
+  <div>
+    <h5 class="small-margin-bottom">
+      Who is the lead agency?
+    </h5>
+
+    <label data-test-lead-agency-picker>
+      <PowerSelect
+        triggerClass="lead-agency-dropdown"
+        supportsDataTestProperties={{true}}
+        @placeholder={{this.searchPlaceholder}}
+        @searchEnabled={{true}}
+        @options={{this.accountNames}}
+        @selected={{this.chosenAccountName}}
+        @onChange={{fn (mut this.chosenAccountName)}}
+        @onClose={{fn (mut landuseForm.data.chosenLeadAgencyId) this.chosenAccountId}}
+        as |accountName|
+      >
+        {{accountName}}
+      </PowerSelect>
+    </label>
+  </div>
+{{/let}}

--- a/client/app/components/packages/landuse-form/lead-agency.js
+++ b/client/app/components/packages/landuse-form/lead-agency.js
@@ -1,0 +1,23 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class PackagesLanduseFormLeadAgencyComponent extends Component {
+  @tracked chosenAccountName;
+
+  get accountNames() {
+    if (this.args.accounts) {
+      return this.args.accounts.map((account) => account.name);
+    } return [];
+  }
+
+  get searchPlaceholder() {
+    if (this.args.landuseForm.data.leadAgency) {
+      return this.args.landuseForm.data.leadAgency.name;
+    } return 'Search agencies...';
+  }
+
+  get chosenAccountId() {
+    const account = this.args.accounts.find((account) => account.name === this.chosenAccountName);
+    return account.id;
+  }
+}

--- a/client/app/models/account.js
+++ b/client/app/models/account.js
@@ -1,0 +1,6 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class AccountModel extends Model {
+  @attr
+  name;
+}

--- a/client/app/models/landuse-form.js
+++ b/client/app/models/landuse-form.js
@@ -22,6 +22,13 @@ export default class LanduseFormModel extends Model {
   @hasMany('landuse-geography', { async: false })
   landuseGeographies;
 
+  // this is just for GETting dcp_leadagency information
+  // we do not PATCH or POST directly to dcp_leadagency
+  // instead we handle sending related information to the backend
+  // through a made-up field called `chosenLeadAgencyId`
+  @belongsTo('lead-agency', { async: false })
+  leadAgency;
+
   @attr dcpVersion;
 
   // project name
@@ -79,8 +86,6 @@ export default class LanduseFormModel extends Model {
   @attr dcpSitedataidentifylandmark;
 
   // Environmental Review attrs
-  @attr dcpLeadagency;
-
   @attr dcpCeqrnumber;
 
   @attr dcpCeqrtype;
@@ -184,6 +189,10 @@ export default class LanduseFormModel extends Model {
   @attr dcpRelatedacquisition;
 
   @attr dcpOnlychangetheeliminationofamappedbutunimp;
+
+  // A made-up field so we can send an id to the backend
+  // and we can bind an account to the dcp_leadagency field
+  @attr chosenLeadAgencyId;
 
   async save() {
     await this.saveDirtyLanduseActions();

--- a/client/app/models/lead-agency.js
+++ b/client/app/models/lead-agency.js
@@ -1,0 +1,8 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class LeadAgencyModel extends Model {
+  @belongsTo('landuse-form', { async: false })
+  landuseForm;
+
+  @attr name;
+}

--- a/client/app/routes/landuse-form.js
+++ b/client/app/routes/landuse-form.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import RSVP from 'rsvp';
 
 export default class LanduseFormRoute extends Route.extend(AuthenticatedRouteMixin) {
   authenticationRoute = '/';
@@ -15,12 +16,16 @@ export default class LanduseFormRoute extends Route.extend(AuthenticatedRouteMix
         'landuse-form.landuse-actions',
         'landuse-form.sitedatah-forms',
         'landuse-form.landuse-geographies',
+        'landuse-form.lead-agency',
       ].join(),
     });
 
     // manually generate a file factory
     landuseFormPackage.createFileQueue();
 
-    return landuseFormPackage;
+    return RSVP.hash({
+      package: landuseFormPackage,
+      accounts: await this.store.findAll('account'),
+    });
   }
 }

--- a/client/app/templates/landuse-form/edit.hbs
+++ b/client/app/templates/landuse-form/edit.hbs
@@ -6,7 +6,8 @@
 </Ui::Breadcrumbs>
 
 <Packages::LanduseForm::Edit
-  @package={{@model}}
+  @package={{@model.package}}
+  @accounts={{@model.accounts}}
 />
 
 {{outlet}}

--- a/client/mirage/config.js
+++ b/client/mirage/config.js
@@ -76,6 +76,11 @@ export default function() {
   this.get('/landuse-actions');
   this.patch('/landuse-actions/:id');
 
+  this.get('/lead-agencys');
+  this.get('/lead-agencys/:id');
+  this.get('/accounts');
+  this.get('/accounts/:id');
+
   this.post('/documents', function(schema, request) {
     // requestBody should be a FormData object
     const { requestBody } = request;

--- a/client/mirage/models/account.js
+++ b/client/mirage/models/account.js
@@ -1,0 +1,4 @@
+import { Model } from 'ember-cli-mirage';
+
+export default Model.extend({
+});

--- a/client/mirage/models/landuse-form.js
+++ b/client/mirage/models/landuse-form.js
@@ -6,4 +6,5 @@ export default Model.extend({
   landuseActions: hasMany('landuse-action'),
   bbls: hasMany('bbl'),
   relatedActions: hasMany('related-action'),
+  leadAgency: belongsTo('lead-agency'),
 });

--- a/client/mirage/models/lead-agency.js
+++ b/client/mirage/models/lead-agency.js
@@ -1,0 +1,5 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  landuseForm: belongsTo('landuse-form'),
+});

--- a/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
@@ -1004,4 +1004,35 @@ module('Acceptance | user can click landuse form edit', function (hooks) {
 
     assert.dom('[data-test-proposed-site-title]').doesNotExist();
   });
+
+  test('User can update lead-agency', async function(assert) {
+    this.server.create('project', 1, {
+      packages: [this.server.create('package', 'toDo', 'landuseForm')],
+    });
+    this.server.create('account', 1, {
+      name: 'first account',
+    });
+    this.server.create('account', 2, {
+      name: 'second account',
+    });
+    this.server.create('account', 3, {
+      name: 'third account',
+    });
+
+    await visit('/landuse-form/1/edit');
+
+    // filling out necessary information in order to save
+    await click('[data-test-add-applicant-button]');
+    await fillIn('[data-test-input="dcpFirstname"]', 'Tess');
+    await fillIn('[data-test-input="dcpLastname"]', 'Ter');
+    await fillIn('[data-test-input="dcpEmail"]', 'tesster@planning.nyc.gov');
+
+    await selectChoose('[data-test-lead-agency-picker]', 'second account');
+
+    await click('[data-test-save-button]');
+
+    assert.equal(this.server.db.landuseForms.firstObject.chosenLeadAgencyId, 2);
+
+    assert.equal(currentURL(), '/landuse-form/1/edit');
+  });
 });

--- a/server/src/accounts/accounts.attrs.ts
+++ b/server/src/accounts/accounts.attrs.ts
@@ -1,0 +1,4 @@
+export const ACCOUNT_ATTRS = [
+  'name',
+];
+  

--- a/server/src/accounts/accounts.controller.ts
+++ b/server/src/accounts/accounts.controller.ts
@@ -1,0 +1,79 @@
+import {
+    Controller,
+    Get,
+    Patch,
+    Body,
+    Query,
+    HttpException,
+    HttpStatus,
+    Session,
+    UseInterceptors,
+    UseGuards,
+    UsePipes,
+    Param,
+  } from '@nestjs/common';
+  import { CrmService } from '../crm/crm.service';
+  import { JsonApiSerializeInterceptor } from '../json-api-serialize.interceptor';
+  import { AuthenticateGuard } from '../authenticate.guard';
+  import { JsonApiDeserializePipe } from '../json-api-deserialize.pipe';
+  import { ACCOUNT_ATTRS } from './accounts.attrs';
+  import { pick } from 'underscore';
+
+  const ACTIVE_STATUSCODE = 1;
+  
+  @UseInterceptors(new JsonApiSerializeInterceptor('accounts', {
+    id: 'accountid',
+    attributes: [
+      ...ACCOUNT_ATTRS,
+    ],
+  
+    transform(account) {
+      try {
+        return {
+          ...account,
+        };
+      } catch(e) {
+        if (e instanceof HttpException) {
+          throw e;
+        } else {
+          throw new HttpException({
+            code: 'ACCOUNTS_ERROR',
+            title: 'Failed load accounts',
+            detail: `An error occurred while loading one or more accounts. ${e.message}`,
+          }, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+      }
+    },
+  }))
+  @UseGuards(AuthenticateGuard)
+  @UsePipes(JsonApiDeserializePipe)
+  @Controller('accounts')
+  export class AccountsController {
+    constructor(
+      private readonly crmService: CrmService,
+    ) {}
+  
+    @Get('/')
+    async accounts() {
+      try {
+        const { records } = await this.crmService.get('accounts',
+          `$select=name
+          &$filter=
+          statuscode eq ${ACTIVE_STATUSCODE}
+          and dcp_agencyceqracronym ne null
+      `);
+        return records;
+      } catch (e) {
+        if (e instanceof HttpException) {
+          throw e;
+        } else {
+          throw new HttpException({
+            code: 'FIND_ACCOUNTS_FAILED',
+            title: 'Failed getting accounts',
+            detail: `An unknown server error occured while getting accounts. ${e.message}`,
+          }, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+      }
+    }
+  }
+  

--- a/server/src/accounts/accounts.module.ts
+++ b/server/src/accounts/accounts.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { CrmModule } from '../crm/crm.module';
+import { AccountsController } from './accounts.controller';
+
+@Module({
+  imports: [
+    CrmModule,
+  ],
+  providers: [],
+  exports: [],
+  controllers: [AccountsController],
+})
+export class AccountsModule {}

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -8,6 +8,7 @@ import { ConfigModule } from './config/config.module';
 import { ContactModule } from './contact/contact.module';
 import { CrmModule } from './crm/crm.module';
 import { ProjectsModule } from './projects/projects.module';
+import { AccountsModule } from './accounts/accounts.module';
 import { PackagesModule } from './packages/packages.module';
 import { DocumentModule } from './document/document.module';
 import { CitypayService } from './citypay/citypay.service';
@@ -16,6 +17,7 @@ import { CitypayModule } from './citypay/citypay.module';
 @Module({
   imports: [
     AuthModule,
+    AccountsModule,
     ConfigModule,
     ContactModule,
     CrmModule,

--- a/server/src/packages/landuse-form/landuse-form.attrs.ts
+++ b/server/src/packages/landuse-form/landuse-form.attrs.ts
@@ -444,7 +444,6 @@ export const LANDUSE_FORM_ATTRS = [
   'dcp_landuse_ProcessSession',
   'dcp_landuse_BulkDeleteFailures',
   'dcp_landuse_PrincipalObjectAttributeAccesses',
-  'dcp_leadagency',
   'dcp_landuseform_dcp_landuse',
   'dcp_landuse_dcp_sitedatageneralform_landuseform',
   'dcp_landuse_Annotations',

--- a/server/src/packages/landuse-form/landuse-form.controller.ts
+++ b/server/src/packages/landuse-form/landuse-form.controller.ts
@@ -18,6 +18,9 @@ import { LANDUSE_FORM_ATTRS } from './landuse-form.attrs';
 @UseInterceptors(new JsonApiSerializeInterceptor('landuse-forms', {
   attributes: [
     ...LANDUSE_FORM_ATTRS,
+
+    // this is an association. before, we thought it wasn't!
+    'dcp_leadagency',
   ],
 }))
 @UseGuards(AuthenticateGuard)
@@ -30,7 +33,11 @@ export class LanduseFormController {
   async update(@Body() body, @Param('id') id) {
     const allowedAttrs = pick(body, LANDUSE_FORM_ATTRS);
 
-    await this.crmService.update('dcp_landuses', id, allowedAttrs);
+    await this.crmService.update('dcp_landuses', id, {
+      ...allowedAttrs,
+
+      ...(body.chosen_lead_agency_id ? { 'dcp_leadagency@odata.bind': `/accounts(${body.chosen_lead_agency_id})` } : {}),
+    });
 
     return {
       dcp_landuseid: id,

--- a/server/src/packages/landuse-form/landuse-form.service.ts
+++ b/server/src/packages/landuse-form/landuse-form.service.ts
@@ -32,7 +32,8 @@ export class LanduseFormService {
         dcp_landuseid eq ${id}
       &$expand=
         dcp_dcp_landuse_dcp_sitedatahform_landuseform,
-        dcp_dcp_landuse_dcp_landusegeography_landuseform
+        dcp_dcp_landuse_dcp_landusegeography_landuseform,
+        dcp_leadagency
     `);
 
     return {

--- a/server/src/packages/packages.controller.ts
+++ b/server/src/packages/packages.controller.ts
@@ -108,6 +108,7 @@ import { CitypayService } from '../citypay/citypay.service';
       'landuse-actions',
       'sitedatah-forms',
       'landuse-geographies',
+      'lead-agency',
     ],
     applicants: {
       ref: 'dcp_applicantinformationid',
@@ -144,6 +145,13 @@ import { CitypayService } from '../citypay/citypay.service';
       ref: 'dcp_landusegeographyid',
       attributes: [
         ...LANDUSE_GEOGRAPHY_ATTRS,
+      ],
+    },
+    'lead-agency': {
+      ref: 'accountid',
+      attributes: [
+        'name',
+        'accountid',
       ],
     },
   },
@@ -223,6 +231,7 @@ import { CitypayService } from '../citypay/citypay.service';
             'landuse-actions': landuseForm.dcp_dcp_landuse_dcp_landuseaction,
             'sitedatah-forms': landuseForm.dcp_dcp_landuse_dcp_sitedatahform_landuseform,
             'landuse-geographies': landuseForm.dcp_dcp_landuse_dcp_landusegeography_landuseform,
+            'lead-agency': landuseForm.dcp_leadagency,
           }
         }
       } else {


### PR DESCRIPTION
**Big Picture Summary**
Users can use a dropdown to search and select a lead agency (e.g. DOE) on the Environmental Review section of the Land Use Form.

**Which major feature does this fit into?**
Draft Land Use Form

**Technical Explanation — How does it work?**
- A **new componen**t was created called `lead-agency` that is rendered on the `environmental-review` component, which is then rendered on the landuse-form
- We have a GET for the `accounts` entity in order to **display a list of all accounts** that match the desired criteria in a dropdown. 
- When a user selects an option from the **dropdown**, the field `chosenLeadAgencyId`, which is just a made-up field and does not exist in CRM, is updated to match the id of the account selected. 
- When the user saves the landuse-form, this `chosenLeadAgencyId` is sent to the backend. And this **account id is then used to bind** the matching account to the `dcp_landuse`'s `dcp_leadagency` field. 
- We never PATCH or POST to this `dcp_leadagency` field. This field is dependent on the "bind" to the matching account. We GET information from `dcp_leadagency` in order to handle display logic on the frontend, but other than that we do not interact with the `lead-agency` model.

Closes [AB#12401](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12401)

**Next steps**: instead of a made-up field on the landuse-form, we should update the lead-agency model and then grab the id from the relationship field of the response body on the landuse-form controller