### PR TITLE
13038: add save button and attachments section to filed eas package

### DIFF
--- a/client/app/components/packages/filed-eas/attached-documents.hbs
+++ b/client/app/components/packages/filed-eas/attached-documents.hbs
@@ -1,0 +1,47 @@
+{{#let @form as |form|}}
+  <form.Section @title="Attached Documents">
+    <p>
+      To complete this submission, attach a CEQR form (either short or full)
+      filled in as appropriate based on the Reasonable Worst Case Development Scenario,
+      CEQR Technical manual, and directions from the EARD Lead Planner assigned to this project.
+      Attach the EAS Analysis Sections and back up materials needed based on the above.
+      If the project requires Waterfront Revitalization Program Consistency review,
+      attach the Consistency Assessment Form with any supporting documentation
+      and written assessments as needed.
+    </p>
+
+    <ul>
+      <li>
+        <Ui::ExternalLink @href="https://www1.nyc.gov/site/oec/environmental-quality-review/ceqr-forms-templates.page">
+          CEQR Form (Short)
+        </Ui::ExternalLink>
+        or
+        <Ui::ExternalLink @href="https://www1.nyc.gov/site/oec/environmental-quality-review/ceqr-forms-templates.page">
+          CEQR Form (Full)
+        </Ui::ExternalLink>
+      </li>
+      <li>
+        <Ui::ExternalLink @href="https://www1.nyc.gov/site/oec/environmental-quality-review/technical-manual.page">
+          CEQR Manual
+        </Ui::ExternalLink>
+      </li>
+      <li>
+        <Ui::ExternalLink @href="https://www1.nyc.gov/assets/planning/download/pdf/applicants/applicant-portal/dcp-signature-form.pdf">
+          Signature Form
+        </Ui::ExternalLink>
+      </li>
+      <li>
+        <Ui::ExternalLink @href="https://www1.nyc.gov/assets/planning/download/pdf/planning-level/waterfront/wrp/wrpform2016.pdf?r=1">
+          Waterfront Revitalization Program (WRP) Form
+        </Ui::ExternalLink>
+        — only if project includes a WR action
+      </li>
+    </ul>
+
+    <Packages::Attachments
+      @package={{@model}}
+      @fileManager={{@model.fileManager}}
+      data-test-section="attachments"
+    />
+  </form.Section>
+{{/let}}

--- a/client/app/components/packages/filed-eas/edit.hbs
+++ b/client/app/components/packages/filed-eas/edit.hbs
@@ -1,35 +1,58 @@
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
+<SaveableForm
+  @model={{@package}}
+  @validators={{array (hash) (hash)}}
+  as |saveableForm|
+>
 
-    <section class="form-section">
-      <h1 class="header-large">
-        Filed Environmental Assessment Statement (EAS)
-        <small class="text-weight-normal">
-          {{if @package.dcpPackageversion (concat '(V' @package.dcpPackageversion ')')}}
-        </small>
-      </h1>
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
 
-      <h2 class="no-margin">
-        {{@package.project.dcpProjectname}}
-        <small class="text-weight-normal">
-          {{if @package.project.dcpName (concat '(' @package.project.dcpName ')')}}
-        </small>
-      </h2>
-
-      <p class="text-large text-dark-gray">
-        {{optionset 'bbl' 'boroughs' 'label' @package.project.dcpBorough}} |
-        {{optionset 'package' 'statuscode' 'label' @package.statuscode}}
-      </p>
-    </section>
-
-    {{#if @package.dcpPackagenotes}}
       <section class="form-section">
-        <p>
-          <strong>Package Notes from City Planning Staff:</strong>
-          <br>
-          {{@package.dcpPackagenotes}}
+        <h1 class="header-large">
+          Filed Environmental Assessment Statement (EAS)
+          <small class="text-weight-normal">
+            {{if @package.dcpPackageversion (concat '(V' @package.dcpPackageversion ')')}}
+          </small>
+        </h1>
+
+        <h2 class="no-margin">
+          {{@package.project.dcpProjectname}}
+          <small class="text-weight-normal">
+            {{if @package.project.dcpName (concat '(' @package.project.dcpName ')')}}
+          </small>
+        </h2>
+
+        <p class="text-large text-dark-gray">
+          {{optionset 'bbl' 'boroughs' 'label' @package.project.dcpBorough}} |
+          {{optionset 'package' 'statuscode' 'label' @package.statuscode}}
         </p>
       </section>
-    {{/if}}
+
+      {{#if @package.dcpPackagenotes}}
+        <section class="form-section">
+          <p>
+            <strong>Package Notes from City Planning Staff:</strong>
+            <br>
+            {{@package.dcpPackagenotes}}
+          </p>
+        </section>
+      {{/if}}
+
+      <Packages::FiledEas::AttachedDocuments
+        @form={{saveableForm}}
+        @model={{@package}}
+      />
+    </div>
+
+    <div class="cell large-4 sticky-sidebar">
+      <saveableForm.PageNav>
+        <saveableForm.SaveButton
+          @isEnabled={{or @package.isDirty saveableForm.isSaveable}}
+          @onClick={{this.savePackage}}
+          data-test-save-button
+        />
+      </saveableForm.PageNav>
+    </div>
   </div>
-</div>
+
+</SaveableForm>

--- a/client/app/components/packages/filed-eas/edit.js
+++ b/client/app/components/packages/filed-eas/edit.js
@@ -1,0 +1,17 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+export default class PackagesFiledEasEditComponent extends Component {
+  @service
+  router;
+
+  @action
+  async savePackage() {
+    try {
+      await this.args.package.save();
+    } catch (error) {
+      console.log('Save Filed EAS package error:', error);
+    }
+  }
+}


### PR DESCRIPTION
**Summary**
Add save button and attachments section to Filed EAS package

**Task Number**
[AB#13038](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13038) (attachments section)
[AB#13040](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13040) (save button)

**Technical Explanation**
Create attachments components for filed-eas package and render it on the filed-eas `edit.hbs` page. Include `saveableForm` and render the save button on the filed-eas `edit.hbs` page. 
