### PR TITLE
13037: add ceqr questionnaire to filed eas package

### DIFF
--- a/client/app/components/packages/filed-eas/ceqr-invoice-questionnaire.hbs
+++ b/client/app/components/packages/filed-eas/ceqr-invoice-questionnaire.hbs
@@ -1,0 +1,86 @@
+{{#let @form as |form|}}
+  <Ui::Question @required={{true}} as |dcpIsthesoleaapplicantagovtagencyQ|>
+    <dcpIsthesoleaapplicantagovtagencyQ.Legend>
+      Is the sole applicant a government agency (City, State, or Federal)?
+    </dcpIsthesoleaapplicantagovtagencyQ.Legend>
+
+    <form.Field
+      @attribute="dcpIsthesoleaapplicantagovtagency"
+      @type="radio-group"
+      as |RadioGroup|
+    >
+      <RadioGroup
+        @options={{optionset 'ceqrInvoiceQuestionnaire' 'dcpIsthesoleaapplicantagovtagency' 'list'}}
+      />
+    </form.Field>
+  </Ui::Question>
+
+  <Ui::Question as |dcpProjectspolelyconsistactionsnotmeasurableQ|>
+    <dcpProjectspolelyconsistactionsnotmeasurableQ.Legend>
+      Does your project solely consist of action(s) that are not measureable by sq. ft.?
+    </dcpProjectspolelyconsistactionsnotmeasurableQ.Legend>
+
+    <form.Field
+      @attribute="dcpProjectspolelyconsistactionsnotmeasurable"
+      @type="radio-group"
+      as |RadioGroup|
+    >
+      <RadioGroup
+        @options={{optionset 'ceqrInvoiceQuestionnaire' 'dcpProjectspolelyconsistactionsnotmeasurable' 'list'}}
+      />
+    </form.Field>
+  </Ui::Question>
+
+  <div>
+    <h5 class="small-margin-bottom">
+      What is the Square Footage of the Total Project?
+    </h5>
+
+    <label data-test-dcpsquarefeet-picker>
+      <PowerSelect
+        triggerClass="square-feet-dropdown"
+        supportsDataTestProperties={{true}}
+        @placeholder="-- Select Square Footage --"
+        @searchEnabled={{false}}
+        @options={{map-by 'code' (optionset 'ceqrInvoiceQuestionnaire' 'dcpSquarefeet' 'list')}}
+        @selected={{form.data.dcpSquarefeet}}
+        @onChange={{fn (mut form.data.dcpSquarefeet)}}
+        as |dcpSquarefeet|
+      >
+        {{optionset 'ceqrInvoiceQuestionnaire' 'dcpSquarefeet' 'label' dcpSquarefeet}}
+      </PowerSelect>
+    </label>
+  </div>
+
+  <Ui::Question as |dcpProjectmodificationtoapreviousapprovalQ|>
+    <dcpProjectmodificationtoapreviousapprovalQ.Legend>
+      Does the project consist solely of modification actions that are not subject to 197c? 
+    </dcpProjectmodificationtoapreviousapprovalQ.Legend>
+
+    <form.Field
+      @attribute="dcpProjectmodificationtoapreviousapproval"
+      @type="radio-group"
+      as |RadioGroup|
+    >
+      <RadioGroup
+        @options={{optionset 'ceqrInvoiceQuestionnaire' 'dcpProjectmodificationtoapreviousapproval' 'list'}}
+      />
+    </form.Field>
+  </Ui::Question>
+
+  <Ui::Question as |dcpRespectivedecrequiredQ|>
+    <dcpRespectivedecrequiredQ.Legend>
+      Does your project produce a need for a CEQR Restrictive Declaration? 
+    </dcpRespectivedecrequiredQ.Legend>
+
+    <form.Field
+      @attribute="dcpRespectivedecrequired"
+      @type="radio-group"
+      as |RadioGroup|
+    >
+      <RadioGroup
+        @options={{optionset 'ceqrInvoiceQuestionnaire' 'dcpRespectivedecrequired' 'list'}}
+      />
+    </form.Field>
+  </Ui::Question>
+{{/let}}

--- a/client/app/components/packages/filed-eas/edit.hbs
+++ b/client/app/components/packages/filed-eas/edit.hbs
@@ -6,7 +6,6 @@
 
   <div class="grid-x grid-margin-x">
     <div class="cell large-8">
-
       <section class="form-section">
         <h1 class="header-large">
           Filed Environmental Assessment Statement (EAS)
@@ -49,6 +48,20 @@
           {{@package.dcpPackagenotes}}
         </saveableForm.Section>
       {{/if}}
+
+      {{#let saveableForm.data.singleCeqrInvoiceQuestionnaire as |ceqrInvoiceQuestionnaire|}}
+        <saveableForm.Section @title="Ceqr Invoice Questionnaire">
+          <saveableForm.SaveableForm
+            @model={{ceqrInvoiceQuestionnaire}}
+            @validators={{array (hash) this.validations.SubmittableCeqrInvoiceQuestionnaireFormValidations}}
+            as |ceqrInvoiceQuestionnaireForm|
+          >
+            <Packages::FiledEas::CeqrInvoiceQuestionnaire
+              @form={{ceqrInvoiceQuestionnaireForm}}
+            />
+          </saveableForm.SaveableForm>
+        </saveableForm.Section>
+      {{/let}}
 
       <Packages::FiledEas::AttachedDocuments
         @form={{saveableForm}}

--- a/client/app/components/packages/filed-eas/edit.js
+++ b/client/app/components/packages/filed-eas/edit.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import SubmittablePackageFormValidations from '../../../validations/submittable-package';
+import SubmittableCeqrInvoiceQuestionnaireFormValidations from '../../../validations/submittable-ceqr-invoice-questionnaire-form';
 
 export default class PackagesFiledEasEditComponent extends Component {
   validations = {
@@ -10,6 +11,10 @@ export default class PackagesFiledEasEditComponent extends Component {
 
   @service
   router;
+
+  validations = {
+    SubmittableCeqrInvoiceQuestionnaireFormValidations,
+  };
 
   @action
   async savePackage() {

--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -28,6 +28,9 @@ import PROJECT_OPTIONSETS from '../optionsets/project';
 import {
   DCPAPPLICANTROLE,
 } from '../optionsets/project-applicant';
+import {
+  CEQR_INVOICE_QUESTIONNAIRE_OPTIONSETS,
+} from '../optionsets/ceqr-invoice-questionnaire';
 
 const OPTIONSET_LOOKUP = {
   applicant: {
@@ -151,6 +154,13 @@ const OPTIONSET_LOOKUP = {
   relatedAction: {
     // Actually a boolean field in CRM, not picklist
     dcpIscompletedaction: YES_NO,
+  },
+  ceqrInvoiceQuestionnaire: {
+    dcpSquarefeet: CEQR_INVOICE_QUESTIONNAIRE_OPTIONSETS.SQUARE_FEET,
+    dcpIsthesoleaapplicantagovtagency: COMMON_OPTIONSETS.YES_NO_PICKLIST_CODE,
+    dcpProjectspolelyconsistactionsnotmeasurable: COMMON_OPTIONSETS.YES_NO_PICKLIST_CODE,
+    dcpProjectmodificationtoapreviousapproval: COMMON_OPTIONSETS.YES_NO_PICKLIST_CODE,
+    dcpRespectivedecrequired: COMMON_OPTIONSETS.YES_NO,
   },
 };
 

--- a/client/app/models/ceqr-invoice-questionnaire.js
+++ b/client/app/models/ceqr-invoice-questionnaire.js
@@ -1,0 +1,24 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class CeqrInvoiceQuestionnaireModel extends Model {
+  @belongsTo('package')
+  package;
+
+  @attr()
+  dcpIsthesoleaapplicantagovtagency;
+
+  @attr()
+  dcpIsthesoleaapplicantagovtagency;
+
+  @attr()
+  dcpProjectspolelyconsistactionsnotmeasurable;
+
+  @attr()
+  dcpSquarefeet;
+
+  @attr()
+  dcpProjectmodificationtoapreviousapproval;
+
+  @attr()
+  dcpRespectivedecrequired;
+}

--- a/client/app/optionsets/ceqr-invoice-questionnaire.js
+++ b/client/app/optionsets/ceqr-invoice-questionnaire.js
@@ -1,0 +1,54 @@
+export const SQUARE_FEET = {
+  SQFT_LESS_10000: {
+    code: 717170001,
+    label: 'less than 10,000 square feet',
+  },
+  SQFT_10000_19999: {
+    code: 717170002,
+    label: '10,000 to 19,999',
+  },
+  SQFT_20000_39999: {
+    code: 717170003,
+    label: '20,000 to 39,999',
+  },
+  SQFT_40000_59999: {
+    code: 717170004,
+    label: '40,000 to 59,999',
+  },
+  SQFT_60000_79999: {
+    code: 717170005,
+    label: '60,000 to 79,999',
+  },
+  SQFT_80000_99999: {
+    code: 717170006,
+    label: '80,000 to 99,999',
+  },
+  SQFT_100000_149999: {
+    code: 717170007,
+    label: '100,000 to 149,999',
+  },
+  SQFT_150000_199999: {
+    code: 717170008,
+    label: '150,000 to 199,999',
+  },
+  SQFT_200000_299999: {
+    code: 717170009,
+    label: '200,000 to 299,999',
+  },
+  SQFT_300000_499999: {
+    code: 717170010,
+    label: '300,000 to 499,999',
+  },
+  SQFT_500000_1000000: {
+    code: 717170011,
+    label: '500,000 to 1,000,000',
+  },
+  SQFT_OVER_1000000: {
+    code: 717170012,
+    label: 'over 1,000,000 square feet',
+  },
+};
+
+export const CEQR_INVOICE_QUESTIONNAIRE_OPTIONSETS = {
+  SQUARE_FEET,
+};

--- a/client/app/optionsets/common.js
+++ b/client/app/optionsets/common.js
@@ -23,6 +23,17 @@ export const YES_NO_INTEGER = {
   },
 };
 
+export const YES_NO_PICKLIST_CODE = {
+  YES: {
+    code: 717170000,
+    label: 'Yes',
+  },
+  NO: {
+    code: 717170001,
+    label: 'No',
+  },
+};
+
 export const YES_NO_UNSURE = {
   YES: {
     code: 717170000,
@@ -56,6 +67,7 @@ export const YES_NO_DONT_KNOW = {
 const COMMON_OPTIONSETS = {
   YES_NO,
   YES_NO_UNSURE,
+  YES_NO_PICKLIST_CODE,
   YES_NO_DONT_KNOW,
   YES_NO_INTEGER,
 };

--- a/client/app/routes/filed-eas.js
+++ b/client/app/routes/filed-eas.js
@@ -7,7 +7,7 @@ export default class FiledEasRoute extends Route.extend(AuthenticatedRouteMixin)
   async model(params) {
     const filedEasPackage = await this.store.findRecord('package', params.id, {
       reload: true,
-      include: 'project',
+      include: 'project,ceqrInvoiceQuestionnaires',
     });
 
     // manually generate a file factory

--- a/client/app/validations/submittable-ceqr-invoice-questionnaire-form.js
+++ b/client/app/validations/submittable-ceqr-invoice-questionnaire-form.js
@@ -1,0 +1,12 @@
+import {
+  validatePresence,
+} from 'ember-changeset-validations/validators';
+
+export default {
+  dcpIsthesoleaapplicantagovtagency: [
+    validatePresence({
+      presence: true,
+      message: 'This field is required',
+    }),
+  ],
+};

--- a/client/mirage/config.js
+++ b/client/mirage/config.js
@@ -93,6 +93,10 @@ export default function() {
 
   this.get('/invoices/:id');
 
+  this.get('/ceqr-invoice-questionnaires');
+  this.get('/ceqr-invoice-questionnaires/:id');
+  this.patch('/ceqr-invoice-questionnaires/:id');
+
   this.post('/documents', function(schema, request) {
     // requestBody should be a FormData object
     const { requestBody } = request;

--- a/client/mirage/factories/package.js
+++ b/client/mirage/factories/package.js
@@ -82,6 +82,9 @@ export default Factory.extend({
 
   filedEas: trait({
     dcpPackagetype: 717170012,
+    afterCreate(projectPackage, server) {
+      server.create('ceqr-invoice-questionnaire', { package: projectPackage });
+    },
   }),
 
   scopeOfWorkDraft: trait({

--- a/client/mirage/models/ceqr-invoice-questionnaire.js
+++ b/client/mirage/models/ceqr-invoice-questionnaire.js
@@ -1,0 +1,5 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  package: belongsTo('package'),
+});

--- a/client/mirage/models/package.js
+++ b/client/mirage/models/package.js
@@ -1,8 +1,9 @@
-import { Model, belongsTo } from 'ember-cli-mirage';
+import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
 
 export default Model.extend({
   project: belongsTo('project'),
   pasForm: belongsTo('pas-form'),
   rwcdsForm: belongsTo('rwcds-form'),
   landuseForm: belongsTo('landuse-form'),
+  ceqrInvoiceQuestionnaires: hasMany('ceqr-invoice-questionnaire'),
 });

--- a/client/tests/acceptance/user-can-edit-filed-eas-test.js
+++ b/client/tests/acceptance/user-can-edit-filed-eas-test.js
@@ -11,6 +11,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { selectFiles } from 'ember-file-upload/test-support';
+import { selectChoose } from 'ember-power-select/test-support';
 
 const saveForm = async () => {
   await click('[data-test-save-button]');
@@ -99,6 +100,9 @@ module('Acceptance | user can edit Filed EAS Packages', function (hooks) {
 
     await visit('/filed-eas/1/edit');
 
+    // filling out necessary fields for submit
+    await click('[data-test-radio="dcpIsthesoleaapplicantagovtagency"][data-test-radio-option="Yes"]');
+
     const file = new File(['foo'], 'Zoning Application.pdf', { type: 'text/plain' });
 
     await selectFiles('#FileUploader1 > input', file);
@@ -135,5 +139,25 @@ module('Acceptance | user can edit Filed EAS Packages', function (hooks) {
 
     assert.dom('[data-test-document-name="0"]').containsText('PAS Form.pdf');
     assert.dom('[data-test-document-name="1"]').containsText('Action Changes.excel');
+  });
+
+  test('User can click through Ceqr Invoice Questionnaire section on Filed Eas', async function (assert) {
+    this.server.create('project', {
+      packages: [
+        this.server.create('package', 'toDo', 'filedEas'),
+      ],
+    });
+
+    await visit('/filed-eas/1/edit');
+
+    await click('[data-test-radio="dcpIsthesoleaapplicantagovtagency"][data-test-radio-option="Yes"]');
+    await click('[data-test-radio="dcpProjectspolelyconsistactionsnotmeasurable"][data-test-radio-option="No"]');
+    await selectChoose('[data-test-dcpsquarefeet-picker]', 'less than 10,000 square feet');
+    await click('[data-test-radio="dcpProjectmodificationtoapreviousapproval"][data-test-radio-option="No"]');
+    await click('[data-test-radio="dcpRespectivedecrequired"][data-test-radio-option="Yes"]');
+
+    await click('[data-test-save-button]');
+
+    assert.equal(currentURL(), '/filed-eas/1/edit');
   });
 });

--- a/server/src/json-api-deserialize.pipe.ts
+++ b/server/src/json-api-deserialize.pipe.ts
@@ -55,6 +55,9 @@ export class JsonApiDeserializePipe implements PipeTransform {
         'zoning-resolutions': {
           valueForRelationship: relationship => relationship.id,
         },
+        'ceqr-invoice-questionnaires': {
+          valueForRelationship: relationship => relationship.id,
+        },
       }).deserialize(value);
     }
 

--- a/server/src/packages/ceqr-invoice-questionnaires/ceqr-invoice-questionnaires.attrs.ts
+++ b/server/src/packages/ceqr-invoice-questionnaires/ceqr-invoice-questionnaires.attrs.ts
@@ -1,0 +1,7 @@
+export const CEQR_INVOICE_QUESTIONNAIRE_ATTRS = [
+  'dcp_isthesoleaapplicantagovtagency',
+  'dcp_projectspolelyconsistactionsnotmeasurable',
+  'dcp_squarefeet',
+  'dcp_projectmodificationtoapreviousapproval',
+  'dcp_respectivedecrequired',
+];

--- a/server/src/packages/ceqr-invoice-questionnaires/ceqr-invoice-questionnaires.controller.ts
+++ b/server/src/packages/ceqr-invoice-questionnaires/ceqr-invoice-questionnaires.controller.ts
@@ -1,0 +1,32 @@
+import { Controller, Patch, Body, Param, Post, UseInterceptors, UseGuards, UsePipes, Delete, HttpException, HttpStatus } from '@nestjs/common';
+import { pick } from 'underscore';
+import { CrmService } from '../../crm/crm.service';
+import { JsonApiSerializeInterceptor } from '../../json-api-serialize.interceptor';
+import { AuthenticateGuard } from '../../authenticate.guard';
+import { JsonApiDeserializePipe } from '../../json-api-deserialize.pipe';
+import { CEQR_INVOICE_QUESTIONNAIRE_ATTRS } from './ceqr-invoice-questionnaires.attrs';
+
+@UseInterceptors(new JsonApiSerializeInterceptor('ceqr-invoice-questionnaires', {
+  id: 'dcp_ceqrinvoicequestionnaireid',
+  attributes: [
+    ...CEQR_INVOICE_QUESTIONNAIRE_ATTRS,
+  ],
+}))
+@UseGuards(AuthenticateGuard)
+@UsePipes(JsonApiDeserializePipe)
+@Controller('ceqr-invoice-questionnaires')
+export class CeqrInvoiceQuestionnairesController {
+  constructor(private readonly crmService: CrmService) {}
+
+  @Patch('/:id')
+  async update(@Body() body, @Param('id') id) {
+    const allowedAttrs = pick(body, CEQR_INVOICE_QUESTIONNAIRE_ATTRS);
+
+    await this.crmService.update('dcp_ceqrinvoicequestionnaires', id, allowedAttrs);
+
+    return {
+      dcp_ceqrinvoicequestionnaireid: id,
+      ...body,
+    }
+  }
+}

--- a/server/src/packages/packages.controller.ts
+++ b/server/src/packages/packages.controller.ts
@@ -30,6 +30,7 @@ import { SITEDATAH_FORM_ATTRS } from './landuse-form/sitedatah-forms/sitedatah-f
 import { LANDUSE_GEOGRAPHY_ATTRS } from './landuse-form/landuse-geography/landuse-geography.attrs';
 import { ZONINGRESOLUTION_ATTRS } from '../zoning-resolutions/zoning-resolutions.attrs';
 import { ZONING_MAP_CHANGE_ATTRS } from './landuse-form/zoning-map-changes/zoning-map-change.attrs';
+import { CEQR_INVOICE_QUESTIONNAIRE_ATTRS } from './ceqr-invoice-questionnaires/ceqr-invoice-questionnaires.attrs';
 import { CitypayService } from '../citypay/citypay.service';
 
 @UseInterceptors(new JsonApiSerializeInterceptor('packages', {
@@ -40,6 +41,8 @@ import { CitypayService } from '../citypay/citypay.service';
     // not a relationship proper, just an array of objects
     // REDO: make this a rel
     'documents',
+
+    'ceqr-invoice-questionnaires',
 
     // entity relationships
     'pas-form',
@@ -54,6 +57,12 @@ import { CitypayService } from '../citypay/citypay.service';
     ref: 'dcp_projectid',
     attributes: [
       ...PROJECT_ATTRS
+    ],
+  },
+  'ceqr-invoice-questionnaires': {
+    ref: 'dcp_ceqrinvoicequestionnaireid',
+    attributes: [
+      ...CEQR_INVOICE_QUESTIONNAIRE_ATTRS,
     ],
   },
   'pas-form': {
@@ -193,7 +202,7 @@ import { CitypayService } from '../citypay/citypay.service';
       const {
         dcp_pasform: pasForm,
         dcp_rwcdsform: rwcdsForm,
-        dcp_landuse: landuseForm
+        dcp_landuse: landuseForm,
       } = projectPackage;
   
       if (pasForm) {
@@ -268,6 +277,7 @@ import { CitypayService } from '../citypay/citypay.service';
       } else {
         return {
           ...projectPackage,
+          'ceqr-invoice-questionnaires': projectPackage.dcp_package_dcp_ceqrinvoicequestionnaire_Package,
         };
       }
     } catch (e) {

--- a/server/src/packages/packages.module.ts
+++ b/server/src/packages/packages.module.ts
@@ -18,6 +18,7 @@ import { RwcdsFormService } from './rwcds-form/rwcds-form.service';
 import { LanduseFormService } from './landuse-form/landuse-form.service';
 import { DocumentModule } from '../document/document.module';
 import { CitypayModule } from '../citypay/citypay.module';
+import { CeqrInvoiceQuestionnairesController } from './ceqr-invoice-questionnaires/ceqr-invoice-questionnaires.controller';
 
 @Module({
   imports: [CrmModule, DocumentModule, CitypayModule],
@@ -36,6 +37,7 @@ import { CitypayModule } from '../citypay/citypay.module';
     LanduseActionsController,
     LanduseGeographyController,
     ZoningMapChangesController,
+    CeqrInvoiceQuestionnairesController,
   ],
 })
 export class PackagesModule {}

--- a/server/src/packages/packages.service.ts
+++ b/server/src/packages/packages.service.ts
@@ -107,7 +107,7 @@ export class PackagesService {
         const { records: [firstPackage] } = await this.crmService.get('dcp_packages', `
         $select=${PACKAGE_ATTRS.join(',')}
         &$filter=dcp_packageid eq ${packageId}
-        &$expand=dcp_project($select=${PROJECT_ATTRS.join(',')})
+        &$expand=dcp_project($select=${PROJECT_ATTRS.join(',')}),dcp_package_dcp_ceqrinvoicequestionnaire_Package
       `);
 
       if (!firstPackage) {


### PR DESCRIPTION
**Summary**
Add Ceqr Invoice Questionnaire section to Filed Eas Package.

**Task/Bug Number**
[AB#13037](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13037)

**Technical Explanation**
- create new `ceqr-invoice-questionnaire` component that is rendered on the `filed-eas/edit.hbs` component
- because the questionnaire is stored in a separate entity, use `$expand` on the package GETter to include the ceqr-invoice-questionnaire
- users can PATCH to the ceqr-invoice-questionnaire fields
