### PR TITLE
13033 13034 Submission and and Show page for Draft EAS

### DIFF
--- a/client/app/components/packages/draft-eas/draft-eas-error.hbs
+++ b/client/app/components/packages/draft-eas/draft-eas-error.hbs
@@ -1,0 +1,20 @@
+{{#if @package.adapterError}}
+  <div class="callout alert" data-test-error-saving>
+    <h5 class="text-red-dark">
+      <FaIcon
+        @icon="exclamation-circle"
+        @size="2x"
+        class="text-red float-left medium-margin-right tiny-margin-top"
+      />
+      There was a problem saving your information.
+    </h5>
+
+    <Errors::List
+      @errors={{@package.adapterError.errors}}
+    />
+
+    <p class="text-red-dark text-small">
+      Please try again. If the problem persists, please contact City Planning at <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or <a href="tel:212-720-3300" class="nowrap">212-720-3300</a>.
+    </p>
+  </div>
+{{/if}}

--- a/client/app/components/packages/draft-eas/edit.hbs
+++ b/client/app/components/packages/draft-eas/edit.hbs
@@ -61,7 +61,39 @@
           @onClick={{this.savePackage}}
           data-test-save-button
         />
+
+        <saveableForm.SubmitButton
+          @isEnabled={{saveableForm.isSubmittable}}
+          class="secondary"
+          data-test-submit-button
+        />
       </saveableForm.PageNav>
+
+      <saveableForm.ConfirmationModal
+        @action={{component saveableForm.SubmitButton
+          onClick=this.submitPackage
+          isEnabled=saveableForm.isSubmittable
+          class="no-margin"
+        }}
+        @footer={{component 'packages/draft-eas/draft-eas-error'
+          package=@package
+        }}
+        @continueButtonTitle="Continue Editing"
+        data-test-confirm-submit-button={{true}}
+      >
+        <h6>Confirm Draft EAS Submission</h6>
+
+        <p class="header-large medium-margin-top small-margin-bottom">
+          Are you sure?
+        </p>
+
+        <p>
+          Before submitting, ensure that necessary attachments have been uploaded.
+          If NYC Planning does not receive enough accurate information,
+          the Lead Planner will notify you and request that this form be resubmitted
+          with necessary materials, corrections, or clarifications.
+        </p>
+      </saveableForm.ConfirmationModal>
     </div>
   </div>
 </SaveableForm>

--- a/client/app/components/packages/draft-eas/edit.js
+++ b/client/app/components/packages/draft-eas/edit.js
@@ -14,4 +14,11 @@ export default class PackagesDraftEasEditComponent extends Component {
       console.log('Save Draft EAS package error:', error);
     }
   }
+
+  @action
+  async submitPackage() {
+    await this.args.package.submit();
+
+    this.router.transitionTo('draft-eas.show', this.args.package.id);
+  }
 }

--- a/client/app/components/packages/draft-eas/show.hbs
+++ b/client/app/components/packages/draft-eas/show.hbs
@@ -1,0 +1,71 @@
+<div class="grid-x grid-margin-x">
+  <div class="cell large-8">
+    <section class="form-section">
+      <h1 class="header-large">
+        Draft Environmental Assessment Statement (EAS) Information Confirmation
+        <small
+          class="text-weight-normal"
+          data-test-package-dcpPackageversion
+        >
+          {{if @package.dcpPackageversion (concat '(V' @package.dcpPackageversion ')')}}
+        </small>
+      </h1>
+
+      <h2 class="no-margin"
+        data-test-project-dcpProjectname
+      >
+        {{@package.project.dcpProjectname}}
+        <small
+          class="text-weight-normal"
+          data-test-project-dcpName
+        >
+          {{if @package.project.dcpName (concat '(' @package.project.dcpName ')')}}
+        </small>
+      </h2>
+
+      <p
+        class="text-large text-dark-gray"
+        data-test-project-dcpBorough
+        data-test-package-statuscode
+      >
+        {{optionset 'bbl' 'boroughs' 'label' @package.project.dcpBorough}} |
+        {{optionset 'package' 'statuscode' 'label' @package.statuscode}}
+      </p>
+    </section>
+
+    <section class="form-section"
+      data-test-attached-documents
+    >
+      <h2 class="section-header">
+        <span id="attachments" class="section-anchor"></span>
+        Attached Documents
+      </h2>
+
+      <ul class="no-bullet">
+        {{#each @package.documents as |document idx|}}
+          <li class="ruled-adjacent tight">
+            <a
+              href={{concat (get-env-variable 'host') '/documents' document.serverRelativeUrl}}
+              target="_blank"
+              rel="noopener noreferrer"
+              data-test-document-name={{idx}}
+            >
+              <strong>
+                {{document.name}}
+              </strong>
+            </a>
+            <small class="text-gray">
+              {{document.timeCreated}}
+            </small>
+          </li>
+        {{/each}}
+      </ul>
+    </section>
+  </div>
+
+  <div class="cell large-4 sticky-sidebar">
+    <Messages::Assistance class="large-margin-top" />
+  </div>
+</div>
+
+{{yield}}

--- a/client/app/templates/draft-eas/show.hbs
+++ b/client/app/templates/draft-eas/show.hbs
@@ -1,11 +1,11 @@
 <Ui::Breadcrumbs as |Crumb|>
   <Crumb @text="My Projects" @route='projects' />
-  <Crumb @text={{@model.package.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
   <Crumb @text="Draft EAS" @disabled={{true}} />
 </Ui::Breadcrumbs>
 
 <Packages::DraftEas::Show
-  @package={{@model.package}}
+  @package={{@model}}
 />
 
 {{outlet}}


### PR DESCRIPTION
### Summary
Sets up the submission process and Show page for the Draft EAS. Sets up tests as well.

#### Task/Bug Number
Fixes [AB#13033](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13033)
Fixes [AB#13034](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13034)

### Technical Explanation
- We can't yet acceptance-test that a file upload completes and the uploaded file shows up on the Show page. We have to create a test where the uploaded files are pre-populated on the test package.
