### PR TITLE
12721  Add visibility icons next to packages

### DIFF
--- a/client/app/components/project/package-list-item.hbs
+++ b/client/app/components/project/package-list-item.hbs
@@ -34,18 +34,35 @@
       @model={{@package.id}}
       data-test-package-link={{@package.id}}
     >
-      {{#if (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' 'FILED_LU_PACKAGE'))}}
-        Filed
-      {{/if}}
-      {{#if (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' 'DRAFT_LU_PACKAGE'))}}
-        Draft
-      {{/if}}
-      <strong>Version {{@package.dcpPackageversion}}</strong>
+      <strong>
+        {{#if (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' 'FILED_LU_PACKAGE'))}}
+          Filed
+        {{/if}}
+        {{#if (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' 'DRAFT_LU_PACKAGE'))}}
+          Draft
+        {{/if}}
+        Land Use
+        <small>
+          Version {{@package.dcpPackageversion}}
+        </small>
+      </strong>
     </LinkTo>
   {{/if}}
-  <span class="text-gray">| {{if (eq @package.statuscode (optionset 'package' 'statuscode' 'code' 'PACKAGE_PREPARATION')) 'Editable since ' 'Submitted '}}
+  <br>
+  {{#if (eq @package.dcpVisibility (optionset 'package' 'dcpVisibility' 'code' 'GENERAL_PUBLIC'))}}
+    <FaIcon @icon="eye" @prefix="far" class="text-orange" />
+    <span class="a11y-orange">
+      Public
+    </span>
+  {{/if}}
+  {{#if (eq @package.dcpVisibility (optionset 'package' 'dcpVisibility' 'code' 'APPLICANT_ONLY'))}}
+    <FaIcon @icon="eye-slash" @prefix="far" class="text-gray" />
+    Private
+  {{/if}}
+  <small class="text-gray">
+    {{if (eq @package.statuscode (optionset 'package' 'statuscode' 'code' 'PACKAGE_PREPARATION')) 'Editable since ' 'Submitted '}}
     <Ui::DateDisplay @date={{@package.dcpStatusdate}} @outputFormat="MM/D/YYYY" @errorMessage="Date Unknown"/>
-  </span>
+  </small>
 </li>
 
 {{yield}}


### PR DESCRIPTION
### Summary
Adds icons next to packages to indicate their visibility. 
Also reformats the package list item to better match the wireframes 

Fixes [AB#12721](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12721) 