### PR TITLE
13056 13064 Set up Tech Memo Submit and Show page

### DIFF
--- a/client/app/components/packages/technical-memo/edit.hbs
+++ b/client/app/components/packages/technical-memo/edit.hbs
@@ -62,7 +62,39 @@
           @onClick={{this.savePackage}}
           data-test-save-button
         />
+
+        <saveableForm.SubmitButton
+          @isEnabled={{saveableForm.isSubmittable}}
+          class="secondary"
+          data-test-submit-button
+        />
       </saveableForm.PageNav>
+
+      <saveableForm.ConfirmationModal
+        @action={{component saveableForm.SubmitButton
+          onClick=this.submitPackage
+          isEnabled=saveableForm.isSubmittable
+          class="no-margin"
+        }}
+        @footer={{component 'packages/technical-memo/technical-memo-error'
+          package=@package
+        }}
+        @continueButtonTitle="Continue Editing"
+        data-test-confirm-submit-button={{true}}
+      >
+        <h6>Confirm Technical Memo Submission</h6>
+
+        <p class="header-large medium-margin-top small-margin-bottom">
+          Are you sure?
+        </p>
+
+        <p>
+          Before submitting, ensure that necessary attachments have been uploaded.
+          If NYC Planning does not receive enough accurate information,
+          the Lead Planner will notify you and request that this form be resubmitted
+          with necessary materials, corrections, or clarifications.
+        </p>
+      </saveableForm.ConfirmationModal>
     </div>
   </div>
 </SaveableForm>

--- a/client/app/components/packages/technical-memo/edit.js
+++ b/client/app/components/packages/technical-memo/edit.js
@@ -14,4 +14,11 @@ export default class PackagesTechnicalMemoEditComponent extends Component {
       console.log('Save Technical Memo package error:', error);
     }
   }
+
+  @action
+  async submitPackage() {
+    await this.args.package.submit();
+
+    this.router.transitionTo('technical-memo.show', this.args.package.id);
+  }
 }

