### PR TITLE
13209 Set up tests for Draft EAS

### DIFF
--- a/client/app/components/packages/draft-eas/attached-documents.hbs
+++ b/client/app/components/packages/draft-eas/attached-documents.hbs
@@ -1,4 +1,6 @@
-<@form.Section @title="Attached Documents">
+<@form.Section @title="Attached Documents"
+  data-test-attached-documents
+>
   <p>
     To complete this submission, attach a CEQR form (either short or full)
     filled in as appropriate based on the Reasonable Worst Case Development Scenario,

--- a/client/app/components/packages/draft-eas/edit.hbs
+++ b/client/app/components/packages/draft-eas/edit.hbs
@@ -9,26 +9,41 @@
     <section class="form-section">
       <h1 class="header-large">
         Draft Environmental Assessment Statement (EAS)
-        <small class="text-weight-normal">
+        <small
+          class="text-weight-normal"
+          data-test-package-dcpPackageversion
+        >
           {{if @package.dcpPackageversion (concat '(V' @package.dcpPackageversion ')')}}
         </small>
       </h1>
 
-        <h2 class="no-margin">
+        <h2 class="no-margin"
+          data-test-project-dcpProjectname
+        >
           {{@package.project.dcpProjectname}}
-          <small class="text-weight-normal">
+          <small
+            class="text-weight-normal"
+            data-test-project-dcpName
+          >
             {{if @package.project.dcpName (concat '(' @package.project.dcpName ')')}}
           </small>
         </h2>
 
-        <p class="text-large text-dark-gray">
+        <p
+          class="text-large text-dark-gray"
+          data-test-project-dcpBorough
+          data-test-package-statuscode
+        >
           {{optionset 'bbl' 'boroughs' 'label' @package.project.dcpBorough}} |
           {{optionset 'package' 'statuscode' 'label' @package.statuscode}}
         </p>
       </section>
 
       {{#if @package.dcpPackagenotes}}
-        <saveableForm.Section @title="Package Notes from City Planning Staff">
+        <saveableForm.Section
+          @title="Package Notes from City Planning Staff"
+          data-test-package-notes
+        >
           {{@package.dcpPackagenotes}}
         </saveableForm.Section>
       {{/if}}

--- a/client/app/components/project/package-section.hbs
+++ b/client/app/components/project/package-section.hbs
@@ -1,5 +1,8 @@
 {{#if @packages.length}}
-  <div ...attributes>
+  <div
+    ...attributes
+    data-test-package-section={{@packageType}}
+  >
     <h2>{{@packageType}}</h2>
 
     <div class="grid-x grid-padding-x">

--- a/client/mirage/factories/package.js
+++ b/client/mirage/factories/package.js
@@ -7,6 +7,8 @@ import {
 export default Factory.extend({
   dcpStatusdate: new Date('December 17, 1995 03:24:00'),
 
+  dcpPackagenotes: 'Some instructions from Planners',
+
   dcpPackageversion(i) {
     const SAMPLE_VERSIONS = [
       1,
@@ -72,6 +74,10 @@ export default Factory.extend({
         });
       }
     },
+  }),
+
+  draftEas: trait({
+    dcpPackagetype: 717170002,
   }),
 
   withLandUseActions: trait({

--- a/client/tests/acceptance/user-can-edit-draft-eas-test.js
+++ b/client/tests/acceptance/user-can-edit-draft-eas-test.js
@@ -1,0 +1,84 @@
+import { module, test } from 'qunit';
+import {
+  visit,
+  click,
+  findAll,
+  currentURL,
+} from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+
+module('Acceptance | user can edit Draft EAS Packages', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(() => {
+    authenticateSession({
+      emailaddress1: 'me@me.com',
+    });
+  });
+
+  test('User sees Project under Awaiting Submission if it has an active Draft EAS', async function (assert) {
+    this.server.create('project', {
+      packages: [
+        this.server.create('package', 'toDo', 'draftEas'),
+        this.server.create('package', 'done', 'draftEas'),
+      ],
+    });
+
+    this.server.create('project', {
+      packages: [
+        this.server.create('package', 'done', 'draftEas'),
+      ],
+    });
+
+    await visit('/projects');
+    assert.equal(findAll('[data-test-projects-list="to-do"] [data-test-my-project-list-item]').length, 1);
+
+    assert.equal(findAll('[data-test-projects-list="done"] [data-test-my-project-list-item]').length, 1);
+  });
+
+  test('User sees Draft EAS Packages section on Project page when one exists', async function (assert) {
+    this.server.create('project', {
+      packages: [
+        this.server.create('package', 'toDo', 'draftEas'),
+        this.server.create('package', 'toDo', 'draftEas'),
+      ],
+    });
+
+    await visit('/projects/1');
+
+    assert.dom('[data-test-package-section="Environmental Assessment Statement (EAS)"]').exists();
+
+    assert.equal(findAll('[data-test-package-link]').length, 2);
+  });
+
+  test('User can click into Draft EAS and see Package info, Package notes, and Attachments', async function (assert) {
+    this.server.create('project', {
+      packages: [
+        this.server.create('package', 'toDo', 'draftEas'),
+      ],
+    });
+
+    await visit('/projects/1');
+
+    await click('[data-test-package-link="1"]');
+
+    assert.equal(currentURL(), '/draft-eas/1/edit');
+
+    assert.dom('[data-test-package-dcpPackageversion]').hasText('(V1)');
+
+    assert.dom('[data-test-project-dcpProjectname]').containsText('Huge New Public Library');
+
+    assert.dom('[data-test-project-dcpName]').hasText('(P2018M0268)');
+
+    assert.dom('[data-test-project-dcpBorough]').containsText('Bronx');
+
+    assert.dom('[data-test-package-statuscode]').containsText('Package Preparation');
+
+    assert.dom('[data-test-package-notes]').containsText('Some instructions from Planners');
+
+    assert.dom('[data-test-attached-documents]').exists();
+  });
+});


### PR DESCRIPTION
### Summary
Sets up tests for Draft EAS. Provides basic coverage of the Draft EAS component to boost project coverage.

#### Task/Bug Number
Fixes [AB#13209](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13209) 

### Technical Explanation
- Introduces test selectors to the Edit component, Package notes section, and Attached documents section. 