### PR TITLE
12683: add zoning resolution dropdown to proposed actions component on landuse-form

### DIFF
--- a/client/app/components/packages/landuse-form/edit.hbs
+++ b/client/app/components/packages/landuse-form/edit.hbs
@@ -61,6 +61,7 @@
       <Packages::LanduseForm::ProposedActions
         @form={{saveableForm}}
         @validations={{this.validations}}
+        @zoningResolutions={{@zoningResolutions}}
       />
 
       <Packages::RelatedAction

--- a/client/app/components/packages/landuse-form/proposed-action-editor.hbs
+++ b/client/app/components/packages/landuse-form/proposed-action-editor.hbs
@@ -42,6 +42,11 @@
     </Ui::Question>
 
     {{#if this.projectHasRequiredActions}}
+
+      <Packages::LanduseForm::ZoningResolutionDropdown
+        @landuseActionForm={{landuseActionForm}}
+        @zoningResolutions={{@zoningResolutions}}
+      />
     
       <Ui::Question as |dcpNameofzoningresolutionsectionQ|>
         <dcpNameofzoningresolutionsectionQ.Label>

--- a/client/app/components/packages/landuse-form/proposed-actions.hbs
+++ b/client/app/components/packages/landuse-form/proposed-actions.hbs
@@ -84,6 +84,7 @@
         >
           <Packages::LanduseForm::ProposedActionEditor
             @landuseActionForm={{landuseActionForm}}
+            @zoningResolutions={{@zoningResolutions}}
           />
         </form.SaveableForm>
       {{/each}}

--- a/client/app/components/packages/landuse-form/zoning-resolution-dropdown.hbs
+++ b/client/app/components/packages/landuse-form/zoning-resolution-dropdown.hbs
@@ -1,0 +1,24 @@
+{{#let @landuseActionForm as |landuseActionForm|}}
+  <div>
+    <h5 class="small-margin-bottom">
+      What Zoning Resolution section is this Action pursuant to?
+    </h5>
+
+    <label data-test-zoning-resolution-picker="{{landuseActionForm.data.dcpActioncode}}">
+      <PowerSelect
+        triggerClass="zoning-resolution-dropdown"
+        supportsDataTestProperties={{true}}
+        @placeholder={{this.searchPlaceholder}}
+        @searchEnabled={{true}}
+        @searchField="dcpZoningresolution"
+        @options={{@zoningResolutions}}
+        @selected={{this.chosenZoningResolution}}
+        @onChange={{fn (mut this.chosenZoningResolution)}}
+        @onClose={{fn (mut landuseActionForm.data.chosenZoningResolutionId) this.chosenZoningResolution.id}}
+        as |zoningResolution|
+      >
+        {{zoningResolution.dcpZoningresolution}}
+      </PowerSelect>
+    </label>
+  </div>
+{{/let}}

--- a/client/app/components/packages/landuse-form/zoning-resolution-dropdown.js
+++ b/client/app/components/packages/landuse-form/zoning-resolution-dropdown.js
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class PackagesLanduseFormZoningResolutionComponent extends Component {
+  @tracked chosenZoningResolution;
+
+  get searchPlaceholder() {
+    if (this.args.landuseActionForm.data.zoningResolution) {
+      return this.args.landuseActionForm.data.zoningResolution.dcpZoningresolution;
+    } return 'Search Zoning Resolution Sections...';
+  }
+}

--- a/client/app/models/landuse-action.js
+++ b/client/app/models/landuse-action.js
@@ -4,6 +4,9 @@ export default class LanduseActionModel extends Model {
   @belongsTo('landuse-form', { async: false })
   landuseForm;
 
+  @belongsTo('zoning-resolution', { async: false })
+  zoningResolution;
+
   @attr dcpActioncode;
 
   @attr dcpPreviouslyapprovedactioncode;
@@ -46,4 +49,6 @@ export default class LanduseActionModel extends Model {
   @attr dcpCrfnnumber;
 
   @attr dcpRecordationdate;
+
+  @attr chosenZoningResolutionId;
 }

--- a/client/app/models/zoning-resolution.js
+++ b/client/app/models/zoning-resolution.js
@@ -1,0 +1,9 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class ZoningResolutionModel extends Model {
+  @belongsTo('landuse-action', { async: false })
+  landuseAction;
+
+  @attr
+  dcpZoningresolution;
+}

--- a/client/app/routes/landuse-form.js
+++ b/client/app/routes/landuse-form.js
@@ -18,6 +18,7 @@ export default class LanduseFormRoute extends Route.extend(AuthenticatedRouteMix
         'landuse-form.landuse-geographies',
         'landuse-form.lead-agency',
         'landuse-form.affected-zoning-resolutions',
+        'landuse-form.landuse-actions.zoning-resolution',
       ].join(),
     });
 
@@ -27,6 +28,7 @@ export default class LanduseFormRoute extends Route.extend(AuthenticatedRouteMix
     return RSVP.hash({
       package: landuseFormPackage,
       accounts: await this.store.findAll('account'),
+      zoningResolutions: await this.store.findAll('zoning-resolution'),
     });
   }
 }

--- a/client/app/templates/landuse-form/edit.hbs
+++ b/client/app/templates/landuse-form/edit.hbs
@@ -8,6 +8,7 @@
 <Packages::LanduseForm::Edit
   @package={{@model.package}}
   @accounts={{@model.accounts}}
+  @zoningResolutions={{@model.zoningResolutions}}
 />
 
 {{outlet}}

--- a/client/mirage/config.js
+++ b/client/mirage/config.js
@@ -84,6 +84,8 @@ export default function() {
   this.get('/landuse-actions');
   this.patch('/landuse-actions/:id');
 
+  this.get('/zoning-resolutions');
+
   this.get('/lead-agencys');
   this.get('/lead-agencys/:id');
   this.get('/accounts');

--- a/client/mirage/models/landuse-action.js
+++ b/client/mirage/models/landuse-action.js
@@ -1,0 +1,6 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  landuseForm: belongsTo('landuse-form'),
+  zoningResolution: belongsTo('zoning-resolution'),
+});

--- a/client/mirage/models/zoning-resolution.js
+++ b/client/mirage/models/zoning-resolution.js
@@ -1,0 +1,5 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  landuseAction: belongsTo('landuse-action'),
+});

