### PR TITLE
13051 Display Package Notes in DEIS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.vscode/

--- a/client/app/components/packages/deis/edit.hbs
+++ b/client/app/components/packages/deis/edit.hbs
@@ -27,6 +27,12 @@
           {{optionset 'package' 'statuscode' 'label' @package.statuscode}}
         </p>
       </section>
+      
+      {{#if @package.dcpPackagenotes}}          
+        <saveableForm.Section @title="Package Notes from City Planning Staff">
+          {{@package.dcpPackagenotes}}
+        </saveableForm.Section>
+      {{/if}}
 
       <Packages::Deis::AttachedDocuments
         @form={{saveableForm}}


### PR DESCRIPTION
### Summary
Display package notes on the DEIS package page

#### Task/Bug Number
Close AB# [13051
](https://dcp-paperless.visualstudio.com/ZAP%20Portals/_workitems/edit/13051)

### Technical Explanation
Display text from the field dcpPackagenotes on the edit.hbs file of the deis package.