### PR TITLE
12713 12714 Fix Related Actions labels, validation, attribute

### DIFF
--- a/client/app/components/packages/related-action-fieldset.hbs
+++ b/client/app/components/packages/related-action-fieldset.hbs
@@ -2,8 +2,7 @@
   <Ui::Question
     class="fieldset relative"
     ...attributes
-    as |Q|
-  >
+  as |Q|>
     <Q.Legend data-test-related-action-title>
       Related Action
     </Q.Legend>
@@ -11,59 +10,85 @@
     <Ui::Question
       class="no-margin-top"
       data-test-action-completed-radio-group
-      as |Q|
-    >
-
-    <Q.Legend class="show-for-sr">
-      Is the action completed?
-    </Q.Legend>
+    as |dcpIscompletedactionQ|>
+      <dcpIscompletedactionQ.Label>
+        Is the action completed?
+      </dcpIscompletedactionQ.Label>
 
       <form.Field
-        @attribute="dcpDevelopmentsite"
-        @type="radio"
-        as |RadioButton|
-      >
-        <RadioButton
-          @targetValue={{true}}
-          data-test-action-completed="true"
-        >
-          Yes
-        </RadioButton>
-        <RadioButton
-          @targetValue={{false}}
-          data-test-action-completed="false"
-        >
-          No
-        </RadioButton>
+        @attribute="dcpIscompletedaction"
+        @type="radio-group"
+      as |DcpIscompletedactionRadioGroup|>
+        <DcpIscompletedactionRadioGroup
+          @options={{optionset 'relatedAction' 'dcpIscompletedaction' 'list'}}
+        />
       </form.Field>
 
     </Ui::Question>
 
+    <Ui::Question
+    as |dcpReferenceapplicationnoQ|>
+      <dcpReferenceapplicationnoQ.Label>
+        Reference/Applicant Number (if applicable)
+      </dcpReferenceapplicationnoQ.Label>
 
-    <label>
-      Reference/Applicant Number (if applicable)
-      <form.Field @attribute="dcpReferenceapplicationno" />
-    </label>
+      <form.Field
+        @attribute="dcpReferenceapplicationno"
+        @maxlength="10"
+        @showCounter={{true}}
+      />
+    </Ui::Question>
 
-    <label>
-      Description
-      <form.Field @attribute="dcpApplicationdescription" />
-    </label>
+    <Ui::Question
+    as |dcpApplicationdescriptionQ|>
+      <dcpApplicationdescriptionQ.Label>
+        Description
+      </dcpApplicationdescriptionQ.Label>
 
-    <label>
-      Disposition or Status
-      <form.Field @attribute="dcpDispositionorstatus" />
-    </label>
+      <form.Field
+        @attribute="dcpApplicationdescription"
+        @maxlength="250"
+        @showCounter={{true}}
+      />
+    </Ui::Question>
 
-    <label>
-      Calendar Number
-      <form.Field @attribute="dcpCalendarnumbercalendarnumber" />
-    </label>
+    <Ui::Question
+    as |dcpDispositionorstatusQ|>
+      <dcpDispositionorstatusQ.Label>
+        Disposition or Status
+      </dcpDispositionorstatusQ.Label>
 
-    <label>
-      Date
-      <form.Field @attribute="dcpApplicationdate" />
-    </label>
+      <form.Field
+        @attribute="dcpDispositionorstatus"
+        @maxlength="100"
+        @showCounter={{true}}
+      />
+    </Ui::Question>
+
+    <Ui::Question
+    as |dcpCalendarnumbercalendarnumberQ|>
+      <dcpCalendarnumbercalendarnumberQ.Label>
+        Calendar Number
+      </dcpCalendarnumbercalendarnumberQ.Label>
+
+      <form.Field
+        @attribute="dcpCalendarnumbercalendarnumber"
+        @maxlength="100"
+        @showCounter={{true}}
+      />
+    </Ui::Question>
+
+    <Ui::Question
+    as |dcpApplicationdateQ|>
+      <dcpApplicationdateQ.Label>
+        Date
+      </dcpApplicationdateQ.Label>
+
+      <form.Field
+        @attribute="dcpApplicationdate"
+        type="date"
+      />
+    </Ui::Question>
 
     <button
       type="button"
@@ -74,6 +99,5 @@
       Remove Related Action
       <FaIcon @icon="times" @prefix="fas" @fixedWidth={{true}} />
     </button>
-
   </Ui::Question>
 {{/let}}

--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -140,6 +140,10 @@ const OPTIONSET_LOOKUP = {
   zoningMapChange: {
     dcpExistingzoningdistrictvalue: ZONING_MAP_CHANGE_OPTIONSETS.DCPEXISTINGZONINGDISTRICTVALUE,
   },
+  relatedAction: {
+    // Actually a boolean field in CRM, not picklist
+    dcpIscompletedaction: YES_NO,
+  },
 };
 
 /**

--- a/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
@@ -291,7 +291,7 @@ module('Acceptance | user can click landuse form edit', function (hooks) {
 
     // add and fill out fields for related action
     await click('[data-test-add-related-action-button]');
-    await click('[data-test-action-completed="true"]');
+    await click('[data-test-radio="dcpIscompletedaction"][data-test-radio-option="Yes"]');
     await fillIn('[data-test-input="dcpReferenceapplicationno"]', '12345678');
     await fillIn('[data-test-input="dcpApplicationdescription"]', 'applicant description');
     await fillIn('[data-test-input="dcpDispositionorstatus"]', 'disposition or status');


### PR DESCRIPTION
### Summary 
Fixes [AB#12713](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12713), and the duplicate [AB#12475](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12475)
Conveniently Fixes [AB#12714](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12714) as well (the wrong attribute was used for that question).


Also makes critical patches to adjacent code in `related-actions-fieldset.hbs`:
  - Standardize dcpIscompletedaction radio group to use "radio-group" input type and optionset helper
  - Add showCounter and maxlength attributes to fields to activate validation UI
  - Uses the Ui::Question component instead of plain labels 
