### PR TITLE
12712: update related actions date field with new date-picker component

### DIFF
--- a/client/app/components/packages/landuse-form/proposed-action-editor.hbs
+++ b/client/app/components/packages/landuse-form/proposed-action-editor.hbs
@@ -202,27 +202,35 @@
 
     {{#if this.projectHasRequiredActionsAndFollowUpYes}}
 
-      <Ui::Question as |dcpDateofpreviousapprovalQ|>
+      <Ui::Question
+      as |dcpDateofpreviousapprovalQ|>
         <dcpDateofpreviousapprovalQ.Label>
           Date of previous approval
         </dcpDateofpreviousapprovalQ.Label>
 
-        <landuseActionForm.Field
-          @attribute="dcpDateofpreviousapproval"
-          type="date"
-          id={{dcpDateofpreviousapprovalQ.questionId}}
+        <EmberFlatpickr
+          data-test-dcpdateofpreviousapproval
+          @allowInput={{false}}
+          @date={{if landuseActionForm.data.dcpDateofpreviousapproval landuseActionForm.data.dcpDateofpreviousapproval null}}
+          @onChange={{fn (mut landuseActionForm.data.dcpDateofpreviousapproval)}}
+          @enableTime={{false}}
+          placeholder="Choose a date..."
         />
       </Ui::Question>
 
-      <Ui::Question as |dcpLapsedateofpreviousapprovalQ|>
+      <Ui::Question
+      as |dcpLapsedateofpreviousapprovalQ|>
         <dcpLapsedateofpreviousapprovalQ.Label>
           Lapse date of previous approval
         </dcpLapsedateofpreviousapprovalQ.Label>
 
-        <landuseActionForm.Field
-          @attribute="dcpLapsedateofpreviousapproval"
-          type="date"
-          id={{dcpLapsedateofpreviousapprovalQ.questionId}}
+        <EmberFlatpickr
+          data-test-dcplapsedateofpreviousapproval
+          @allowInput={{false}}
+          @date={{if landuseActionForm.data.dcpLapsedateofpreviousapproval landuseActionForm.data.dcpLapsedateofpreviousapproval null}}
+          @onChange={{fn (mut landuseActionForm.data.dcpLapsedateofpreviousapproval)}}
+          @enableTime={{false}}
+          placeholder="Choose a date..."
         />
       </Ui::Question>
 
@@ -291,15 +299,19 @@
         />
       </Ui::Question>
 
-      <Ui::Question as |dcpRecordationdateQ|>
+      <Ui::Question
+      as |dcpRecordationdateQ|>
         <dcpRecordationdateQ.Label>
           Recordation date of Legal Instrument
         </dcpRecordationdateQ.Label>
 
-        <landuseActionForm.Field
-          @attribute="dcpRecordationdate"
-          type="date"
-          id={{dcpRecordationdateQ.questionId}}
+        <EmberFlatpickr
+          data-test-dcprecordationdate
+          @allowInput={{false}}
+          @date={{if landuseActionForm.data.dcpRecordationdate landuseActionForm.data.dcpRecordationdate null}}
+          @onChange={{fn (mut landuseActionForm.data.dcpRecordationdate)}}
+          @enableTime={{false}}
+          placeholder="Choose a date..."
         />
       </Ui::Question>
 

--- a/client/app/components/packages/related-action-fieldset.hbs
+++ b/client/app/components/packages/related-action-fieldset.hbs
@@ -84,9 +84,13 @@
         Date
       </dcpApplicationdateQ.Label>
 
-      <form.Field
-        @attribute="dcpApplicationdate"
-        type="date"
+      <EmberFlatpickr
+        data-test-dcpapplicationdate
+        @allowInput={{false}}
+        @date={{if form.data.dcpApplicationdate form.data.dcpApplicationdate null}}
+        @onChange={{fn (mut form.data.dcpApplicationdate)}}
+        @enableTime={{false}}
+        placeholder="Choose a date..."
       />
     </Ui::Question>
 

--- a/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
@@ -12,6 +12,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { selectChoose } from 'ember-power-select/test-support';
+import { setFlatpickrDate } from 'ember-flatpickr/test-support/helpers';
 import exceedMaximum from '../helpers/exceed-maximum-characters';
 
 const saveForm = async () => {
@@ -296,11 +297,15 @@ module('Acceptance | user can click landuse form edit', function (hooks) {
     await fillIn('[data-test-input="dcpApplicationdescription"]', 'applicant description');
     await fillIn('[data-test-input="dcpDispositionorstatus"]', 'disposition or status');
     await fillIn('[data-test-input="dcpCalendarnumbercalendarnumber"]', 'calendar number');
-    await fillIn('[data-test-input="dcpApplicationdate"]', 'application date');
+
+    const applicationDate = new Date(2020, 0, 1);
+    setFlatpickrDate('[data-test-dcpapplicationdate]', applicationDate);
+
     await click('[data-test-save-button]');
 
     assert.equal(this.server.db.applicants.firstObject.dcpFirstname, 'Tess');
     assert.equal(this.server.db.relatedActions.firstObject.dcpReferenceapplicationno, '12345678');
+    assert.ok(this.server.db.relatedActions.firstObject.dcpApplicationdate[0].includes('2020-01-01'));
   });
 
   test('User can fill out and save Housing Plans section', async function (assert) {
@@ -608,6 +613,9 @@ module('Acceptance | user can click landuse form edit', function (hooks) {
     await click('[data-test-radio="dcpApplicantispublicagencyactions"][data-test-action="ZC"][data-test-radio-option="Yes"]');
     await click('[data-test-radio="dcpApplicantispublicagencyactions"][data-test-action="ZA"][data-test-radio-option="No"]');
 
+    const recordationDate = new Date(2020, 0, 1);
+    setFlatpickrDate('[data-test-dcprecordationdate]', recordationDate);
+
     await click('[data-test-save-button]');
 
     assert.equal(this.server.db.landuseForms.firstObject.dcpLegalinstrument, 717170000);
@@ -621,6 +629,7 @@ module('Acceptance | user can click landuse form edit', function (hooks) {
     assert.equal(this.server.db.landuseActions[1].dcpPreviouslyapprovedactioncode, 717170013);
     assert.equal(this.server.db.landuseActions[0].dcpApplicantispublicagencyactions, true);
     assert.equal(this.server.db.landuseActions[1].dcpApplicantispublicagencyactions, false);
+    assert.ok(this.server.db.landuseActions.firstObject.dcpRecordationdate[0].includes('2020-01-01'));
 
     assert.equal(currentURL(), '/landuse-form/1/edit');
   });
@@ -1256,11 +1265,11 @@ module('Acceptance | user can click landuse form edit', function (hooks) {
 
     await visit('/landuse-form/1/edit');
 
-    assert.dom('[data-test-input="dcpDateofpreviousapproval"]').doesNotExist();
+    assert.dom('[data-test-dcpdateofpreviousapproval').doesNotExist();
 
     await selectChoose('[data-test-dcpPreviouslyapprovedactioncode-picker="ZC"]', 'BF');
 
-    assert.dom('[data-test-input="dcpDateofpreviousapproval"]').exists();
+    assert.dom('[data-test-dcpdateofpreviousapproval').exists();
 
     assert.equal(currentURL(), '/landuse-form/1/edit');
   });

--- a/server/src/packages/landuse-form/landuse-actions/landuse-actions.attrs.ts
+++ b/server/src/packages/landuse-form/landuse-actions/landuse-actions.attrs.ts
@@ -13,12 +13,9 @@ export const LANDUSE_ACTION_ATTRS = [
   'dcp_istheactiontoauthorizeorpermitanopenuse',
   'dcp_istheactiontoauthorizeacommercial',
   'dcp_followuptopreviousaction',
-  'dcp_dateofpreviousapproval',
-  'dcp_lapsedateofpreviousapproval',
   'dcp_typeoflegalinstrument',
   'dcp_modsubjectto197c',
   'dcp_indicatewhetheractionisamodification',
   'dcp_crfnnumber',
-  'dcp_recordationdate',
   '_dcp_landuseid_value',
 ];

--- a/server/src/packages/landuse-form/landuse-actions/landuse-actions.controller.ts
+++ b/server/src/packages/landuse-form/landuse-actions/landuse-actions.controller.ts
@@ -29,11 +29,19 @@ export class LanduseActionsController {
   @Patch('/:id')
   async update(@Body() body, @Param('id') id) {
     const allowedAttrs = pick(body, LANDUSE_ACTION_ATTRS);
+    console.log('sunflower', body);
+
+    const dateOfPreviousApproval = body.dcp_dateofpreviousapproval[0];
+    const lapseDateOfPreviousApproval = body.dcp_lapsedateofpreviousapproval[0];
+    const recordationDate = body.dcp_recordationdate[0];
 
     await this.crmService.update('dcp_landuseactions', id, {
       ...allowedAttrs,
 
       ...(body.chosen_zoning_resolution_id ? { 'dcp_zoningresolutionsectionactionispursuantto@odata.bind': `/dcp_zoningresolutions(${body.chosen_zoning_resolution_id})` } : {}),
+      dcp_dateofpreviousapproval: dateOfPreviousApproval,
+      dcp_lapsedateofpreviousapproval: lapseDateOfPreviousApproval,
+      dcp_recordationdate: recordationDate,
     });
 
     return {

--- a/server/src/packages/landuse-form/related-actions/related-actions.attrs.ts
+++ b/server/src/packages/landuse-form/related-actions/related-actions.attrs.ts
@@ -4,7 +4,6 @@ export const RELATED_ACTION_ATTRS = [
   'dcp_applicationdescription',
   'dcp_dispositionorstatus',
   'dcp_calendarnumbercalendarnumber',
-  'dcp_applicationdate',
   'dcp_landuseid_value',
   'dcp_landuseid'
 ];

--- a/server/src/packages/landuse-form/related-actions/related-actions.controller.ts
+++ b/server/src/packages/landuse-form/related-actions/related-actions.controller.ts
@@ -31,12 +31,13 @@ import {
     @Patch('/:id')
     async update(@Body() body, @Param('id') id) {
       const allowedAttrs = pick(body, RELATED_ACTION_ATTRS);
-  
-        await this.crmService.update(
-          'dcp_relatedactionses',
-          id,
-          allowedAttrs,
-        );
+      const applicationDate = body.dcp_applicationdate[0];
+
+        await this.crmService.update('dcp_relatedactionses', id, {
+          ...allowedAttrs,
+    
+          dcp_applicationdate: applicationDate,
+        });
   
       return {
         dcp_relatedactionsid: id,

--- a/server/src/packages/packages.controller.ts
+++ b/server/src/packages/packages.controller.ts
@@ -131,6 +131,7 @@ import { CitypayService } from '../citypay/citypay.service';
       ref: 'dcp_relatedactionsid',
       attributes: [
         ...RELATED_ACTION_ATTRS,
+        'dcp_applicationdate',
       ],
     },
     'landuse-actions': {
@@ -139,6 +140,9 @@ import { CitypayService } from '../citypay/citypay.service';
         ...LANDUSE_ACTION_ATTRS,
 
         'zoning-resolution',
+        'dcp_dateofpreviousapproval',
+        'dcp_lapsedateofpreviousapproval',
+        'dcp_recordationdate',
       ],
       'zoning-resolution': {
         ref: 'dcp_zoningresolutionid',


### PR DESCRIPTION
**Big Picture Summary**
Implement EmberFlatpickr for the `dcpApplictiondate` field on the Related Actions component. 

**Which major feature does this fit into?**
Related Actions section of the Land Use Form

**Technical Explanation — How does it work?**
Previously we were using `type="date"` on the `dcpApplicationdate` input field. This PR implements the `EmberFlatpickr` component (which Andy already did the styling for in the new version of labs-ui). This updates the styling of the calendar picker as well as fixes the issue of the date not saving to CRM correctly. Getting the correct date format to save to CRM did require some reformatting in the `related-actions.controller`. 

Closes [AB#12712](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12712)

NOTE: I actually might update some other date fields in this PR, so this is technically a "draft" for now