### PR TITLE
12489 Standby patch to remove hyphens from PackageId portion of Sharepoint folder names

### DIFF
--- a/server/src/document/document.controller.ts
+++ b/server/src/document/document.controller.ts
@@ -63,7 +63,7 @@ export class DocumentController {
     // from current and past revisions. When retrieving documents, we can then
     // only look up this one folder, instead of two separate folders (one for
     // previous revision documents and one for current revision documents).
-    const folderName = `${strippedPackageName}_${instanceId.toUpperCase()}`;
+    const folderName = `${strippedPackageName}_${instanceId.toUpperCase().replace(/-/g, '')}`;
 
     return this.documentService.uploadDocument('dcp_package',
       instanceId,

--- a/server/src/document/document.service.ts
+++ b/server/src/document/document.service.ts
@@ -288,7 +288,7 @@ async getParentSiteLocation() {
   async findPackageSharepointDocuments(packageName, id: string) {
     try {
       const strippedPackageName = packageName.replace(/-/g, '').replace(/\s+/g, '').replace(/'+/g, '').replace(/^\~|\#|\%|\&|\*|\{|\}|\\|\:|\<|\>|\?|\/|\||\"/g, '');
-      const folderIdentifier = `${strippedPackageName}_${id.toUpperCase()}`;
+      const folderIdentifier = `${strippedPackageName}_${id.toUpperCase().replace(/-/g, '')}`;
 
       const { value: documents } = await this.crmService.getSharepointFolderFiles(`dcp_package/${folderIdentifier}`);
 


### PR DESCRIPTION
### Summary 
The problem is that a recent CRM enhancement changed the format for Sharepoint Folder names, so it differed from the format Applicant Portal used. 

To match the new version used for **version 1** folder names, we remove hyphens from the Package Id component of the folder name.

**However, the second and subsequent versions have yet another different format. Unlike the first version, the Package Name portion removes underscores, and the Package ID section _includes_ Package IDs.**

**It is on CRM to fix this issue with second revisions.** 

#### Task/Bug Number
Potential fix for [AB#12489](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12489)


