### PR TITLE
12672 Patch de/serialization for dcp_500kpluszone

### DIFF
--- a/server/src/json-api-deserialize.pipe.ts
+++ b/server/src/json-api-deserialize.pipe.ts
@@ -1,5 +1,6 @@
 import { ArgumentMetadata, Injectable, PipeTransform } from '@nestjs/common';
 import { Deserializer } from 'jsonapi-serializer';
+import { underscore } from 'inflected';
 
 @Injectable()
 export class JsonApiDeserializePipe implements PipeTransform {
@@ -8,7 +9,16 @@ export class JsonApiDeserializePipe implements PipeTransform {
 
     if (type === 'body') {
       return new Deserializer({
-        keyForAttribute: 'snake_case',
+        keyForAttribute: (attribute) => {
+          // One-off deserialization for any properties should happen here.
+          // Add another if statement.
+          // See https://github.com/NYCPlanning/labs-applicant-portal/pull/771
+          // TODO: Extract out and modularize the set of one-offs if it grows
+          // beyond 2.
+          if (attribute === 'dcp500kpluszone')
+            return 'dcp_500kpluszone';
+          return underscore(attribute);
+        },
         packages: {
           valueForRelationship: relationship => relationship.id,
         },

--- a/server/src/json-api-serialize.interceptor.ts
+++ b/server/src/json-api-serialize.interceptor.ts
@@ -16,6 +16,15 @@ export class JsonApiSerializeInterceptor implements NestInterceptor {
       // REDO: we should just make the client support dash prefixes
       // because it'll be tough when we have to deserialize
       keyForAttribute(key) {
+        // One-off serialization for any properties should happen here.
+        // Add another if statement.
+        // See https://github.com/NYCPlanning/labs-applicant-portal/pull/771
+        // TODO: Extract out and modularize the set of one-offs if it grows
+        // beyond 2.
+        if (key === 'dcp_500kpluszone') {
+          return 'dcp500kpluszone';
+        }
+
         let dasherized = dasherize(key);
 
         if (dasherized[0] === '-') {


### PR DESCRIPTION
### Summary 

Fixes [AB#12572](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12572) (answeres to the dcp_500kpluszone question was not getting written to/read from CRM)

It turns out our current Nest de/serialization and CRM is at odds with
Ember Data in regards to whether digits appear
before for after a dash/underscore. Thus we have to implement
custom serialization/deserialization for attributes with
digit tokens.

### Technical Details (Important -- read this!)

When generating JSONAPI request payloads, Ember Data dasherizes model properties by
  1. placing dashes before any capital letters. Note this is only letters but not numbers
  2. lowercasing the capital letters

When generating models from JSONAPI response payloads, Ember Data does the reverse:
  1. capitalizing letters that immediately follow a dash
  2. remove dashes

When deserializeing JSONAPI request payloads, Nest replaces dashes with underscores.
(This appropriately generate respective CRM properties)

When serializing objects into JSONAPI request responses, Nest replaces underscores with dashes.

Thus...
   - It is not possible to rely on the "5" in 500 for proper dasherization, because Ember Data uses capital letters
to indicate placement of a dash during serialization (into a JSONAPI object). Thus when Ember Data serializes dcp500kpluszone, it simply is `dcp500kpluszone`. Contrast this to another property like dcpProjectname, which Ember Data serializes into dcp-projectname. 
  -   In our backend, without the dash the Nest deserializer cannot automatically determine where an underscore should be placed and generate the respective CRM property for dcp500kpluszone. 
  - To solve this problem, in the Deserializer we add manual deserialization (translation) of dcp500kpluszone to dcp_500kpluszone. Similarly, during Serialization we translate dcp_500kpluszone to dcp500kpluszone.
  - For all other attributes, we default to the `snake_case` implementation, which turns out to just be the `underscore()` method from the Inflector library. 

