### PR TITLE
12728 edit package button

### DIFF
--- a/client/app/components/project/package-list-item.hbs
+++ b/client/app/components/project/package-list-item.hbs
@@ -1,19 +1,31 @@
-<li>
-  {{#if (eq @package.statuscode (optionset 'package' 'statuscode' 'code' 'REVIEWED_REVISIONS_REQUIRED'))}}
-    <FaIcon @icon="exclamation-triangle" class="text-gold" />
-  {{else}}
-    <FaIcon
-      @icon={{if (eq @package.statuscode (optionset 'package' 'statuscode' 'code' 'PACKAGE_PREPARATION')) 'edit' 'check'}}
-      class={{if (eq @package.statuscode (optionset 'package' 'statuscode' 'code' 'PACKAGE_PREPARATION')) '' 'text-green-dark'}}
-    />
-  {{/if}}
+<li class="small-margin-bottom">
   {{#if (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' "PAS_PACKAGE"))}}
     <LinkTo
       @route={{if (eq @package.statuscode (optionset 'package' 'statuscode' 'code' 'PACKAGE_PREPARATION')) 'pas-form.edit' 'pas-form.show'}}
       @model={{@package.id}}
       data-test-package-link={{@package.id}}
     >
-      <strong>Version {{@package.dcpPackageversion}}</strong>
+      {{#if (eq @package.statuscode (optionset 'package' 'statuscode' 'code' 'PACKAGE_PREPARATION'))}}
+        <button
+          type="button"
+          class="button no-margin"
+        >
+          <FaIcon @icon="edit" />
+          <strong>
+            PAS
+            <small>
+              Version {{@package.dcpPackageversion}}
+            </small>
+          </strong>
+        </button>
+      {{else}}
+        <strong>
+          PAS
+          <small>
+            Version {{@package.dcpPackageversion}}
+          </small>
+        </strong>
+      {{/if}}
     </LinkTo>
   {{/if}}
   {{#if (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' 'RWCDS'))}}
@@ -22,7 +34,27 @@
       @model={{@package.id}}
       data-test-package-link={{@package.id}}
     >
-      <strong>Version {{@package.dcpPackageversion}}</strong>
+      {{#if (eq @package.statuscode (optionset 'package' 'statuscode' 'code' 'PACKAGE_PREPARATION'))}}
+        <button
+          type="button"
+          class="button no-margin"
+        >
+          <FaIcon @icon="edit" />
+          <strong>
+            RWCDS
+            <small>
+              Version {{@package.dcpPackageversion}}
+            </small>
+          </strong>
+        </button>
+      {{else}}
+        <strong>
+          RWCDS
+          <small>
+            Version {{@package.dcpPackageversion}}
+          </small>
+        </strong>
+      {{/if}}
     </LinkTo>
   {{/if}}
   {{#if (or
@@ -34,18 +66,39 @@
       @model={{@package.id}}
       data-test-package-link={{@package.id}}
     >
-      <strong>
-        {{#if (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' 'FILED_LU_PACKAGE'))}}
-          Filed
-        {{/if}}
-        {{#if (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' 'DRAFT_LU_PACKAGE'))}}
-          Draft
-        {{/if}}
-        Land Use
-        <small>
-          Version {{@package.dcpPackageversion}}
-        </small>
-      </strong>
+      {{#if (eq @package.statuscode (optionset 'package' 'statuscode' 'code' 'PACKAGE_PREPARATION'))}}
+        <button
+          type="button"
+          class="button no-margin"
+        >
+          <FaIcon @icon="edit" />
+          <strong>
+            {{#if (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' 'FILED_LU_PACKAGE'))}}
+              Filed
+            {{/if}}
+            {{#if (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' 'DRAFT_LU_PACKAGE'))}}
+              Draft
+            {{/if}}
+            Land Use
+            <small>
+              Version {{@package.dcpPackageversion}}
+            </small>
+          </strong>
+        </button>
+      {{else}}
+        <strong>
+          {{#if (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' 'FILED_LU_PACKAGE'))}}
+            Filed
+          {{/if}}
+          {{#if (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' 'DRAFT_LU_PACKAGE'))}}
+            Draft
+          {{/if}}
+          Land Use
+          <small>
+            Version {{@package.dcpPackageversion}}
+          </small>
+        </strong>
+      {{/if}}
     </LinkTo>
   {{/if}}
   <br>


### PR DESCRIPTION
### Summary 
This makes sure that the Package list UI matches the wireframes:
  - There's a new "edit" orange button for the latest version of a package
  - only the button has an edit icon
Fixes [AB#12728](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12728) 
![image](https://user-images.githubusercontent.com/3311663/96309270-d6ad9a80-0fb9-11eb-90d9-20dc1c8f25d5.png)
![image](https://user-images.githubusercontent.com/3311663/96309293-df9e6c00-0fb9-11eb-9ebe-cfcea21658b5.png)