--- a/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
@@ -1264,4 +1264,36 @@ module('Acceptance | user can click landuse form edit', function (hooks) {
 
     assert.equal(currentURL(), '/landuse-form/1/edit');
   });
+
+  test('User can search and select from zoning resolution dropdown in proposed actions section', async function (assert) {
+    this.server.create('project', 1, {
+      packages: [this.server.create('package', 'toDo', 'landuseForm')],
+    });
+
+    this.server.create('zoning-resolution', 1, {
+      dcpZoningresolution: 'AppendixD',
+    });
+    this.server.create('zoning-resolution', 2, {
+      dcpZoningresolution: 'AppendixF',
+    });
+    this.server.create('zoning-resolution', 3, {
+      dcpZoningresolution: '74-116',
+    });
+
+    await visit('/landuse-form/1/edit');
+
+    // filling out necessary information in order to save
+    await click('[data-test-add-applicant-button]');
+    await fillIn('[data-test-input="dcpFirstname"]', 'Tess');
+    await fillIn('[data-test-input="dcpLastname"]', 'Ter');
+    await fillIn('[data-test-input="dcpEmail"]', 'tesster@planning.nyc.gov');
+
+    await selectChoose('[data-test-zoning-resolution-picker="ZA"]', 'AppendixF');
+
+    await click('[data-test-save-button]');
+
+    assert.equal(this.server.db.landuseActions[1].chosenZoningResolutionId, 2);
+
+    assert.equal(currentURL(), '/landuse-form/1/edit');
+  });
 });

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -13,6 +13,7 @@ import { PackagesModule } from './packages/packages.module';
 import { DocumentModule } from './document/document.module';
 import { CitypayService } from './citypay/citypay.service';
 import { CitypayModule } from './citypay/citypay.module';
+import { ZoningResolutionsModule } from './zoning-resolutions/zoning-resolutions.module';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { CitypayModule } from './citypay/citypay.module';
     PackagesModule,
     DocumentModule,
     CitypayModule,
+    ZoningResolutionsModule,
   ],
   controllers: [AppController],
   providers: [CitypayService],

--- a/server/src/json-api-deserialize.pipe.ts
+++ b/server/src/json-api-deserialize.pipe.ts
@@ -52,6 +52,9 @@ export class JsonApiDeserializePipe implements PipeTransform {
         'zoning-map-changes': {
           valueForRelationship: relationship => relationship.id,
         },
+        'zoning-resolutions': {
+          valueForRelationship: relationship => relationship.id,
+        },
       }).deserialize(value);
     }
 

