### PR TITLE
12549 Disable Sign-In Next btn and email input after click

### DIFF
--- a/client/app/components/auth/sign-in.hbs
+++ b/client/app/components/auth/sign-in.hbs
@@ -8,6 +8,7 @@
       @type="text"
       @value={{this.email}}
       id={{Q.questionId}}
+      disabled={{if this.isLoginStarted "disabled"}}
     />
 
     <div class="grid-x grid-margin-x">
@@ -16,9 +17,14 @@
           class="button secondary expanded text-weight-bold"
           type="submit"
           data-test-sign-in="next"
+          disabled={{if this.isLoginStarted "disabled"}}
         >
-          Next
-          <FaIcon @icon="arrow-right" @fixedWidth={{true}} />
+          {{#if this.isLoginStarted}}
+            <FaIcon @icon="spinner" @spin={{true}} @pulse={{true}} class="small-margin-right" />
+          {{else}}
+            Next
+            <FaIcon @icon="arrow-right" @fixedWidth={{true}} />
+          {{/if}}
         </button>
       </div>
       <div class="cell auto medium-order-1">

--- a/client/app/components/auth/sign-in.js
+++ b/client/app/components/auth/sign-in.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 const noop = async () => {};
 
@@ -12,9 +13,14 @@ export default class AuthSignInComponent extends Component {
 
   searchContacts = this.args.searchContacts || noop;
 
+  @tracked
+  isLoginStarted = false;
+
   @action
   async startLogin(loginEmail, event) {
     event.preventDefault();
+
+    this.isLoginStarted = true;
 
     const {
       isNycidValidated,

--- a/client/tests/integration/components/auth/sign-in-test.js
+++ b/client/tests/integration/components/auth/sign-in-test.js
@@ -30,6 +30,16 @@ module('Integration | Component | auth/sign-in', function(hooks) {
 
     await click('[data-test-sign-in="next"]');
 
+    // We have to rerender to reset the isLoginStarted tracked
+    // property in the Auth::SignIn component. REDO: consider
+    // if it isn't too much overhead to use tasks to track state of
+    // searchContacts
+    await render(hbs`
+      <Auth::SignIn
+        @searchContacts={{this.searchContacts}}
+      />
+    `);
+
     this.set('searchContacts', () => ({
       isNycidValidated: null,
       isNycidEmailRegistered: true,
@@ -38,6 +48,12 @@ module('Integration | Component | auth/sign-in', function(hooks) {
 
     await click('[data-test-sign-in="next"]');
 
+    await render(hbs`
+      <Auth::SignIn
+        @searchContacts={{this.searchContacts}}
+      />
+    `);
+
     this.set('searchContacts', () => ({
       isNycidValidated: null,
       isNycidEmailRegistered: false,
@@ -45,6 +61,13 @@ module('Integration | Component | auth/sign-in', function(hooks) {
     }));
 
     await click('[data-test-sign-in="next"]');
+
+    await render(hbs`
+      <Auth::SignIn
+        @searchContacts={{this.searchContacts}}
+      />
+   `);
+
 
     this.set('searchContacts', () => ({
       isNycidValidated: false,


### PR DESCRIPTION
Disable the sign-in Next button while it queries contacts. This dramatically improves the sign-in UX. 

Fixes [AB#12549](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12549)