### PR TITLE
13196 retrofit PackageSection

### DIFF
--- a/client/app/components/project/package-section.hbs
+++ b/client/app/components/project/package-section.hbs
@@ -1,42 +1,21 @@
-<div ...attributes>
-  <h2>{{@packageType}}</h2>
+{{#if @packages.length}}
+  <div ...attributes>
+    <h2>{{@packageType}}</h2>
 
-  <div class="grid-x grid-padding-x">
-    <div class="cell large-6">
-      <ol class="no-bullet">
-        {{#each @packages as |package|}}
-          <Project::PackageListItem
-            @package={{package}}
-          />
-        {{/each}}
-      </ol>
-    </div>
-    <div class="cell large-6">
-      {{#let (flatten (map-by 'invoices' @packages)) as |invoices|}}
-        {{#if invoices}}
-          <h4>Invoices</h4>
-
-          {{#each invoices as |invoice|}}
-            <Project::PackageSection::InvoiceInfo
-              @invoice={{invoice}}
+    <div class="grid-x grid-padding-x">
+      <div class="cell large-6">
+        <ol class="no-bullet">
+          {{#each @packages as |package|}}
+            <Project::PackageListItem
+              @package={{package}}
             />
           {{/each}}
-
-          <br/>
-          <br/>
-          <button
-            type="button"
-            class="secondary button"
-            {{on 'click' (fn this.beginPayment)}}
-          >
-            Pay
-          </button>
-
-          <Ui::GenericModal
-            @show={{this.isPaying}}
-            @closeButtonAction={{fn (mut this.isPaying) false}}
-          >
-            <h3>Invoices to be paid</h3>
+        </ol>
+      </div>
+      <div class="cell large-6">
+        {{#let (flatten (map-by 'invoices' @packages)) as |invoices|}}
+          {{#if invoices}}
+            <h4>Invoices</h4>
 
             {{#each invoices as |invoice|}}
               <Project::PackageSection::InvoiceInfo
@@ -46,48 +25,71 @@
 
             <br/>
             <br/>
-            <h3>Total: ${{reduce (fn this.sum) 0 (map-by 'dcpGrandtotal' invoices)}}</h3>
+            <button
+              type="button"
+              class="secondary button"
+              {{on 'click' (fn this.beginPayment)}}
+            >
+              Pay
+            </button>
 
-            <p>
-              The following link will direct you to the CityPay website for payment processing. Before proceeding, be ready with
-              payment information such as routing numbers, account number, or credit card numbers. Credit card payments via CityPay
-              are subject to a 2% processing fee.
-            </p>
+            <Ui::GenericModal
+              @show={{this.isPaying}}
+              @closeButtonAction={{fn (mut this.isPaying) false}}
+            >
+              <h3>Invoices to be paid</h3>
 
-            <p>
-              Upon payment, this Project will be considered “Filed” and appear in public searches on <a href="https://zap.planning.nyc.gov/" rel="noreferrer noopener">https://zap.planning.nyc.gov/</a>.
-            </p>
+              {{#each invoices as |invoice|}}
+                <Project::PackageSection::InvoiceInfo
+                  @invoice={{invoice}}
+                />
+              {{/each}}
 
-            <div class="grid-x">
-              <div class="cell large-6 small-padding-right">
-                <a
-                  class="button expanded large {{unless this.paymentLink 'disabled'}}"
-                  href={{this.paymentLink}}
-                  rel="noreferrer noopener"
-                  target="_blank"
-                >
-                  {{#if this.paymentLink}}
-                    <strong>
-                      Go To CityPay <FaIcon @icon="external-link-alt" />
-                    </strong>
-                  {{else}}
-                    <FaIcon @icon="spinner" @spin={{true}} @pulse={{true}} class="text-silver" />
-                  {{/if}}
-                </a>
-              </div>
-              <div class="cell large-6 small-padding-left">
-                <button
-                  type="button"
-                  class="button expanded large secondary"
-                  {{on "click" (fn (mut this.isPaying) false)}}
+              <br/>
+              <br/>
+              <h3>Total: ${{reduce (fn this.sum) 0 (map-by 'dcpGrandtotal' invoices)}}</h3>
+
+              <p>
+                The following link will direct you to the CityPay website for payment processing. Before proceeding, be ready with
+                payment information such as routing numbers, account number, or credit card numbers. Credit card payments via CityPay
+                are subject to a 2% processing fee.
+              </p>
+
+              <p>
+                Upon payment, this Project will be considered “Filed” and appear in public searches on <a href="https://zap.planning.nyc.gov/" rel="noreferrer noopener">https://zap.planning.nyc.gov/</a>.
+              </p>
+
+              <div class="grid-x">
+                <div class="cell large-6 small-padding-right">
+                  <a
+                    class="button expanded large {{unless this.paymentLink 'disabled'}}"
+                    href={{this.paymentLink}}
+                    rel="noreferrer noopener"
+                    target="_blank"
                   >
-                  Cancel
-                </button>
+                    {{#if this.paymentLink}}
+                      <strong>
+                        Go To CityPay <FaIcon @icon="external-link-alt" />
+                      </strong>
+                    {{else}}
+                      <FaIcon @icon="spinner" @spin={{true}} @pulse={{true}} class="text-silver" />
+                    {{/if}}
+                  </a>
+                </div>
+                <div class="cell large-6 small-padding-left">
+                  <button
+                    type="button"
+                    class="button expanded large secondary"
+                    {{on "click" (fn (mut this.isPaying) false)}}
+                    >
+                    Cancel
+                  </button>
+                </div>
               </div>
-            </div>
-          </Ui::GenericModal>
-        {{/if}}
-      {{/let}}
+            </Ui::GenericModal>
+          {{/if}}
+        {{/let}}
+      </div>
     </div>
   </div>
-</div>
+{{/if}}

--- a/client/app/models/project.js
+++ b/client/app/models/project.js
@@ -112,8 +112,8 @@ export default class ProjectModel extends Model {
 
   get eisPackages() {
     const eisPackages = [
-      ...this.deisPackages,
       ...this.feisPackages,
+      ...this.deisPackages,
     ];
 
     return eisPackages;

--- a/client/app/templates/project.hbs
+++ b/client/app/templates/project.hbs
@@ -41,68 +41,41 @@
       </p>
     </section>
 
-    {{#if @model.landusePackages.length}}
       <Project::PackageSection
         @packages={{@model.landusePackages}}
         @packageType="Land Use"
         class="large-padding-top large-margin-bottom ruled-adjacent"
       />
-    {{/if}}
 
-    {{#if @model.easPackages.length}}
-      <section class="large-padding-top large-margin-bottom ruled-adjacent">
-        <h2>Environmental Assessment Statement (EAS)</h2>
-        <ol class="no-bullet">
-          {{#each @model.easPackages as |easPackage|}}
-            <Project::PackageListItem
-              @package={{easPackage}}
-              />
-          {{/each}}
-        </ol>
-      </section>
-    {{/if}} 
+      <Project::PackageSection
+        @packages={{@model.easPackages}}
+        @packageType="Environmental Assessment Statement (EAS)"
+        class="large-padding-top large-margin-bottom ruled-adjacent"
+      />
   
-    {{#if @model.eisPackages.length}}
-      <section class="large-padding-top large-margin-bottom ruled-adjacent">
-        <h2>Environmental Impact Statement (EIS)</h2>
-        <ol class="no-bullet">
-          {{#each @model.eisPackages as |eisPackage|}}
-            <Project::PackageListItem
-              @package={{eisPackage}}
-            />
-          {{/each}}
-        </ol>
-      </section>
-    {{/if}}
+      <Project::PackageSection
+        @packages={{@model.eisPackages}}
+        @packageType="Environmental Impact Statement (EIS)"
+        class="large-padding-top large-margin-bottom ruled-adjacent"
+      />
 
-    {{#if @model.technicalMemoPackages.length}}
-      <section class="large-padding-top large-margin-bottom ruled-adjacent">
-        <h2>Technical Memo</h2>
-        <ol class="no-bullet">
-          {{#each @model.technicalMemoPackages as |technicalMemoPackage|}}
-            <Project::PackageListItem
-              @package={{technicalMemoPackage}}
-            />
-          {{/each}}
-        </ol>
-      </section>
-    {{/if}}
+      <Project::PackageSection
+        @packages={{@model.technicalMemoPackages}}
+        @packageType="Technical Memo"
+        class="large-padding-top large-margin-bottom ruled-adjacent"
+      />
 
-    {{#if @model.rwcdsPackages.length}}
       <Project::PackageSection
         @packages={{@model.rwcdsPackages}}
         @packageType="Reasonable Worst Case Development Scenario"
         class="large-padding-top large-margin-bottom ruled-adjacent"
       />
-    {{/if}}
 
-    {{#if @model.pasPackages.length}}
       <Project::PackageSection
         @packages={{@model.pasPackages}}
         @packageType="Pre-Application Statement"
         class="large-padding-top large-margin-bottom ruled-adjacent"
       />
-    {{/if}}
   </div>{{! end left/main column }}
   <div class="cell large-4">
 


### PR DESCRIPTION
### Summary
Apply the new PackageSection component to EAS, EIS and Technical Memo sections
- Also moves the check for existing packages (`{{#if @packages.length}}`) inside PackageSection, to reduce repeated code. 
- Also minor patch to display Final EIS (FEIS) first before Draft EIS, to be consistent with other Package sections. 

#### Task/Bug Number
Fixes [AB#13196](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13196)
