### PR TITLE
12722 12775 Enable Land Use section of Project(s) pages

### DIFF
--- a/client/app/controllers/project.js
+++ b/client/app/controllers/project.js
@@ -6,8 +6,6 @@ import { optionset } from '../helpers/optionset';
 import { STATECODE, STATUSCODE } from '../optionsets/contact';
 
 export default class ProjectController extends Controller {
-  queryParams = ['landuse'];
-
   @tracked landuse = false;
 
   @tracked contactMgmtOpen = false;

--- a/client/app/controllers/projects.js
+++ b/client/app/controllers/projects.js
@@ -1,6 +1,5 @@
 import Controller from '@ember/controller';
 import { sort } from '@ember/object/computed';
-import { tracked } from '@glimmer/tracking';
 import {
   STATUSCODE,
   DCPVISIBILITY,
@@ -21,9 +20,6 @@ export function packageIsToDo(projectPackages) {
 }
 
 export default class ProjectsController extends Controller {
-  queryParams = ['landuse'];
-
-  @tracked landuse = false;
   // TODO: organize this business logic as computed properties on the projects model
 
   // Projects awaiting the applicant's submission
@@ -32,7 +28,7 @@ export default class ProjectsController extends Controller {
     // Check that at least ONE of the packages is currently editable
     return this.model.filter((project) => packageIsToDo(project.pasPackages)
       || packageIsToDo(project.rwcdsPackages)
-      || (packageIsToDo(project.landusePackages) && this.landuse));
+      || (packageIsToDo(project.landusePackages)));
   }
 
   // Projects in NYC Planning's hands

--- a/client/app/templates/project.hbs
+++ b/client/app/templates/project.hbs
@@ -36,17 +36,15 @@
 
     </section>
 
-    {{#if this.landuse}}
-      {{#if @model.landusePackages.length}}
-        <h2>Draft Land Use Form</h2>
-        <ol class="no-bullet">
-          {{#each @model.landusePackages as |landusePackage|}}
-            <Project::PackageListItem
-              @package={{landusePackage}}
-            />
-          {{/each}}
-        </ol>
-      {{/if}}
+    {{#if @model.landusePackages.length}}
+      <h2>Land Use</h2>
+      <ol class="no-bullet">
+        {{#each @model.landusePackages as |landusePackage|}}
+          <Project::PackageListItem
+            @package={{landusePackage}}
+          />
+        {{/each}}
+      </ol>
     {{/if}}
 
     {{#if @model.rwcdsPackages.length}}


### PR DESCRIPTION
### Summary
Enables by default the Land Use section on the Project page, and makes sure that that projects with active Draft or Filed Land Use packages appear under Awaiting Submission. 

 Removes the use of `landuse=` queryParam to toggle those sections.

Fixes [AB#12722](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12722) [AB#12775](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12775) 