### PR TITLE
13030 13032 Draft EAS attachments & Save button

### DIFF
--- a/client/app/components/packages/draft-eas/attached-documents.hbs
+++ b/client/app/components/packages/draft-eas/attached-documents.hbs
@@ -1,0 +1,38 @@
+<@form.Section @title="Attached Documents">
+  <p>
+    To complete this submission, attach a CEQR form (either short or full)
+    filled in as appropriate based on the Reasonable Worst Case Development Scenario,
+    CEQR Technical manual, and directions from the EARD Lead Planner assigned to this project.
+    Attach the EAS Analysis Sections and back up materials needed based on the above.
+    If the project requires Waterfront Revitalization Program Consistency review,
+    attach the Consistency Assessment Form with any supporting documentation
+    and written assessments as needed.
+  </p>
+
+  <ul>
+    <li>
+      <Ui::ExternalLink @href="https://www1.nyc.gov/site/oec/environmental-quality-review/ceqr-forms-templates.page">
+        CEQR Form
+      </Ui::ExternalLink>
+    </li>
+    <li>
+      <Ui::ExternalLink @href="https://www1.nyc.gov/site/oec/environmental-quality-review/technical-manual.page">
+        CEQR Manual
+      </Ui::ExternalLink>
+    </li>
+    <li>
+      <Ui::ExternalLink @href="https://www1.nyc.gov/assets/planning/download/pdf/planning-level/waterfront/wrp/wrpform2016.pdf?r=1">
+        WRP Form
+      </Ui::ExternalLink>
+    </li>
+  </ul>
+
+  <Packages::Attachments
+    @package={{@model}}
+    @fileManager={{@model.fileManager}}
+    data-test-section="attachments"
+  />
+</@form.Section>
+
+
+

--- a/client/app/components/packages/draft-eas/edit.hbs
+++ b/client/app/components/packages/draft-eas/edit.hbs
@@ -1,5 +1,10 @@
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
+<SaveableForm
+  @model={{@package}}
+  @validators={{array (hash) (hash)}}
+  as |saveableForm|
+>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
 
     <section class="form-section">
       <h1 class="header-large">
@@ -14,12 +19,30 @@
         <small class="text-weight-normal">
           {{if @package.project.dcpName (concat '(' @package.project.dcpName ')')}}
         </small>
-      </h2>
+        </h1>
 
-      <p class="text-large text-dark-gray">
-        {{optionset 'bbl' 'boroughs' 'label' @package.project.dcpBorough}} |
-        {{optionset 'package' 'statuscode' 'label' @package.statuscode}}
-      </p>
-    </section>
+        <h2 class="no-margin">
+          {{@package.project.dcpProjectname}}
+          <small class="text-weight-normal">
+            {{if @package.project.dcpName (concat '(' @package.project.dcpName ')')}}
+          </small>
+        </h2>
+
+        <p class="text-large text-dark-gray">
+          {{optionset 'bbl' 'boroughs' 'label' @package.project.dcpBorough}} |
+          {{optionset 'package' 'statuscode' 'label' @package.statuscode}}
+        </p>
+      </section>
+    </div>
+
+    <div class="cell large-4 sticky-sidebar">
+      <saveableForm.PageNav>
+        <saveableForm.SaveButton
+          @isEnabled={{or @package.isDirty saveableForm.isSaveable}}
+          @onClick={{this.savePackage}}
+          data-test-save-button
+        />
+      </saveableForm.PageNav>
+    </div>
   </div>
-</div>
+</SaveableForm>

--- a/client/app/components/packages/draft-eas/edit.hbs
+++ b/client/app/components/packages/draft-eas/edit.hbs
@@ -10,16 +10,9 @@
       <h1 class="header-large">
         Draft Environmental Assessment Statement (EAS)
         <small class="text-weight-normal">
-        {{if @package.dcpPackageversion (concat '(V' @package.dcpPackageversion ')')}}
-      </small>
-      </h1>
-
-      <h2 class="no-margin">
-        {{@package.project.dcpProjectname}}
-        <small class="text-weight-normal">
-          {{if @package.project.dcpName (concat '(' @package.project.dcpName ')')}}
+          {{if @package.dcpPackageversion (concat '(V' @package.dcpPackageversion ')')}}
         </small>
-        </h1>
+      </h1>
 
         <h2 class="no-margin">
           {{@package.project.dcpProjectname}}
@@ -33,6 +26,11 @@
           {{optionset 'package' 'statuscode' 'label' @package.statuscode}}
         </p>
       </section>
+
+      <Packages::DraftEas::AttachedDocuments
+        @form={{saveableForm}}
+        @model={{@package}}
+      />
     </div>
 
     <div class="cell large-4 sticky-sidebar">

--- a/client/app/components/packages/draft-eas/edit.js
+++ b/client/app/components/packages/draft-eas/edit.js
@@ -1,0 +1,17 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+export default class PackagesDraftEasEditComponent extends Component {
+  @service
+  router;
+
+  @action
+  async savePackage() {
+    try {
+      await this.args.package.save();
+    } catch (error) {
+      console.log('Save Draft EAS package error:', error);
+    }
+  }
+}

--- a/client/app/components/packages/filed-eas/edit.hbs
+++ b/client/app/components/packages/filed-eas/edit.hbs
@@ -5,8 +5,8 @@
       <h1 class="header-large">
         Filed Environmental Assessment Statement (EAS)
         <small class="text-weight-normal">
-        {{if @package.dcpPackageversion (concat '(V' @package.dcpPackageversion ')')}}
-      </small>
+          {{if @package.dcpPackageversion (concat '(V' @package.dcpPackageversion ')')}}
+        </small>
       </h1>
 
       <h2 class="no-margin">


### PR DESCRIPTION
### Summary
Set up SaveableForm, Attachments section, and save button for the Draft EAS package page.

Fixes [AB#13030](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13030)
Fixes [AB#13032](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13032)

### Technical Details
Our SaveableForm component worked well! It was able to act on a package model instead of a form model.
And it worked without passing in any validations.