### PR TITLE
Re-enables the “email” param

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -6,6 +6,7 @@
     <title>NYC Planning Applicants</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="referrer" content="no-referrer-when-downgrade">
 
     {{content-for "head"}}
 

--- a/server/src/auth.middleware.ts
+++ b/server/src/auth.middleware.ts
@@ -36,11 +36,12 @@ export class AuthMiddleware implements NestMiddleware {
         const email = refererParams.searchParams.get('email'); // the query param, email, sent from the client. this is who the "Creeper" wants to be.
         const { mail: userEmail } = validatedToken; // the "creepers" actual email, for verification.
 
-        // REDO: env variables.
-        // if an e-mail is provided, implicitly it means force creeper mode. then verify creeper mode
-        // with some criteria.
         if (email && (userEmail === 'dcpcreeper@gmail.com' || userEmail.includes('@planning.nyc.gov'))) {
-          validatedToken = await this._spoofToken(validatedToken, email);
+          // simply include the "creeper" param in the session
+          validatedToken = {
+            ...validatedToken,
+            creeperTargetEmail: email,
+          };
         }
       }
 

--- a/server/src/projects/projects.controller.ts
+++ b/server/src/projects/projects.controller.ts
@@ -89,7 +89,18 @@ export class ProjectsController {
 
   @Get('/')
   async listOfCurrentUserProjects(@Session() session) {
-    const { contactId } = session;
+    let { contactId, creeperTargetEmail } = session;
+
+    // if this needs to be in other parts of the app, consider a pipe or interceptor
+    if (creeperTargetEmail) {
+      try {
+        const { contactid } = await this.contactService.findOneByEmail(creeperTargetEmail);
+
+        contactId = contactid
+      } catch (e) {
+        throw e;
+      }
+    }
 
     try {
       if (contactId) {


### PR DESCRIPTION
Takes a simpler approach, removes the dangerous “imposter” capability which re-generated the entire token.

### Summary
Allows the "email" param on the /projects view. Will show assigned projects for that e-mail.

#### Task/Bug Number
[AB#12660](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12660)

### Technical Explanation
Inserts the `email` search param into the session, allowing it to be referenced as-needed. Right now, the implementation is simplistic because it's only really needed in one place (dcp users may still view projects and forms that are not theirs). If we need to have this in other places, we should consider a pipe or guard or something that'll extract the correct "creeped" contcctid and swap teh current session with that id. 