--- a/server/src/packages/landuse-form/landuse-actions/landuse-actions.controller.ts
+++ b/server/src/packages/landuse-form/landuse-actions/landuse-actions.controller.ts
@@ -30,11 +30,11 @@ export class LanduseActionsController {
   async update(@Body() body, @Param('id') id) {
     const allowedAttrs = pick(body, LANDUSE_ACTION_ATTRS);
 
-      await this.crmService.update(
-        'dcp_landuseactions',
-        id,
-        allowedAttrs,
-      );
+    await this.crmService.update('dcp_landuseactions', id, {
+      ...allowedAttrs,
+
+      ...(body.chosen_zoning_resolution_id ? { 'dcp_zoningresolutionsectionactionispursuantto@odata.bind': `/dcp_zoningresolutions(${body.chosen_zoning_resolution_id})` } : {}),
+    });
 
     return {
       dcp_landuseactionid: id,

--- a/server/src/packages/landuse-form/landuse-form.service.ts
+++ b/server/src/packages/landuse-form/landuse-form.service.ts
@@ -5,6 +5,7 @@ import {
 } from '@nestjs/common';
 import { CrmService } from '../../crm/crm.service';
 import { LANDUSE_FORM_ATTRS } from './landuse-form.attrs';
+import { LANDUSE_ACTION_ATTRS } from './landuse-actions/landuse-actions.attrs';
 
 const ACTIVE_STATECODE = 0;
 
@@ -21,8 +22,7 @@ export class LanduseFormService {
         dcp_dcp_applicantinformation_dcp_landuse,
         dcp_dcp_applicantrepinformation_dcp_landuse,
         dcp_dcp_projectbbl_dcp_landuse($filter=statecode eq ${ACTIVE_STATECODE}),
-        dcp_dcp_landuse_dcp_relatedactions,
-        dcp_dcp_landuse_dcp_landuseaction
+        dcp_dcp_landuse_dcp_relatedactions
     `);
 
     // We make a second request to accommodate additional hasMany expands.
@@ -37,6 +37,16 @@ export class LanduseFormService {
         dcp_dcp_landuse_dcp_affectedzoningresolution_Landuseform,
         dcp_dcp_landuse_dcp_zoningmapchanges_LandUseForm,
     `);
+
+    const { records: landuseActionsWithZr } = await this.crmService.get(`dcp_landuseactions`, `
+      $select=${LANDUSE_ACTION_ATTRS.join(',')}
+      &$filter=
+        _dcp_landuseid_value eq ${id}
+      &$expand=
+        dcp_zoningresolutionsectionactionispursuantto
+    `);
+
+    landuseForm.landuseActions = landuseActionsWithZr;
 
     return {
       ...landuseForm,

--- a/server/src/packages/packages.controller.ts
+++ b/server/src/packages/packages.controller.ts
@@ -28,6 +28,7 @@ import { RELATED_ACTION_ATTRS } from './landuse-form/related-actions/related-act
 import { LANDUSE_ACTION_ATTRS } from './landuse-form/landuse-actions/landuse-actions.attrs';
 import { SITEDATAH_FORM_ATTRS } from './landuse-form/sitedatah-forms/sitedatah-form.attrs';
 import { LANDUSE_GEOGRAPHY_ATTRS } from './landuse-form/landuse-geography/landuse-geography.attrs';
+import { ZONINGRESOLUTION_ATTRS } from '../zoning-resolutions/zoning-resolutions.attrs';
 import { ZONING_MAP_CHANGE_ATTRS } from './landuse-form/zoning-map-changes/zoning-map-change.attrs';
 import { CitypayService } from '../citypay/citypay.service';
 
@@ -136,7 +137,15 @@ import { CitypayService } from '../citypay/citypay.service';
       ref: 'dcp_landuseactionid',
       attributes: [
         ...LANDUSE_ACTION_ATTRS,
+
+        'zoning-resolution',
       ],
+      'zoning-resolution': {
+        ref: 'dcp_zoningresolutionid',
+        attributes: [
+          ...ZONINGRESOLUTION_ATTRS,
+        ],
+      },
     },
     'sitedatah-forms': {
       ref: 'dcp_sitedatahformid',
@@ -243,7 +252,12 @@ import { CitypayService } from '../citypay/citypay.service';
             ],
             bbls: landuseForm.dcp_dcp_projectbbl_dcp_landuse,
             'related-actions': landuseForm.dcp_dcp_landuse_dcp_relatedactions,
-            'landuse-actions': landuseForm.dcp_dcp_landuse_dcp_landuseaction,
+            'landuse-actions': landuseForm.landuseActions.map(action => {
+              return {
+                ...action,
+                'zoning-resolution': action.dcp_zoningresolutionsectionactionispursuantto,
+              }
+            }),
             'sitedatah-forms': landuseForm.dcp_dcp_landuse_dcp_sitedatahform_landuseform,
             'landuse-geographies': landuseForm.dcp_dcp_landuse_dcp_landusegeography_landuseform,
             'lead-agency': landuseForm.dcp_leadagency,

--- a/server/src/zoning-resolutions/zoning-resolutions.attrs.ts
+++ b/server/src/zoning-resolutions/zoning-resolutions.attrs.ts
@@ -1,0 +1,3 @@
+export const ZONINGRESOLUTION_ATTRS = [
+  'dcp_zoningresolution',
+];

--- a/server/src/zoning-resolutions/zoning-resolutions.controller.ts
+++ b/server/src/zoning-resolutions/zoning-resolutions.controller.ts
@@ -1,0 +1,73 @@
+import {
+    Controller,
+    Get,
+    HttpException,
+    HttpStatus,
+    UseInterceptors,
+    UseGuards,
+    UsePipes,
+  } from '@nestjs/common';
+  import { CrmService } from '../crm/crm.service';
+  import { JsonApiSerializeInterceptor } from '../json-api-serialize.interceptor';
+  import { AuthenticateGuard } from '../authenticate.guard';
+  import { JsonApiDeserializePipe } from '../json-api-deserialize.pipe';
+  import { ZONINGRESOLUTION_ATTRS } from './zoning-resolutions.attrs';
+
+  const ACTIVE_STATUSCODE = 1;
+  const ACTIVE_STATECODE = 0;
+
+  @UseInterceptors(new JsonApiSerializeInterceptor('zoning-resolutions', {
+    id: 'dcp_zoningresolutionid',
+    attributes: [
+      ...ZONINGRESOLUTION_ATTRS,
+    ],
+
+    transform(zoningResolution) {
+      try {
+        return {
+          ...zoningResolution,
+        };
+      } catch(e) {
+        if (e instanceof HttpException) {
+          throw e;
+        } else {
+          throw new HttpException({
+            code: 'ZONINGRESOLUTIONS_ERROR',
+            title: 'Failed load zoning resolutions',
+            detail: `An error occurred while loading one or more zoning resolutions. ${e.message}`,
+          }, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+      }
+    },
+  }))
+  @UseGuards(AuthenticateGuard)
+  @UsePipes(JsonApiDeserializePipe)
+  @Controller('zoning-resolutions')
+  export class ZoningResolutionsController {
+    constructor(
+      private readonly crmService: CrmService,
+    ) {}
+
+    @Get('/')
+    async zoningResolutions() {
+      try {
+        const { records } = await this.crmService.get('dcp_zoningresolutions',
+          `$select=dcp_zoningresolution
+          &$filter=
+          statuscode eq ${ACTIVE_STATUSCODE}
+          and statecode eq ${ACTIVE_STATECODE}
+      `);
+        return records;
+      } catch (e) {
+        if (e instanceof HttpException) {
+          throw e;
+        } else {
+          throw new HttpException({
+            code: 'FIND_ZONINGRESOLUTIONS_FAILED',
+            title: 'Failed getting zoning resolutions',
+            detail: `An unknown server error occured while getting zoning resolutions. ${e.message}`,
+          }, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+      }
+    }
+  }

--- a/server/src/zoning-resolutions/zoning-resolutions.module.ts
+++ b/server/src/zoning-resolutions/zoning-resolutions.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { CrmModule } from '../crm/crm.module';
+import { ZoningResolutionsController } from './zoning-resolutions.controller';
+
+@Module({
+  imports: [
+    CrmModule,
+  ],
+  providers: [],
+  exports: [],
+  controllers: [ZoningResolutionsController],
+})
+export class ZoningResolutionsModule {}


### PR DESCRIPTION
**Big Picture Summary**
Create a new Zoning Resolution dropdown that is part of the Proposed Actions section on the Land Use Form.

**Which major feature does this fit into?**
Proposed Actions section of the Land Use Form

**Technical Explanation — How does it work?**
- all zoning resolution names and ID's in CRM (around 600 records) are loaded onto the landuse-form. These zoning resolution names are used for the options list in the dropdown.
- when a user selects an option from the dropdown a Zoning Resolution id is sent to the backend and when the `dcp_landuseaction` entity is PATCHed, the zoning resolution id is binded to the landuseAction using the `dcp_zoningresolutionsectionactionispursuantto` field

**NOTE**: for the sake of time I created a fake ID field on the landuse-action model called `chosenZoningResolutionId` which is sent to the backend to bind the zoningResolution to the landuseAction. This can be updated in the future by doing this through updating the zoningResolution model directly and then using the "relationship" between the landuseAction and the zoningResolution (one-to-one) to access the chosen ID for binding. Can do this in a future refactor.

Addresses [AB#12683](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12683)
