### PR TITLE
12887 Basic set up for Filed Land Use

### DIFF
--- a/client/app/components/project/package-list-item.hbs
+++ b/client/app/components/project/package-list-item.hbs
@@ -25,12 +25,21 @@
       <strong>Version {{@package.dcpPackageversion}}</strong>
     </LinkTo>
   {{/if}}
-  {{#if (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' 'DRAFT_LU_PACKAGE'))}}
+  {{#if (or
+    (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' 'DRAFT_LU_PACKAGE'))
+    (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' 'FILED_LU_PACKAGE'))
+  )}}
     <LinkTo
       @route={{if (eq @package.statuscode (optionset 'package' 'statuscode' 'code' 'PACKAGE_PREPARATION')) 'landuse-form.edit' 'landuse-form.show'}}
       @model={{@package.id}}
       data-test-package-link={{@package.id}}
     >
+      {{#if (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' 'FILED_LU_PACKAGE'))}}
+        Filed
+      {{/if}}
+      {{#if (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' 'DRAFT_LU_PACKAGE'))}}
+        Draft
+      {{/if}}
       <strong>Version {{@package.dcpPackageversion}}</strong>
     </LinkTo>
   {{/if}}

--- a/client/app/models/package.js
+++ b/client/app/models/package.js
@@ -77,7 +77,8 @@ export default class PackageModel extends Model {
     if (this.dcpPackagetype === DCPPACKAGETYPE.RWCDS.code) {
       await this.rwcdsForm.save();
     }
-    if (this.dcpPackagetype === DCPPACKAGETYPE.DRAFT_LU_PACKAGE.code) {
+    if (this.dcpPackagetype === DCPPACKAGETYPE.DRAFT_LU_PACKAGE.code
+      || this.dcpPackagetype === DCPPACKAGETYPE.FILED_LU_PACKAGE.code) {
       await this.saveDeletedRecords(recordsToDelete);
       await this.landuseForm.save();
     }
@@ -126,7 +127,8 @@ export default class PackageModel extends Model {
         || this.rwcdsForm.hasDirtyAttributes
         || this.rwcdsForm.isAffectedZoningResolutionsDirty;
     }
-    if (this.dcpPackagetype === DCPPACKAGETYPE.DRAFT_LU_PACKAGE.code) {
+    if (this.dcpPackagetype === DCPPACKAGETYPE.DRAFT_LU_PACKAGE.code
+      || this.dcpPackagetype === DCPPACKAGETYPE.FILED_LU_PACKAGE.code) {
       return isPackageDirty
         || this.landuseForm.hasDirtyAttributes
         || this.landuseForm.isBblsDirty

--- a/client/app/models/project.js
+++ b/client/app/models/project.js
@@ -57,8 +57,26 @@ export default class ProjectModel extends Model {
   }
 
   get landusePackages() {
+    const landusePackages = [
+      ...this.filedLandusePackages,
+      ...this.draftLandusePackages,
+    ];
+
+    return landusePackages;
+  }
+
+  get draftLandusePackages() {
     const landusePackages = this.packages
       .filter((projectPackage) => projectPackage.dcpPackagetype === optionset(['package', 'dcpPackagetype', 'code', 'DRAFT_LU_PACKAGE']))
+      .sortBy('dcpPackageversion')
+      .reverse();
+
+    return landusePackages;
+  }
+
+  get filedLandusePackages() {
+    const landusePackages = this.packages
+      .filter((projectPackage) => projectPackage.dcpPackagetype === optionset(['package', 'dcpPackagetype', 'code', 'FILED_LU_PACKAGE']))
       .sortBy('dcpPackageversion')
       .reverse();
 

--- a/server/src/packages/packages.service.ts
+++ b/server/src/packages/packages.service.ts
@@ -176,7 +176,8 @@ export class PackagesService {
         };
       }
 
-      if (dcpPackage.dcp_packagetype === PACKAGE_TYPE_OPTIONSET['DRAFT_LU_PACKAGE'].code) {
+      if (dcpPackage.dcp_packagetype === PACKAGE_TYPE_OPTIONSET['DRAFT_LU_PACKAGE'].code
+      || dcpPackage.dcp_packagetype === PACKAGE_TYPE_OPTIONSET['FILED_LU_PACKAGE'].code) {
         return {
           dcp_landuse: await this.landuseFormService.find(dcpPackage._dcp_landuseapplication_value)
         };


### PR DESCRIPTION
### Summary
Originally meant to roughly spike an end-to-end setup of Filed Land Use form, but this can probably already satisfy the basic user stories.
This proves that Filed Land Use not only can re-use the same components, but can even re-use the same models, routes and
backend API controllers and services, since a Filed Land Use Package+Form is essentially a Draft Land Use Package+Form but with a different Package "type" value. 

Fixes #774 

### Technical details:
  - Both Filed and Draft Land Use forms make use of the `dcp_landuse` entity to represent the form, so we did not need to set up a new *-form controller or service for a new form type. 
  - The only thing distinguishing a Draft from a Filed Land Use form is the associated Package's type (filed or draft)
  - Upon Draft Land Use Form submission and sign-off by DCP, CRM copies the Draft dcp_landuse record to the new Filed dcp_landuse record of a new Filed Land Use package.
  - Most entities associated with `dcp_landuse`, like Related Actions (`dcp_relatedactions`), Subject Sites (`dcp_sitedatah`) are also generated new records associated with the new `dcp_landuse` record. 
  - Some entites like `dcp_applicantinformation` do not receive new records. Both the draft and filed land use forms modify the same applicant records. 