### PR TITLE
12395 draft lu zoning map amendment

### DIFF
--- a/client/app/components/packages/landuse-form/edit.hbs
+++ b/client/app/components/packages/landuse-form/edit.hbs
@@ -74,13 +74,6 @@
         @form={{saveableForm}}
       />
 
-      <Packages::LanduseForm::ZoningTextAmendment
-        @form={{saveableForm}}
-        @addZrSection={{this.addZrSection}}
-        @removeZrSection={{this.removeZrSection}}
-        @validations={{this.validations}}
-      />
-
       {{#let (intersect
         (map-by "dcpActioncode" this.landuseForm.landuseActions)
         (array 'HA' 'HC' 'HD' 'HG' 'HN' 'HO' 'HP' 'HU')
@@ -119,6 +112,20 @@
 
       <Packages::LanduseForm::Disposition
         @form={{saveableForm}}
+      />
+
+      <Packages::LanduseForm::ZoningTextAmendment
+        @form={{saveableForm}}
+        @addZrSection={{this.addZrSection}}
+        @removeZrSection={{this.removeZrSection}}
+        @validations={{this.validations}}
+      />
+
+      <Packages::LanduseForm::ZoningMapAmendment
+        @form={{saveableForm}}
+        @addZoningMapChange={{this.addZoningMapChange}}
+        @removeZoningMapChange={{this.removeZoningMapChange}}
+        @validations={{this.validations}}
       />
 
       <Packages::LanduseForm::AttachedDocuments

--- a/client/app/components/packages/landuse-form/edit.js
+++ b/client/app/components/packages/landuse-form/edit.js
@@ -17,6 +17,8 @@ import SaveableLanduseGeographyValidations from '../../../validations/saveable-l
 import SubmittableLanduseGeographyValidations from '../../../validations/submittable-landuse-geography';
 import SaveableAffectedZoningResolutionFormValidations from '../../../validations/saveable-affected-zoning-resolution-form';
 import SubmittableAffectedZoningResolutionFormValidations from '../../../validations/submittable-affected-zoning-resolution-form';
+import SaveableZoningMapChangeValidations from '../../../validations/saveable-zoning-map-change';
+import SubmittableZoningMapChangeValidations from '../../../validations/submittable-zoning-map-change';
 import { addToHasMany, removeFromHasMany } from '../../../utils/ember-changeset';
 
 export default class LandUseFormComponent extends Component {
@@ -36,6 +38,8 @@ export default class LandUseFormComponent extends Component {
     SubmittableLanduseGeographyValidations,
     SaveableAffectedZoningResolutionFormValidations,
     SubmittableAffectedZoningResolutionFormValidations,
+    SaveableZoningMapChangeValidations,
+    SubmittableZoningMapChangeValidations,
   };
 
   @tracked recordsToDelete = [];
@@ -171,5 +175,23 @@ export default class LandUseFormComponent extends Component {
     this.recordsToDelete.push(affectedZoningResolution);
 
     affectedZoningResolution.deleteRecord();
+  }
+
+  @action
+  addZoningMapChange(changeset) {
+    const newZoningMapChange = this.store.createRecord('zoning-map-change', {
+      landuseForm: this.landuseForm,
+    });
+
+    addToHasMany(changeset, 'zoningMapChanges', newZoningMapChange);
+  }
+
+  @action
+  removeZoningMapChange(zoningMapChange, changeset) {
+    removeFromHasMany(changeset, 'zoningMapChanges', zoningMapChange);
+
+    this.recordsToDelete.push(zoningMapChange);
+
+    zoningMapChange.deleteRecord();
   }
 }

--- a/client/app/components/packages/landuse-form/zoning-map-amendment-fieldset.hbs
+++ b/client/app/components/packages/landuse-form/zoning-map-amendment-fieldset.hbs
@@ -1,0 +1,71 @@
+{{#let @form as |form|}}
+  <Ui::Question
+    class="fieldset relative"
+    ...attributes
+  as |Q|>
+    <Q.Legend data-test-zoning-map-change-title>
+      Zoning Map Change
+    </Q.Legend>
+
+    <Ui::Question
+    as |dcpZoningsectionmapsnumberQ|>
+      <dcpZoningsectionmapsnumberQ.Label>
+        Zoning Section Map(s) Number
+      </dcpZoningsectionmapsnumberQ.Label>
+
+      <form.Field
+        @attribute="dcpZoningsectionmapsnumber"
+        @maxlength="100"
+        @showCounter={{true}}
+        id={{dcpZoningsectionmapsnumberQ.id}}
+      />
+    </Ui::Question>
+
+
+    <Ui::Question
+    as |dcpExistingzoningdistrictvalueQ|>
+      <dcpExistingzoningdistrictvalueQ.Label
+        data-test-applicant-state-dropdown
+      >
+        Existing Zoning District(s)
+      </dcpExistingzoningdistrictvalueQ.Label>
+      
+      <label data-test-dcpExistingzoningdistrictvalue-dropdown>
+        <PowerSelect
+          supportsDataTestProperties={{true}}
+          @selected={{form.data.dcpExistingzoningdistrictvalue}}
+          @placeholder="-- select --"
+          @options={{map-by 'code' (optionset 'zoningMapChange' 'dcpExistingzoningdistrictvalue' 'list')}}
+          @onChange={{fn (mut form.data.dcpExistingzoningdistrictvalue)}}
+        as |dcpExistingzoningdistrictvalue|>
+          {{optionset 'zoningMapChange' 'dcpExistingzoningdistrictvalue' 'label' dcpExistingzoningdistrictvalue}}
+        </PowerSelect>
+      </label>
+    </Ui::Question>
+
+    <Ui::Question
+    as |dcpProposedzoningmapvalueQ|>
+      <dcpProposedzoningmapvalueQ.Label>
+        Proposed Zoning District(s)
+      </dcpProposedzoningmapvalueQ.Label>
+
+      <form.Field
+        @attribute="dcpProposedzoningmapvalue"
+        @maxlength="100"
+        @showCounter={{true}}
+        id={{dcpProposedzoningmapvalueQ.id}}
+      />
+    </Ui::Question>
+
+    <button
+      type="button"
+      class="delete-fieldset"
+      {{on "click" (fn @removeZoningMapChange form.data)}}
+      data-test-remove-zoning-map-change-button
+    >
+      Delete Zoning Map Change
+      <FaIcon @icon="times" @prefix="fas" @fixedWidth={{true}} />
+    </button>
+
+  </Ui::Question>
+{{/let}}

--- a/client/app/components/packages/landuse-form/zoning-map-amendment.hbs
+++ b/client/app/components/packages/landuse-form/zoning-map-amendment.hbs
@@ -1,0 +1,83 @@
+{{#let @form as |form|}}
+  {{#if (in-array
+    (map-by "dcpActioncode" form.data.data.landuseActions)
+    'ZM')
+  }}
+    <form.Section @title="Zoning Map Amendment">
+      {{#if form.errors.zoningMapChanges}}
+        {{#each form.errors.zoningMapChanges.validation as |message|}}
+          <div class="callout alert"
+            data-test-validation-message="has-zoningMapChanges">
+            {{message}}
+          </div>
+        {{/each}}
+      {{/if}}
+
+      <Ui::Question
+      as |dcpTotalzoningareatoberezonedQ|>
+        <dcpTotalzoningareatoberezonedQ.Label>
+          What is the total area of all Zoning Lots in the area to the be rezoned?
+        </dcpTotalzoningareatoberezonedQ.Label>
+        
+        {{!-- Todo: refactor to avoid double label for sake of PowerSelect --}}
+        <label data-test-dcpTotalzoningareatoberezoned-dropdown>
+          <PowerSelect
+            supportsDataTestProperties={{true}}
+            @selected={{form.data.dcpTotalzoningareatoberezoned}}
+            @placeholder="-- select --"
+            @options={{map-by 'code' (optionset 'landuseForm' 'dcpTotalzoningareatoberezoned' 'list')}}
+            @onChange={{fn (mut form.data.dcpTotalzoningareatoberezoned)}}
+          as |dcpTotalzoningareatoberezoned|>
+            {{optionset 'landuseForm' 'dcpTotalzoningareatoberezoned' 'label' dcpTotalzoningareatoberezoned}}
+          </PowerSelect>
+        </label>
+      </Ui::Question>
+
+      <p>
+        List all Zoning Map changes
+      </p>
+      <ul class="no-bullet">
+        {{#each
+          (filter-by 'isDeleted' false @form.data.zoningMapChanges)
+        as |zoningMapChange zoningMapChangeIndex|}}
+          <li class="scale-fade-in">
+            <form.SaveableForm
+              @model={{zoningMapChange}}
+              @validators={{array
+                @validations.SaveableZoningMapChangeValidations
+                @validations.SubmittableZoningMapChangeValidations
+              }}
+            as |zoningMapChangeForm|>
+              <Packages::LanduseForm::ZoningMapAmendmentFieldset
+                @form={{zoningMapChangeForm}}
+                @removeZoningMapChange={{fn
+                  @removeZoningMapChange
+                  zoningMapChange
+                  @form.data}}
+                data-test-zoning-map-change-fieldset={{zoningMapChangeIndex}}
+              />
+            </form.SaveableForm>
+          </li>
+        {{/each}}
+      </ul>
+
+      <div class="fieldset-adder">
+        <h5 class="small-margin-bottom">
+          Add a Zoning Map Change:
+        </h5>
+        <div class="grid-x">
+          <div class="cell large-6 small-padding-right">
+            <button
+              class="button expanded secondary no-margin"
+              type="button"
+              {{on "click" (fn @addZoningMapChange @form.data) }}
+              data-test-add-zoning-map-change-button
+            >
+              <strong>Add Zoning Map Change</strong>
+            </button>
+          </div>
+        </div>
+      </div>
+    </form.Section>
+  {{/if}}
+{{/let}}

--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -16,6 +16,7 @@ import {
 } from '../optionsets/affected-zoning-resolution';
 import LANDUSE_ACTION_OPTIONSETS from '../optionsets/landuse-action';
 import LANDUSE_GEOGRAPHY_OPTIONSETS from '../optionsets/landuse-geography';
+import ZONING_MAP_CHANGE_OPTIONSETS from '../optionsets/zoning-map-change';
 import PACKAGE_OPTIONSETS from '../optionsets/package';
 import LANDUSE_FORM_OPTIONSETS from '../optionsets/landuse-form';
 import {
@@ -97,6 +98,7 @@ const OPTIONSET_LOOKUP = {
     dcpChangestreetalignmentopt: COMMON_OPTIONSETS.YES_NO_INTEGER,
     dcpChangestreetgradeopt: COMMON_OPTIONSETS.YES_NO_INTEGER,
     dcpTypedisposition: LANDUSE_FORM_OPTIONSETS.DCPTYPEDISPOSITION,
+    dcpTotalzoningareatoberezoned: LANDUSE_FORM_OPTIONSETS.DCPTOTALZONINGAREATOBEREZONED,
   },
   rwcdsForm: {
     dcpHasprojectchangedsincesubmissionofthepas: YES_NO,
@@ -134,6 +136,9 @@ const OPTIONSET_LOOKUP = {
   },
   landuseGeography: {
     dcpIsthesiteimprovedunimprovedorpartlyimp: LANDUSE_GEOGRAPHY_OPTIONSETS.DCPISTHESITEIMPROVEDUNIMPROVEDORPARTLYIMP,
+  },
+  zoningMapChange: {
+    dcpExistingzoningdistrictvalue: ZONING_MAP_CHANGE_OPTIONSETS.DCPEXISTINGZONINGDISTRICTVALUE,
   },
 };
 

--- a/client/app/models/landuse-form.js
+++ b/client/app/models/landuse-form.js
@@ -25,6 +25,9 @@ export default class LanduseFormModel extends Model {
   @hasMany('affected-zoning-resolution', { async: false })
   affectedZoningResolutions;
 
+  @hasMany('zoning-map-change', { async: false })
+  zoningMapChanges;
+
   // this is just for GETting dcp_leadagency information
   // we do not PATCH or POST directly to dcp_leadagency
   // instead we handle sending related information to the backend
@@ -204,6 +207,9 @@ export default class LanduseFormModel extends Model {
 
   @attr dcpTowhom;
 
+  // Zoning Map Amendment attrs
+  @attr dcpTotalzoningareatoberezoned;
+
   async save() {
     await this.saveDirtyLanduseActions();
     await this.saveDirtyRelatedActions();
@@ -213,6 +219,7 @@ export default class LanduseFormModel extends Model {
     await this.saveDirtyBbls();
     await this.saveDirtyProject();
     await this.saveDirtyAffectedZoningResolutions();
+    await this.saveZoningMapChanges();
     await super.save();
   }
 
@@ -278,6 +285,14 @@ export default class LanduseFormModel extends Model {
     );
   }
 
+  async saveZoningMapChanges() {
+    return Promise.all(
+      this.zoningMapChanges
+        .filter((zoningMapChange) => zoningMapChange.hasDirtyAttributes)
+        .map((zoningMapChange) => zoningMapChange.save()),
+    );
+  }
+
   get isLanduseActionsDirty() {
     const dirtyLanduseActions = this.landuseActions.filter((action) => action.hasDirtyAttributes);
 
@@ -323,5 +338,11 @@ export default class LanduseFormModel extends Model {
     const dirtyZrs = this.affectedZoningResolutions.filter((zr) => zr.hasDirtyAttributes);
 
     return dirtyZrs.length > 0;
+  }
+
+  get isZoningMapChanges() {
+    const dirtyZoningMapChanges = this.zoningMapChanges.filter((zoningMapChange) => zoningMapChange.hasDirtyAttributes);
+
+    return dirtyZoningMapChanges.length > 0;
   }
 }

--- a/client/app/models/package.js
+++ b/client/app/models/package.js
@@ -136,7 +136,8 @@ export default class PackageModel extends Model {
         || this.landuseForm.isLanduseGeographiesDirty
         || this.landuseForm.isRelatedActionsDirty
         || this.landuseForm.isProjectDirty
-        || this.landuseForm.isAffectedZoningResolutionsDirty;
+        || this.landuseForm.isAffectedZoningResolutionsDirty
+        || this.landuseForm.isZoningMapChangesDirty;
     }
 
     return isPackageDirty;

--- a/client/app/models/zoning-map-change.js
+++ b/client/app/models/zoning-map-change.js
@@ -1,0 +1,38 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class ZoningMapChangeModel extends Model {
+  @belongsTo('landuse-form', { async: false })
+  landuseForm;
+
+  @attr versionnumber;
+
+  @attr dcpProposedzoningmapvalue;
+
+  @attr statuscode;
+
+  @attr overriddencreatedon;
+
+  @attr modifiedon;
+
+  @attr createdon;
+
+  @attr statecode;
+
+  @attr dcpZoningsectionmapsnumber;
+
+  @attr dcpProposedzoningdistrictvalue;
+
+  @attr dcpChangenumber;
+
+  @attr importsequencenumber;
+
+  @attr dcpNumber;
+
+  @attr utcconversiontimezonecode;
+
+  @attr dcpZoningmapchangesid;
+
+  @attr dcpExistingzoningdistrictvalue;
+
+  @attr dcpName;
+}

--- a/client/app/optionsets/landuse-form.js
+++ b/client/app/optionsets/landuse-form.js
@@ -129,6 +129,41 @@ export const DCPTYPEDISPOSITION = {
   },
 };
 
+export const DCPTOTALZONINGAREATOBEREZONED = {
+  LT_10K: {
+    code: 717170000,
+    label: 'Less than 10,000 square feet',
+  },
+  LT_20K: {
+    code: 717170001,
+    label: '10,000 to 19,999 square feet',
+  },
+  LT_40K: {
+    code: 717170002,
+    label: '20,000 to 39,999 square feet',
+  },
+  LT_70K: {
+    code: 717170003,
+    label: '40,000 to 69,999 square feet',
+  },
+  LT_100K: {
+    code: 717170004,
+    label: '70,000 to 99,999 square feet',
+  },
+  LT_240K: {
+    code: 717170005,
+    label: '100,000 to 239,999 square feet',
+  },
+  LTE_500K: {
+    code: 717170006,
+    label: '240,000 to 500,000 square feet',
+  },
+  GT_500K: {
+    code: 717170007,
+    label: 'Greater than 500,000 square feet',
+  },
+};
+
 const LANDUSE_FORM_OPTIONSETS = {
   CEQR_TYPE,
   DCPDEVSIZE,
@@ -141,6 +176,7 @@ const LANDUSE_FORM_OPTIONSETS = {
   DCPLEGALINSTRUMENT,
   DCPONLYCHANGETHEELIMINATIONOFAMAPPEDBUTUNIMP,
   DCPTYPEDISPOSITION,
+  DCPTOTALZONINGAREATOBEREZONED,
 };
 
 export default LANDUSE_FORM_OPTIONSETS;

--- a/client/app/optionsets/zoning-map-change.js
+++ b/client/app/optionsets/zoning-map-change.js
@@ -1,0 +1,600 @@
+export const DCPEXISTINGZONINGDISTRICTVALUE = {
+  R1_1: {
+    code: 717170000,
+    label: 'R1-1',
+  },
+  R1_2: {
+    code: 717170001,
+    label: 'R1-2',
+  },
+  R1_2A: {
+    code: 717170002,
+    label: 'R1-2A',
+  },
+  R2: {
+    code: 717170003,
+    label: 'R2',
+  },
+  R2A: {
+    code: 717170004,
+    label: 'R2A',
+  },
+  R2X: {
+    code: 717170005,
+    label: 'R2X',
+  },
+  R3_1: {
+    code: 717170006,
+    label: 'R3-1',
+  },
+  R3_2: {
+    code: 717170007,
+    label: 'R3-2',
+  },
+  R3A: {
+    code: 717170008,
+    label: 'R3A',
+  },
+  R3X: {
+    code: 717170009,
+    label: 'R3X',
+  },
+  R4: {
+    code: 717170010,
+    label: 'R4',
+  },
+  R4_1: {
+    code: 717170011,
+    label: 'R4-1',
+  },
+  R4A: {
+    code: 717170012,
+    label: 'R4A',
+  },
+  R4B: {
+    code: 717170013,
+    label: 'R4B',
+  },
+  R5: {
+    code: 717170014,
+    label: 'R5',
+  },
+  R5A: {
+    code: 717170015,
+    label: 'R5A',
+  },
+  R5B: {
+    code: 717170016,
+    label: 'R5B',
+  },
+  R5D: {
+    code: 717170017,
+    label: 'R5D',
+  },
+  R6: {
+    code: 717170018,
+    label: 'R6',
+  },
+  R6A: {
+    code: 717170019,
+    label: 'R6A',
+  },
+  R6B: {
+    code: 717170020,
+    label: 'R6B',
+  },
+  R7_1: {
+    code: 717170021,
+    label: 'R7-1',
+  },
+  R7_2: {
+    code: 717170022,
+    label: 'R7-2',
+  },
+  R7_3: {
+    code: 717170023,
+    label: 'R7-3',
+  },
+  R7A: {
+    code: 717170024,
+    label: 'R7A',
+  },
+  R7B: {
+    code: 717170025,
+    label: 'R7B',
+  },
+  R7D: {
+    code: 717170026,
+    label: 'R7D',
+  },
+  R7X: {
+    code: 717170027,
+    label: 'R7X',
+  },
+  R8: {
+    code: 717170028,
+    label: 'R8',
+  },
+  R8A: {
+    code: 717170029,
+    label: 'R8A',
+  },
+  R8B: {
+    code: 717170030,
+    label: 'R8B',
+  },
+  R8X: {
+    code: 717170031,
+    label: 'R8X',
+  },
+  R9: {
+    code: 717170032,
+    label: 'R9',
+  },
+  R9_1: {
+    code: 717170033,
+    label: 'R9-1',
+  },
+  R9A: {
+    code: 717170034,
+    label: 'R9A',
+  },
+  R9D: {
+    code: 717170035,
+    label: 'R9D',
+  },
+  R9X: {
+    code: 717170036,
+    label: 'R9X',
+  },
+  R10: {
+    code: 717170037,
+    label: 'R10',
+  },
+  R10A: {
+    code: 717170038,
+    label: 'R10A',
+  },
+  R10H: {
+    code: 717170039,
+    label: 'R10H',
+  },
+  R10X: {
+    code: 717170040,
+    label: 'R10X',
+  },
+  C1_1: {
+    code: 717170041,
+    label: 'C1-1',
+  },
+  C1_2: {
+    code: 717170042,
+    label: 'C1-2',
+  },
+  C1_3: {
+    code: 717170043,
+    label: 'C1-3',
+  },
+  C1_4: {
+    code: 717170044,
+    label: 'C1-4',
+  },
+  C1_5: {
+    code: 717170045,
+    label: 'C1-5',
+  },
+  C1_6: {
+    code: 717170046,
+    label: 'C1-6',
+  },
+  C1_6A: {
+    code: 717170047,
+    label: 'C1-6A',
+  },
+  C1_7: {
+    code: 717170048,
+    label: 'C1-7',
+  },
+  C1_7A: {
+    code: 717170049,
+    label: 'C1-7A',
+  },
+  C1_8: {
+    code: 717170050,
+    label: 'C1-8',
+  },
+  C1_8A: {
+    code: 717170051,
+    label: 'C1-8A',
+  },
+  C1_8X: {
+    code: 717170052,
+    label: 'C1-8X',
+  },
+  C1_9: {
+    code: 717170053,
+    label: 'C1-9',
+  },
+  C1_9A: {
+    code: 717170054,
+    label: 'C1-9A',
+  },
+  C2_1: {
+    code: 717170055,
+    label: 'C2-1',
+  },
+  C2_2: {
+    code: 717170056,
+    label: 'C2-2',
+  },
+  C2_3: {
+    code: 717170057,
+    label: 'C2-3',
+  },
+  C2_4: {
+    code: 717170058,
+    label: 'C2-4',
+  },
+  C2_5: {
+    code: 717170059,
+    label: 'C2-5',
+  },
+  C2_6: {
+    code: 717170060,
+    label: 'C2-6',
+  },
+  C2_6A: {
+    code: 717170061,
+    label: 'C2-6A',
+  },
+  C2_7: {
+    code: 717170062,
+    label: 'C2-7',
+  },
+  C2_7A: {
+    code: 717170063,
+    label: 'C2-7A',
+  },
+  C2_7X: {
+    code: 717170064,
+    label: 'C2-7X',
+  },
+  C2_8: {
+    code: 717170065,
+    label: 'C2-8',
+  },
+  C2_8A: {
+    code: 717170066,
+    label: 'C2-8A',
+  },
+  C3: {
+    code: 717170067,
+    label: 'C3',
+  },
+  C3A: {
+    code: 717170068,
+    label: 'C3A',
+  },
+  C4_1: {
+    code: 717170069,
+    label: 'C4-1',
+  },
+  C4_2: {
+    code: 717170070,
+    label: 'C4-2',
+  },
+  C4_2A: {
+    code: 717170071,
+    label: 'C4-2A',
+  },
+  C4_2F: {
+    code: 717170072,
+    label: 'C4-2F',
+  },
+  C4_3: {
+    code: 717170073,
+    label: 'C4-3',
+  },
+  C4_3A: {
+    code: 717170074,
+    label: 'C4-3A',
+  },
+  C4_4: {
+    code: 717170075,
+    label: 'C4-4',
+  },
+  C4_4A: {
+    code: 717170076,
+    label: 'C4-4A',
+  },
+  C4_4D: {
+    code: 717170077,
+    label: 'C4-4D',
+  },
+  C4_4L: {
+    code: 717170078,
+    label: 'C4-4L',
+  },
+  C4_5: {
+    code: 717170079,
+    label: 'C4-5',
+  },
+  C4_5A: {
+    code: 717170080,
+    label: 'C4-5A',
+  },
+  C4_5D: {
+    code: 717170081,
+    label: 'C4-5D',
+  },
+  C4_5X: {
+    code: 717170082,
+    label: 'C4-5X',
+  },
+  C4_6: {
+    code: 717170083,
+    label: 'C4-6',
+  },
+  C4_6A: {
+    code: 717170084,
+    label: 'C4-6A',
+  },
+  C4_7: {
+    code: 717170085,
+    label: 'C4-7',
+  },
+  C4_7A: {
+    code: 717170086,
+    label: 'C4-7A',
+  },
+  C5_1: {
+    code: 717170087,
+    label: 'C5-1',
+  },
+  C5_1A: {
+    code: 717170088,
+    label: 'C5-1A',
+  },
+  C5_2: {
+    code: 717170089,
+    label: 'C5-2',
+  },
+  C5_2_5: {
+    code: 717170090,
+    label: 'C5-2.5',
+  },
+  C5_2A: {
+    code: 717170091,
+    label: 'C5-2A',
+  },
+  C5_3: {
+    code: 717170092,
+    label: 'C5-3',
+  },
+  C5_3_5: {
+    code: 717170093,
+    label: 'C5-3.5',
+  },
+  C5_4: {
+    code: 717170094,
+    label: 'C5-4',
+  },
+  C5_5: {
+    code: 717170096,
+    label: 'C5-5',
+  },
+  C5_P: {
+    code: 717170097,
+    label: 'C5-P',
+  },
+  C6_1: {
+    code: 717170098,
+    label: 'C6-1',
+  },
+  C6_1G: {
+    code: 717170099,
+    label: 'C6-1G',
+  },
+  C6_2: {
+    code: 717170100,
+    label: 'C6-2',
+  },
+  C6_2A: {
+    code: 717170101,
+    label: 'C6-2A',
+  },
+  C6_2G: {
+    code: 717170102,
+    label: 'C6-2G',
+  },
+  C6_2M: {
+    code: 717170103,
+    label: 'C6-2M',
+  },
+  C6_3: {
+    code: 717170104,
+    label: 'C6-3',
+  },
+  C6_3A: {
+    code: 717170105,
+    label: 'C6-3A',
+  },
+  C6_3D: {
+    code: 717170106,
+    label: 'C6-3D',
+  },
+  C6_3X: {
+    code: 717170107,
+    label: 'C6-3X',
+  },
+  C6_4: {
+    code: 717170108,
+    label: 'C6-4',
+  },
+  C6_4_5: {
+    code: 717170109,
+    label: 'C6-4.5',
+  },
+  C6_4A: {
+    code: 717170110,
+    label: 'C6-4A',
+  },
+  C6_4M: {
+    code: 717170111,
+    label: 'C6-4M',
+  },
+  C6_4X: {
+    code: 717170112,
+    label: 'C6-4X',
+  },
+  C6_5: {
+    code: 717170113,
+    label: 'C6-5',
+  },
+  C6_5_5: {
+    code: 717170114,
+    label: 'C6-5.5',
+  },
+  C6_6: {
+    code: 717170115,
+    label: 'C6-6',
+  },
+  C6_6_5: {
+    code: 717170116,
+    label: 'C6-6.5',
+  },
+  C6_7: {
+    code: 717170117,
+    label: 'C6-7',
+  },
+  C6_7_5: {
+    code: 717170118,
+    label: 'C6-7.5',
+  },
+  C6_7T: {
+    code: 717170119,
+    label: 'C6-7T',
+  },
+  C6_8: {
+    code: 717170120,
+    label: 'C6-8',
+  },
+  C6_9: {
+    code: 717170121,
+    label: 'C6-9',
+  },
+  C7: {
+    code: 717170122,
+    label: 'C7',
+  },
+  C8_1: {
+    code: 717170123,
+    label: 'C8-1',
+  },
+  C8_2: {
+    code: 717170124,
+    label: 'C8-2',
+  },
+  C8_3: {
+    code: 717170125,
+    label: 'C8-3',
+  },
+  C8_4: {
+    code: 717170126,
+    label: 'C8-4',
+  },
+  M1_1: {
+    code: 717170127,
+    label: 'M1-1',
+  },
+  M1_1D: {
+    code: 717170128,
+    label: 'M1-1D',
+  },
+  M1_2: {
+    code: 717170129,
+    label: 'M1-2',
+  },
+  M1_2D: {
+    code: 717170130,
+    label: 'M1-2D',
+  },
+  M1_3: {
+    code: 717170131,
+    label: 'M1-3',
+  },
+  M1_3D: {
+    code: 717170132,
+    label: 'M1-3D',
+  },
+  M1_4: {
+    code: 717170133,
+    label: 'M1-4',
+  },
+  M1_4D: {
+    code: 717170134,
+    label: 'M1-4D',
+  },
+  M1_5: {
+    code: 717170135,
+    label: 'M1-5',
+  },
+  M1_5A: {
+    code: 717170136,
+    label: 'M1-5A',
+  },
+  M1_5B: {
+    code: 717170137,
+    label: 'M1-5B',
+  },
+  M1_5D: {
+    code: 717170138,
+    label: 'M1-5D',
+  },
+  M1_5M: {
+    code: 717170139,
+    label: 'M1-5M',
+  },
+  M1_6: {
+    code: 717170140,
+    label: 'M1-6',
+  },
+  M1_6D: {
+    code: 717170141,
+    label: 'M1-6D',
+  },
+  M1_6M: {
+    code: 717170142,
+    label: 'M1-6M',
+  },
+  M2_1: {
+    code: 717170143,
+    label: 'M2-1',
+  },
+  M2_2: {
+    code: 717170144,
+    label: 'M2-2',
+  },
+  M2_3: {
+    code: 717170145,
+    label: 'M2-3',
+  },
+  M2_4: {
+    code: 717170146,
+    label: 'M2-4',
+  },
+  M3_1: {
+    code: 717170147,
+    label: 'M3-1',
+  },
+  M3_2: {
+    code: 717170148,
+    label: 'M3-2',
+  },
+};
+
+const ZONING_MAP_CHANGE_OPTIONSETS = {
+  DCPEXISTINGZONINGDISTRICTVALUE,
+};
+
+export default ZONING_MAP_CHANGE_OPTIONSETS;

--- a/client/app/templates/landuse-form/edit.hbs
+++ b/client/app/templates/landuse-form/edit.hbs
@@ -1,6 +1,6 @@
 <Ui::Breadcrumbs as |Crumb|>
   <Crumb @text="My Projects" @route='projects' />
-  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb @text={{@model.package.project.dcpProjectname}} @disabled={{true}} />
   <Crumb @text="Land Use" @disabled={{true}} />
   <Crumb @text="Edit" @current={{true}} />
 </Ui::Breadcrumbs>

--- a/client/app/validations/saveable-zoning-map-change.js
+++ b/client/app/validations/saveable-zoning-map-change.js
@@ -1,0 +1,20 @@
+import {
+  validateLength,
+} from 'ember-changeset-validations/validators';
+
+export default {
+  dcpZoningsectionmapsnumber: [
+    validateLength({
+      min: 0,
+      max: 100,
+      message: 'Number is too long (max {max} characters)',
+    }),
+  ],
+  dcpProposedzoningmapvalue: [
+    validateLength({
+      min: 0,
+      max: 100,
+      message: 'Number is too long (max {max} characters)',
+    }),
+  ],
+};

--- a/client/app/validations/submittable-zoning-map-change.js
+++ b/client/app/validations/submittable-zoning-map-change.js
@@ -1,0 +1,5 @@
+import SaveableZoningMapChange from './saveable-zoning-map-change';
+
+export default {
+  ...SaveableZoningMapChange,
+};

--- a/client/mirage/config.js
+++ b/client/mirage/config.js
@@ -50,6 +50,12 @@ export default function() {
   this.post('/affected-zoning-resolutions');
   this.del('/affected-zoning-resolutions/:id');
 
+  this.get('/zoning-map-changes');
+  this.get('/zoning-map-changes/:id');
+  this.patch('/zoning-map-changes/:id');
+  this.post('/zoning-map-changes');
+  this.del('/zoning-map-changes/:id');
+
   this.get('/rwcds-forms');
   this.get('/rwcds-forms/:id');
   this.patch('/rwcds-forms/:id');

--- a/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
@@ -12,6 +12,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { selectChoose } from 'ember-power-select/test-support';
+import exceedMaximum from '../helpers/exceed-maximum-characters';
 
 const saveForm = async () => {
   await click('[data-test-save-button]');
@@ -1160,5 +1161,58 @@ module('Acceptance | user can click landuse form edit', function (hooks) {
     await visit('/landuse-form/2/edit');
 
     assert.dom('[data-test-landuse-attachment-list]').exists();
+  });
+
+  test('User can add and delete a Zoning Map Change on the landuse form', async function (assert) {
+    this.server.create('project', {
+      packages: [
+        this.server.create('package', 'toDo', {
+          dcpPackagetype: 717170001,
+          landuseForm: this.server.create('landuse-form', {
+            landuseActions: [
+              this.server.create('landuse-action', {
+                dcpActioncode: 'ZM',
+              }),
+            ],
+          }),
+        }),
+      ],
+    });
+
+    await visit('/landuse-form/1/edit');
+
+    await selectChoose('[data-test-dcpTotalzoningareatoberezoned-dropdown]', '240,000 to 500,000 square feet');
+
+    // add and fill out fields for Zoning Text Amendment section
+    await click('[data-test-add-zoning-map-change-button]');
+    assert.dom('[data-test-zoning-map-change-fieldset="0"]').exists();
+
+    await fillIn('[data-test-input="dcpZoningsectionmapsnumber"]', exceedMaximum(100, 'String'));
+    assert.dom('[data-test-validation-message="dcpZoningsectionmapsnumber"]').exists();
+
+    await fillIn('[data-test-input="dcpZoningsectionmapsnumber"]', 'zoning section num 1234');
+    assert.dom('[data-test-validation-message="dcpZoningsectionmapsnumber"]').doesNotExist();
+
+    await selectChoose('[data-test-dcpExistingzoningdistrictvalue-dropdown]', 'R2A');
+
+    await fillIn('[data-test-input="dcpProposedzoningmapvalue"]', exceedMaximum(100, 'String'));
+    assert.dom('[data-test-validation-message="dcpProposedzoningmapvalue"]').exists();
+
+    await fillIn('[data-test-input="dcpProposedzoningmapvalue"]', 'some zoning map value');
+    assert.dom('[data-test-validation-message="dcpProposedzoningmapvalue"]').doesNotExist();
+
+    await click('[data-test-save-button]');
+
+    assert.equal(this.server.db.landuseForms.firstObject.dcpTotalzoningareatoberezoned, 717170006);
+    assert.equal(this.server.db.zoningMapChanges.firstObject.dcpZoningsectionmapsnumber, 'zoning section num 1234');
+    assert.equal(this.server.db.zoningMapChanges.firstObject.dcpExistingzoningdistrictvalue, 717170004);
+    assert.equal(this.server.db.zoningMapChanges.firstObject.dcpProposedzoningmapvalue, 'some zoning map value');
+
+    await click('[data-test-remove-zoning-map-change-button]');
+    assert.dom('[data-test-zr-section-fieldset="0"]').doesNotExist();
+
+    await click('[data-test-save-button]');
+
+    assert.equal(this.server.db.zoningMapChanges.length, 0);
   });
 });

--- a/server/src/json-api-deserialize.pipe.ts
+++ b/server/src/json-api-deserialize.pipe.ts
@@ -39,6 +39,9 @@ export class JsonApiDeserializePipe implements PipeTransform {
         'affected-zoning-resolutions': {
           valueForRelationship: relationship => relationship.id,
         },
+        'zoning-map-changes': {
+          valueForRelationship: relationship => relationship.id,
+        },
       }).deserialize(value);
     }
 

--- a/server/src/packages/landuse-form/landuse-form.service.ts
+++ b/server/src/packages/landuse-form/landuse-form.service.ts
@@ -34,7 +34,8 @@ export class LanduseFormService {
         dcp_dcp_landuse_dcp_sitedatahform_landuseform,
         dcp_dcp_landuse_dcp_landusegeography_landuseform,
         dcp_leadagency,
-        dcp_dcp_landuse_dcp_affectedzoningresolution_Landuseform
+        dcp_dcp_landuse_dcp_affectedzoningresolution_Landuseform,
+        dcp_dcp_landuse_dcp_zoningmapchanges_LandUseForm,
     `);
 
     return {

--- a/server/src/packages/landuse-form/zoning-map-changes/zoning-map-change.attrs.ts
+++ b/server/src/packages/landuse-form/zoning-map-changes/zoning-map-change.attrs.ts
@@ -1,0 +1,18 @@
+export const ZONING_MAP_CHANGE_ATTRS = [
+  'versionnumber',
+  'dcp_proposedzoningmapvalue',
+  'statuscode',
+  'overriddencreatedon',
+  'modifiedon',
+  'createdon',
+  'statecode',
+  'dcp_zoningsectionmapsnumber',
+  'dcp_proposedzoningdistrictvalue',
+  'dcp_changenumber',
+  'importsequencenumber',
+  'dcp_number',
+  'utcconversiontimezonecode',
+  'dcp_zoningmapchangesid',
+  'dcp_existingzoningdistrictvalue',
+  'dcp_name',
+];

--- a/server/src/packages/landuse-form/zoning-map-changes/zoning-map-change.controller.ts
+++ b/server/src/packages/landuse-form/zoning-map-changes/zoning-map-change.controller.ts
@@ -1,0 +1,68 @@
+import {
+    Controller,
+    Patch,
+    Body,
+    Param,
+    Post,
+    UseInterceptors,
+    UseGuards,
+    UsePipes,
+    Delete,
+  } from '@nestjs/common';
+  import { pick } from 'underscore';
+  import { CrmService } from '../../../crm/crm.service';
+  import { JsonApiSerializeInterceptor } from '../../../json-api-serialize.interceptor';
+  import { AuthenticateGuard } from '../../../authenticate.guard';
+  import { JsonApiDeserializePipe } from '../../../json-api-deserialize.pipe';
+  import { ZONING_MAP_CHANGE_ATTRS } from './zoning-map-change.attrs';
+  
+  @UseInterceptors(
+    new JsonApiSerializeInterceptor('zoning-map-changes', {
+      id: 'dcp_zoningmapchangesid',
+      attributes: [...ZONING_MAP_CHANGE_ATTRS],
+    }),
+  )
+  @UseGuards(AuthenticateGuard)
+  @UsePipes(JsonApiDeserializePipe)
+  @Controller('zoning-map-changes')
+  export class ZoningMapChangesController {
+    constructor(private readonly crmService: CrmService) {}
+  
+    @Patch('/:id')
+    async update(@Body() body, @Param('id') id) {
+      const allowedAttrs = pick(body, ZONING_MAP_CHANGE_ATTRS);
+  
+        await this.crmService.update(
+          'dcp_zoningmapchangeses',
+          id,
+          allowedAttrs,
+        );
+  
+      return {
+        dcp_zoningmapchangesid: id,
+        allowedAttrs,
+      };
+    }
+  
+    @Post('/')
+    create(@Body() body) {
+      const allowedAttrs = pick(body, ZONING_MAP_CHANGE_ATTRS);
+
+      return this.crmService.create('dcp_zoningmapchangeses', {
+        ...allowedAttrs,
+        // Due to CRM, dcp_LandUseForm here is case sensitive...
+        'dcp_LandUseForm@odata.bind': `/dcp_landuses(${body.landuse_form})`,
+      });
+    }
+  
+    @Delete('/:id')
+    async delete(@Param('id') id) {
+
+      await this.crmService.delete('dcp_zoningmapchangeses', id);
+  
+      return {
+        id,
+      };
+    }
+  }
+  

--- a/server/src/packages/packages.controller.ts
+++ b/server/src/packages/packages.controller.ts
@@ -28,6 +28,7 @@ import { RELATED_ACTION_ATTRS } from './landuse-form/related-actions/related-act
 import { LANDUSE_ACTION_ATTRS } from './landuse-form/landuse-actions/landuse-actions.attrs';
 import { SITEDATAH_FORM_ATTRS } from './landuse-form/sitedatah-forms/sitedatah-form.attrs';
 import { LANDUSE_GEOGRAPHY_ATTRS } from './landuse-form/landuse-geography/landuse-geography.attrs';
+import { ZONING_MAP_CHANGE_ATTRS } from './landuse-form/zoning-map-changes/zoning-map-change.attrs';
 import { CitypayService } from '../citypay/citypay.service';
 
 @UseInterceptors(new JsonApiSerializeInterceptor('packages', {
@@ -110,6 +111,7 @@ import { CitypayService } from '../citypay/citypay.service';
       'landuse-geographies',
       'lead-agency',
       'affected-zoning-resolutions',
+      'zoning-map-changes',
     ],
     applicants: {
       ref: 'dcp_applicantinformationid',
@@ -159,6 +161,12 @@ import { CitypayService } from '../citypay/citypay.service';
       ref: 'dcp_affectedzoningresolutionid',
       attributes: [
         ...AFFECTEDZONINGRESOLUTION_ATTRS,
+      ],
+    },
+    'zoning-map-changes': {
+      ref: 'dcp_zoningmapchangesid',
+      attributes: [
+        ...ZONING_MAP_CHANGE_ATTRS,
       ],
     },
   },
@@ -240,6 +248,7 @@ import { CitypayService } from '../citypay/citypay.service';
             'landuse-geographies': landuseForm.dcp_dcp_landuse_dcp_landusegeography_landuseform,
             'lead-agency': landuseForm.dcp_leadagency,
             'affected-zoning-resolutions': landuseForm.dcp_dcp_landuse_dcp_affectedzoningresolution_Landuseform,
+            'zoning-map-changes': landuseForm.dcp_dcp_landuse_dcp_zoningmapchanges_LandUseForm,
           }
         }
       } else {

--- a/server/src/packages/packages.module.ts
+++ b/server/src/packages/packages.module.ts
@@ -9,6 +9,7 @@ import { AffectedZoningResolutionsController } from './rwcds-form/affected-zonin
 import { RelatedActionsController } from './landuse-form/related-actions/related-actions.controller';
 import { SitedatahFormsController } from './landuse-form/sitedatah-forms/sitedatah-forms.controller';
 import { LanduseGeographyController } from './landuse-form/landuse-geography/landuse-geography.controller';
+import { ZoningMapChangesController } from './landuse-form/zoning-map-changes/zoning-map-change.controller';
 import { LanduseActionsController } from './landuse-form/landuse-actions/landuse-actions.controller';
 import { RwcdsFormController } from './rwcds-form/rwcds-form.controller';
 import { LanduseFormController } from './landuse-form/landuse-form.controller';
@@ -34,6 +35,7 @@ import { CitypayModule } from '../citypay/citypay.module';
     SitedatahFormsController,
     LanduseActionsController,
     LanduseGeographyController,
+    ZoningMapChangesController,
   ],
 })
 export class PackagesModule {}


### PR DESCRIPTION
### Summary
Sets up the Draft Land Use Zoning Map Amendment Section
Fixes [AB#12395](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12395) 

### Technical details (Nice-to-knows, but you don't really need to read all this):
Mostly follow the same patterns as other sections. Some nice-to-knows:
- This PR sets an example for calling *-fieldset components going forward. Notice how the zoning-map-amendment-fieldset component is called without the @zoningMapChange argument, since that argument is redundant and confusing.
- Similarly this PR sets an example for calling the `@ remove<fieldset>` actions. Previously in other sections we passed an extra, unnecessary argument to the `@ remove<fieldset>` action inside the *-fieldset file (at the remove button). 
- We should later assess whether the `ZONING_MAP_CHANGE_OPTIONSET.DCPEXISTINGZONINGDISTRICTVALUE` 
optionset is frequently growing/shrinking. If so, we should pull this optionset down on app load. I created a ticket here: [AB#12865](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12865)
- Another area we are pushing up against the "saveable form" api: the Q.Label component doesn't create working data-test hooks for power selects. Power select need a redundant `<label>` to house working test selectors. 
- In CRM, the singular entity name for a Zoning Map Change is dcp_zoningmapchanges, and plural is dcp_zoningmapchangeses. But we hide most of the app from this detail. It only affects the direct, low-level calls to the CRM Web API.



