### PR TITLE
13209 Sets up basic tests for technical memo

### DIFF
--- a/client/app/components/packages/technical-memo/attached-documents.hbs
+++ b/client/app/components/packages/technical-memo/attached-documents.hbs
@@ -1,4 +1,7 @@
-<@form.Section @title="Attached Documents">
+<@form.Section
+  @title="Attached Documents"
+  data-test-attached-documents
+>
   <Packages::Attachments
     @package={{@model}}
     @fileManager={{@model.fileManager}}

--- a/client/app/components/packages/technical-memo/edit.hbs
+++ b/client/app/components/packages/technical-memo/edit.hbs
@@ -9,26 +9,42 @@
     <section class="form-section">
       <h1 class="header-large">
         Technical Memo
-        <small class="text-weight-normal">
+        <small
+          class="text-weight-normal"
+          data-test-package-dcpPackageversion
+        >
           {{if @package.dcpPackageversion (concat '(V' @package.dcpPackageversion ')')}}
         </small>
       </h1>
 
-        <h2 class="no-margin">
+        <h2
+          class="no-margin"
+          data-test-project-dcpProjectname
+        >
           {{@package.project.dcpProjectname}}
-          <small class="text-weight-normal">
+          <small
+            class="text-weight-normal"
+            data-test-project-dcpName
+          >
             {{if @package.project.dcpName (concat '(' @package.project.dcpName ')')}}
           </small>
         </h2>
 
-        <p class="text-large text-dark-gray">
+        <p
+          class="text-large text-dark-gray"
+          data-test-project-dcpBorough
+          data-test-package-statuscode
+        >
           {{optionset 'bbl' 'boroughs' 'label' @package.project.dcpBorough}} |
           {{optionset 'package' 'statuscode' 'label' @package.statuscode}}
         </p>
       </section>
 
       {{#if @package.dcpPackagenotes}}
-        <saveableForm.Section @title="Package Notes from City Planning Staff">
+        <saveableForm.Section
+          @title="Package Notes from City Planning Staff"
+          data-test-package-notes
+        >
           {{@package.dcpPackagenotes}}
         </saveableForm.Section>
       {{/if}}

--- a/client/app/controllers/projects.js
+++ b/client/app/controllers/projects.js
@@ -30,7 +30,8 @@ export default class ProjectsController extends Controller {
       || packageIsToDo(project.rwcdsPackages)
       || (packageIsToDo(project.landusePackages))
       || (packageIsToDo(project.easPackages))
-      || (packageIsToDo(project.eisPackages)));
+      || (packageIsToDo(project.eisPackages))
+      || (packageIsToDo(project.technicalMemoPackages)));
   }
 
   // Projects in NYC Planning's hands

--- a/client/mirage/factories/package.js
+++ b/client/mirage/factories/package.js
@@ -92,6 +92,10 @@ export default Factory.extend({
     dcpPackagetype: 717170003,
   }),
 
+  technicalMemo: trait({
+    dcpPackagetype: 717170007,
+  }),
+
   withLandUseActions: trait({
     afterCreate(projectPackage, server) {
       server.create('pas-form', 'withLandUseActions', { package: projectPackage });

--- a/client/tests/acceptance/user-can-edit-technical-memo-test.js
+++ b/client/tests/acceptance/user-can-edit-technical-memo-test.js
@@ -1,0 +1,84 @@
+import { module, test } from 'qunit';
+import {
+  visit,
+  click,
+  findAll,
+  currentURL,
+} from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+
+module('Acceptance | user can edit Technical Memo Packages', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(() => {
+    authenticateSession({
+      emailaddress1: 'me@me.com',
+    });
+  });
+
+  test('User sees Project under Awaiting Submission if it has an active Technical Memo', async function (assert) {
+    this.server.create('project', {
+      packages: [
+        this.server.create('package', 'toDo', 'technicalMemo'),
+        this.server.create('package', 'done', 'technicalMemo'),
+      ],
+    });
+
+    this.server.create('project', {
+      packages: [
+        this.server.create('package', 'done', 'technicalMemo'),
+      ],
+    });
+
+    await visit('/projects');
+    assert.equal(findAll('[data-test-projects-list="to-do"] [data-test-my-project-list-item]').length, 1);
+
+    assert.equal(findAll('[data-test-projects-list="done"] [data-test-my-project-list-item]').length, 1);
+  });
+
+  test('User sees Technical Memo Packages section on Project page when one exists', async function (assert) {
+    this.server.create('project', {
+      packages: [
+        this.server.create('package', 'toDo', 'technicalMemo'),
+        this.server.create('package', 'toDo', 'technicalMemo'),
+      ],
+    });
+
+    await visit('/projects/1');
+
+    assert.dom('[data-test-package-section="Technical Memo"]').exists();
+
+    assert.equal(findAll('[data-test-package-link]').length, 2);
+  });
+
+  test('User can click into Technical Memo and see Package info, Package notes, and Attachments', async function (assert) {
+    this.server.create('project', {
+      packages: [
+        this.server.create('package', 'toDo', 'technicalMemo'),
+      ],
+    });
+
+    await visit('/projects/1');
+
+    await click('[data-test-package-link="1"]');
+
+    assert.equal(currentURL(), '/technical-memo/1/edit');
+
+    assert.dom('[data-test-package-dcpPackageversion]').hasText('(V1)');
+
+    assert.dom('[data-test-project-dcpProjectname]').containsText('Huge New Public Library');
+
+    assert.dom('[data-test-project-dcpName]').hasText('(P2018M0268)');
+
+    assert.dom('[data-test-project-dcpBorough]').containsText('Bronx');
+
+    assert.dom('[data-test-package-statuscode]').containsText('Package Preparation');
+
+    assert.dom('[data-test-package-notes]').containsText('Some instructions from Planners');
+
+    assert.dom('[data-test-attached-documents]').exists();
+  });
+});


### PR DESCRIPTION
### Summary
Follows the pattern for Draft EAS to set up basic tests for Technical Memo (note that it does not yet include tests for submit and show page, since those do not yet exist)

#### Task/Bug Number
Contributes towards fixing [AB#13209](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13209)

### Technical Explanation
- Turns out I previously forgot to include Projects with active Technical Memo underneath "Awaiting Submission". These tests helped reveal that. :) 
