### PR TITLE
13039: add package notes to filed eas package

### DIFF
--- a/client/app/components/packages/filed-eas/edit.hbs
+++ b/client/app/components/packages/filed-eas/edit.hbs
@@ -21,5 +21,15 @@
         {{optionset 'package' 'statuscode' 'label' @package.statuscode}}
       </p>
     </section>
+
+    {{#if @package.dcpPackagenotes}}
+      <section class="form-section">
+        <p>
+          <strong>Package Notes from City Planning Staff:</strong>
+          <br>
+          {{@package.dcpPackagenotes}}
+        </p>
+      </section>
+    {{/if}}
   </div>
 </div>

--- a/server/src/packages/packages.attrs.ts
+++ b/server/src/packages/packages.attrs.ts
@@ -10,4 +10,5 @@ export const PACKAGE_ATTRS = [
   'dcp_packageid',
   'dcp_name',
   'dcp_statusdate',
+  'dcp_packagenotes',
 ];


### PR DESCRIPTION
**Summary**
Display package notes on the Filed Eas package page

**Task/Bug Number**
Closes [AB#13039](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13039)

**Technical Explanation**
Display text from the field `dcpPackagenotes` on the `edit.hbs` file of the filed-eas package.
