### PR TITLE
12777 Add conditional fields to Housing Plans

### DIFF
--- a/client/app/components/packages/landuse-form/housing-plans.hbs
+++ b/client/app/components/packages/landuse-form/housing-plans.hbs
@@ -72,7 +72,44 @@
               as |DcpMannerofdispositionRadioGroup|>
                 <DcpMannerofdispositionRadioGroup
                   @options={{optionset 'landuseForm' 'dcpMannerofdisposition' 'list'}}
-                />
+                  @onChange={{fn this.resetDependentFields this.dependantsOf.dcpMannerofdisposition}}
+                as |dcpMannerofdisposition|>
+                  {{#if (eq
+                    dcpMannerofdisposition
+                    (optionset 'landuseForm' 'dcpMannerofdisposition' 'code' 'Direct')
+                  )}}
+                    <Ui::Question
+                      @required={{true}}
+                    as |dcpFromQ|>
+                      <dcpFromQ.Label>
+                        From (Indicate City Agency)
+                      </dcpFromQ.Label>
+
+                      <form.Field
+                        @attribute="dcpFrom"
+                        @maxlength="100"
+                        @showCounter={{true}}
+                        id={{dcpFromQ.id}}
+                      />
+                    </Ui::Question>
+
+                    <Ui::Question
+                      @required={{true}}
+                    as |dcpToQ|>
+                      <dcpToQ.Label>
+                        To (Indicate Sponsor/Developer/Purchaser/Lessee
+                        or Local Public Development Corp.)
+                      </dcpToQ.Label>
+    
+                      <form.Field
+                        @attribute="dcpTo"
+                        @maxlength="100"
+                        @showCounter={{true}}
+                        id={{dcpToQ.id}}
+                      />
+                    </Ui::Question>
+                  {{/if}}
+                </DcpMannerofdispositionRadioGroup>
               </form.Field>
             </Ui::Question>
 

--- a/client/app/components/packages/landuse-form/housing-plans.js
+++ b/client/app/components/packages/landuse-form/housing-plans.js
@@ -1,0 +1,27 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class PackagesLanduseFormHousingPlansComponent extends Component {
+  // The following properties represent lists of fields
+  // dependent on the value of a respective radio group.
+  // For a radio group property,
+  // the associated list of fields are those which should be
+  // cleared (reset) when the radio-group value changes.
+  dependantsOf = {
+    dcpMannerofdisposition: [
+      'dcpFrom',
+      'dcpTo',
+    ],
+  }
+
+  get landuseForm() {
+    return this.args.form.data;
+  }
+
+  @action
+  resetDependentFields(fields) {
+    fields.forEach((field) => {
+      this.landuseForm.set(field, null);
+    });
+  }
+}

--- a/client/app/models/landuse-form.js
+++ b/client/app/models/landuse-form.js
@@ -111,6 +111,10 @@ export default class LanduseFormModel extends Model {
 
   @attr dcpRestrictandcondition;
 
+  @attr dcpFrom;
+
+  @attr dcpTo;
+
   // public facilities attrs
   @attr dcpOfficespaceleaseopt;
 

--- a/client/app/validations/saveable-landuse-form.js
+++ b/client/app/validations/saveable-landuse-form.js
@@ -137,6 +137,20 @@ export default {
       message: 'Text is too long (max {max} characters)',
     }),
   ],
+  dcpFrom: [
+    validateLength({
+      min: 0,
+      max: 100,
+      message: 'Text is too long (max {max} characters)',
+    }),
+  ],
+  dcpTo: [
+    validateLength({
+      min: 0,
+      max: 100,
+      message: 'Text is too long (max {max} characters)',
+    }),
+  ],
   dcpTextexistingfacility: [
     validateLength({
       min: 0,

--- a/client/app/validations/submittable-landuse-form.js
+++ b/client/app/validations/submittable-landuse-form.js
@@ -41,6 +41,32 @@ export default {
       message: 'This field is required',
     }),
   ],
+  dcpFrom: [
+    ...SaveableLanduseForm.dcpFrom,
+    // TODO: Debug why we can't use
+    // import LANDUSE_FORM_OPTIONSETS from '../optionsets/landuse-form';
+    // ...
+    // withValue: LANDUSE_FORM_OPTIONSETS.DCPMANNEROFDISPOSITION.DIRECT,
+    validatePresenceIf({
+      presence: true,
+      on: 'dcpMannerofdisposition',
+      withValue: 717170001,
+      message: 'This field is required',
+    }),
+  ],
+  dcpTo: [
+    ...SaveableLanduseForm.dcpTo,
+    // TODO: Debug why we can't use
+    // import LANDUSE_FORM_OPTIONSETS from '../optionsets/landuse-form';
+    // ...
+    // withValue: LANDUSE_FORM_OPTIONSETS.DCPMANNEROFDISPOSITION.DIRECT,
+    validatePresenceIf({
+      presence: true,
+      on: 'dcpMannerofdisposition',
+      withValue: 717170001,
+      message: 'This field is required',
+    }),
+  ],
   applicants: [
     validateLength({
       min: 1,

--- a/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
@@ -303,7 +303,7 @@ module('Acceptance | user can click landuse form edit', function (hooks) {
     assert.equal(this.server.db.relatedActions.firstObject.dcpReferenceapplicationno, '12345678');
   });
 
-  test('User can fill out and save first part of Housing Plans', async function (assert) {
+  test('User can fill out and save Housing Plans section', async function (assert) {
     // Create a land use form with housing-related actions
     this.server.create('project', {
       packages: [
@@ -340,6 +340,36 @@ module('Acceptance | user can click landuse form edit', function (hooks) {
 
     assert.dom('[data-test-radio="dcpMannerofdisposition"]').exists();
     assert.dom('[data-test-radio="dcpRestrictandcondition"]').exists();
+
+    assert.dom('[data-test-radio="dcpFrom"]').doesNotExist();
+    assert.dom('[data-test-radio="dcpTo"]').doesNotExist();
+
+    await click('[data-test-radio="dcpMannerofdisposition"][data-test-radio-option="Direct"]');
+
+    assert.dom('[data-test-input="dcpFrom"]').exists();
+    assert.dom('[data-test-input="dcpTo"]').exists();
+
+    await fillIn('[data-test-input="dcpFrom"]', exceedMaximum(100, 'String'));
+
+    assert.dom('[data-test-validation-message="dcpFrom"]').exists();
+
+    await fillIn('[data-test-input="dcpFrom"]', 'Some text');
+
+    assert.dom('[data-test-validation-message="dcpFrom"]').doesNotExist();
+
+    await fillIn('[data-test-input="dcpTo"]', exceedMaximum(100, 'String'));
+
+    assert.dom('[data-test-validation-message="dcpTo"]').exists();
+
+    await fillIn('[data-test-input="dcpTo"]', 'Some text');
+
+    assert.dom('[data-test-validation-message="dcpTo"]').doesNotExist();
+
+    await click('[data-test-radio="dcpMannerofdisposition"][data-test-radio-option="General"]');
+    await click('[data-test-radio="dcpMannerofdisposition"][data-test-radio-option="Direct"]');
+
+    assert.dom('[data-test-input="dcpFrom"]').hasNoValue();
+    assert.dom('[data-test-input="dcpTo"]').hasNoValue();
   });
 
   test('Housing sections only appear if Project contains housing-related Land Use Actions', async function (assert) {


### PR DESCRIPTION
### Summary
Adds fields for dcpFrom and dcpTo to the Housing Plans section.
They are conditionally shown when dcpMannerofdisposition is "Direct"

Fixes [AB#12777](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12777)