--- a/client/app/components/packages/technical-memo/show.hbs
+++ b/client/app/components/packages/technical-memo/show.hbs
@@ -1,0 +1,71 @@
+<div class="grid-x grid-margin-x">
+  <div class="cell large-8">
+    <section class="form-section">
+      <h1 class="header-large">
+        Technical Memo Information Confirmation
+        <small
+          class="text-weight-normal"
+          data-test-package-dcpPackageversion
+        >
+          {{if @package.dcpPackageversion (concat '(V' @package.dcpPackageversion ')')}}
+        </small>
+      </h1>
+
+      <h2 class="no-margin"
+        data-test-project-dcpProjectname
+      >
+        {{@package.project.dcpProjectname}}
+        <small
+          class="text-weight-normal"
+          data-test-project-dcpName
+        >
+          {{if @package.project.dcpName (concat '(' @package.project.dcpName ')')}}
+        </small>
+      </h2>
+
+      <p
+        class="text-large text-dark-gray"
+        data-test-project-dcpBorough
+        data-test-package-statuscode
+      >
+        {{optionset 'bbl' 'boroughs' 'label' @package.project.dcpBorough}} |
+        {{optionset 'package' 'statuscode' 'label' @package.statuscode}}
+      </p>
+    </section>
+
+    <section class="form-section"
+      data-test-attached-documents
+    >
+      <h2 class="section-header">
+        <span id="attachments" class="section-anchor"></span>
+        Attached Documents
+      </h2>
+
+      <ul class="no-bullet">
+        {{#each @package.documents as |document idx|}}
+          <li class="ruled-adjacent tight">
+            <a
+              href={{concat (get-env-variable 'host') '/documents' document.serverRelativeUrl}}
+              target="_blank"
+              rel="noopener noreferrer"
+              data-test-document-name={{idx}}
+            >
+              <strong>
+                {{document.name}}
+              </strong>
+            </a>
+            <small class="text-gray">
+              {{document.timeCreated}}
+            </small>
+          </li>
+        {{/each}}
+      </ul>
+    </section>
+  </div>
+
+  <div class="cell large-4 sticky-sidebar">
+    <Messages::Assistance class="large-margin-top" />
+  </div>
+</div>
+
+{{yield}}

--- a/client/app/components/packages/technical-memo/technical-memo-error.hbs
+++ b/client/app/components/packages/technical-memo/technical-memo-error.hbs
@@ -1,0 +1,20 @@
+{{#if @package.adapterError}}
+  <div class="callout alert" data-test-error-saving>
+    <h5 class="text-red-dark">
+      <FaIcon
+        @icon="exclamation-circle"
+        @size="2x"
+        class="text-red float-left medium-margin-right tiny-margin-top"
+      />
+      There was a problem saving your information.
+    </h5>
+
+    <Errors::List
+      @errors={{@package.adapterError.errors}}
+    />
+
+    <p class="text-red-dark text-small">
+      Please try again. If the problem persists, please contact City Planning at <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or <a href="tel:212-720-3300" class="nowrap">212-720-3300</a>.
+    </p>
+  </div>
+{{/if}}

--- a/client/app/templates/technical-memo/show.hbs
+++ b/client/app/templates/technical-memo/show.hbs
@@ -1,0 +1,11 @@
+<Ui::Breadcrumbs as |Crumb|>
+  <Crumb @text="My Projects" @route='projects' />
+  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb @text="Technical Memo" @disabled={{true}} />
+</Ui::Breadcrumbs>
+
+<Packages::TechnicalMemo::Show
+  @package={{@model}}
+/>
+
+{{outlet}}

--- a/client/tests/acceptance/user-can-edit-technical-memo-test.js
+++ b/client/tests/acceptance/user-can-edit-technical-memo-test.js
@@ -4,10 +4,18 @@ import {
   click,
   findAll,
   currentURL,
+  settled,
+  waitFor,
 } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import { selectFiles } from 'ember-file-upload/test-support';
+
+const saveForm = async () => {
+  await click('[data-test-save-button]');
+  await settled();
+};
 
 module('Acceptance | user can edit Technical Memo Packages', function (hooks) {
   setupApplicationTest(hooks);
@@ -80,5 +88,53 @@ module('Acceptance | user can edit Technical Memo Packages', function (hooks) {
     assert.dom('[data-test-package-notes]').containsText('Some instructions from Planners');
 
     assert.dom('[data-test-attached-documents]').exists();
+  });
+
+
+  test('User can submit Technical Memo and see Package info and Attached Documents section', async function (assert) {
+    this.server.create('project', {
+      packages: [
+        this.server.create('package', 'toDo', 'technicalMemo'),
+      ],
+    });
+
+    await visit('/technical-memo/1/edit');
+
+    const file = new File(['foo'], 'Zoning Application.pdf', { type: 'text/plain' });
+
+    await selectFiles('#FileUploader1 > input', file);
+
+    await assert.dom('[data-test-document-to-be-uploaded-name]').exists();
+
+    saveForm();
+
+    await waitFor('[data-test-document-name="0"');
+
+    await assert.dom('[data-test-document-to-be-uploaded-name]').doesNotExist();
+
+    await click('[data-test-submit-button]');
+
+    await click('[data-test-confirm-submit-button]');
+
+    await settled();
+
+    await waitFor('[data-test-project-dcpProjectname]');
+
+    assert.equal(currentURL(), '/technical-memo/1?header=true');
+
+    assert.dom('[data-test-attached-documents]').exists();
+  });
+
+  test('User sees Attached Documents on the Technical Memo Show page', async function (assert) {
+    this.server.create('project', {
+      packages: [
+        this.server.create('package', 'toDo', 'withExistingDocuments', 'technicalMemo'),
+      ],
+    });
+
+    await visit('/technical-memo/1');
+
+    assert.dom('[data-test-document-name="0"]').containsText('PAS Form.pdf');
+    assert.dom('[data-test-document-name="1"]').containsText('Action Changes.excel');
   });
 });


### PR DESCRIPTION
### Summary
Follows pattern of Draft EAS to set up the Tech Memo Submission and Show Page. Sets up the corresponding tests, as well.

#### Task/Bug Number
Fixes [AB#13056](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13056)
Fixes [AB#13064](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13064)
Contributes to [AB#13209](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13209)

