### PR TITLE
12712: update  date fields on landuse-form to include  new date-picker component

### DIFF
--- a/client/app/components/packages/landuse-form/proposed-action-editor.hbs
+++ b/client/app/components/packages/landuse-form/proposed-action-editor.hbs
@@ -202,27 +202,35 @@
 
     {{#if this.projectHasRequiredActionsAndFollowUpYes}}
 
-      <Ui::Question as |dcpDateofpreviousapprovalQ|>
+      <Ui::Question
+      as |dcpDateofpreviousapprovalQ|>
         <dcpDateofpreviousapprovalQ.Label>
           Date of previous approval
         </dcpDateofpreviousapprovalQ.Label>
 
-        <landuseActionForm.Field
-          @attribute="dcpDateofpreviousapproval"
-          type="date"
-          id={{dcpDateofpreviousapprovalQ.questionId}}
+        <EmberFlatpickr
+          data-test-dcpdateofpreviousapproval
+          @allowInput={{false}}
+          @date={{if landuseActionForm.data.dcpDateofpreviousapproval landuseActionForm.data.dcpDateofpreviousapproval null}}
+          @onChange={{fn (mut landuseActionForm.data.dcpDateofpreviousapproval)}}
+          @enableTime={{false}}
+          placeholder="Choose a date..."
         />
       </Ui::Question>
 
-      <Ui::Question as |dcpLapsedateofpreviousapprovalQ|>
+      <Ui::Question
+      as |dcpLapsedateofpreviousapprovalQ|>
         <dcpLapsedateofpreviousapprovalQ.Label>
           Lapse date of previous approval
         </dcpLapsedateofpreviousapprovalQ.Label>
 
-        <landuseActionForm.Field
-          @attribute="dcpLapsedateofpreviousapproval"
-          type="date"
-          id={{dcpLapsedateofpreviousapprovalQ.questionId}}
+        <EmberFlatpickr
+          data-test-dcplapsedateofpreviousapproval
+          @allowInput={{false}}
+          @date={{if landuseActionForm.data.dcpLapsedateofpreviousapproval landuseActionForm.data.dcpLapsedateofpreviousapproval null}}
+          @onChange={{fn (mut landuseActionForm.data.dcpLapsedateofpreviousapproval)}}
+          @enableTime={{false}}
+          placeholder="Choose a date..."
         />
       </Ui::Question>
 
@@ -291,15 +299,19 @@
         />
       </Ui::Question>
 
-      <Ui::Question as |dcpRecordationdateQ|>
+      <Ui::Question
+      as |dcpRecordationdateQ|>
         <dcpRecordationdateQ.Label>
           Recordation date of Legal Instrument
         </dcpRecordationdateQ.Label>
 
-        <landuseActionForm.Field
-          @attribute="dcpRecordationdate"
-          type="date"
-          id={{dcpRecordationdateQ.questionId}}
+        <EmberFlatpickr
+          data-test-dcprecordationdate
+          @allowInput={{false}}
+          @date={{if landuseActionForm.data.dcpRecordationdate landuseActionForm.data.dcpRecordationdate null}}
+          @onChange={{fn (mut landuseActionForm.data.dcpRecordationdate)}}
+          @enableTime={{false}}
+          placeholder="Choose a date..."
         />
       </Ui::Question>
 

--- a/client/app/components/packages/related-action-fieldset.hbs
+++ b/client/app/components/packages/related-action-fieldset.hbs
@@ -84,9 +84,13 @@
         Date
       </dcpApplicationdateQ.Label>
 
-      <form.Field
-        @attribute="dcpApplicationdate"
-        type="date"
+      <EmberFlatpickr
+        data-test-dcpapplicationdate
+        @allowInput={{false}}
+        @date={{if form.data.dcpApplicationdate form.data.dcpApplicationdate null}}
+        @onChange={{fn (mut form.data.dcpApplicationdate)}}
+        @enableTime={{false}}
+        placeholder="Choose a date..."
       />
     </Ui::Question>
 

--- a/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
@@ -11,6 +11,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { selectChoose } from 'ember-power-select/test-support';
+import { setFlatpickrDate } from 'ember-flatpickr/test-support/helpers';
 import exceedMaximum from '../helpers/exceed-maximum-characters';
 
 const saveForm = async () => {
@@ -283,11 +284,15 @@ module('Acceptance | user can click landuse form edit', function (hooks) {
     await fillIn('[data-test-input="dcpApplicationdescription"]', 'applicant description');
     await fillIn('[data-test-input="dcpDispositionorstatus"]', 'disposition or status');
     await fillIn('[data-test-input="dcpCalendarnumbercalendarnumber"]', 'calendar number');
-    await fillIn('[data-test-input="dcpApplicationdate"]', 'application date');
+
+    const applicationDate = new Date(2020, 0, 1);
+    setFlatpickrDate('[data-test-dcpapplicationdate]', applicationDate);
+
     await click('[data-test-save-button]');
 
     assert.equal(this.server.db.applicants.firstObject.dcpFirstname, 'Tess');
     assert.equal(this.server.db.relatedActions.firstObject.dcpReferenceapplicationno, '12345678');
+    assert.ok(this.server.db.relatedActions.firstObject.dcpApplicationdate[0].includes('2020-01-01'));
   });
 
   test('User can fill out and save Housing Plans section', async function (assert) {
@@ -595,6 +600,9 @@ module('Acceptance | user can click landuse form edit', function (hooks) {
     await click('[data-test-radio="dcpApplicantispublicagencyactions"][data-test-action="ZC"][data-test-radio-option="Yes"]');
     await click('[data-test-radio="dcpApplicantispublicagencyactions"][data-test-action="ZA"][data-test-radio-option="No"]');
 
+    const recordationDate = new Date(2020, 0, 1);
+    setFlatpickrDate('[data-test-dcprecordationdate]', recordationDate);
+
     await click('[data-test-save-button]');
 
     assert.equal(this.server.db.landuseForms.firstObject.dcpLegalinstrument, 717170000);
@@ -608,6 +616,7 @@ module('Acceptance | user can click landuse form edit', function (hooks) {
     assert.equal(this.server.db.landuseActions[1].dcpPreviouslyapprovedactioncode, 717170013);
     assert.equal(this.server.db.landuseActions[0].dcpApplicantispublicagencyactions, true);
     assert.equal(this.server.db.landuseActions[1].dcpApplicantispublicagencyactions, false);
+    assert.ok(this.server.db.landuseActions.firstObject.dcpRecordationdate[0].includes('2020-01-01'));
 
     assert.equal(currentURL(), '/landuse-form/1/edit');
   });
@@ -1244,11 +1253,11 @@ module('Acceptance | user can click landuse form edit', function (hooks) {
 
     await visit('/landuse-form/1/edit');
 
-    assert.dom('[data-test-input="dcpDateofpreviousapproval"]').doesNotExist();
+    assert.dom('[data-test-dcpdateofpreviousapproval').doesNotExist();
 
     await selectChoose('[data-test-dcpPreviouslyapprovedactioncode-picker="ZC"]', 'BF');
 
-    assert.dom('[data-test-input="dcpDateofpreviousapproval"]').exists();
+    assert.dom('[data-test-dcpdateofpreviousapproval').exists();
 
     assert.equal(currentURL(), '/landuse-form/1/edit');
   });

--- a/server/src/json-api-deserialize.pipe.ts
+++ b/server/src/json-api-deserialize.pipe.ts
@@ -52,6 +52,9 @@ export class JsonApiDeserializePipe implements PipeTransform {
         'zoning-map-changes': {
           valueForRelationship: relationship => relationship.id,
         },
+        'landuse-actions': {
+          valueForRelationship: relationship => relationship.id,
+        },
         'zoning-resolutions': {
           valueForRelationship: relationship => relationship.id,
         },

--- a/server/src/packages/landuse-form/landuse-actions/landuse-actions.attrs.ts
+++ b/server/src/packages/landuse-form/landuse-actions/landuse-actions.attrs.ts
@@ -13,12 +13,9 @@ export const LANDUSE_ACTION_ATTRS = [
   'dcp_istheactiontoauthorizeorpermitanopenuse',
   'dcp_istheactiontoauthorizeacommercial',
   'dcp_followuptopreviousaction',
-  'dcp_dateofpreviousapproval',
-  'dcp_lapsedateofpreviousapproval',
   'dcp_typeoflegalinstrument',
   'dcp_modsubjectto197c',
   'dcp_indicatewhetheractionisamodification',
   'dcp_crfnnumber',
-  'dcp_recordationdate',
   '_dcp_landuseid_value',
 ];

--- a/server/src/packages/landuse-form/landuse-actions/landuse-actions.controller.ts
+++ b/server/src/packages/landuse-form/landuse-actions/landuse-actions.controller.ts
@@ -29,16 +29,35 @@ export class LanduseActionsController {
   @Patch('/:id')
   async update(@Body() body, @Param('id') id) {
     const allowedAttrs = pick(body, LANDUSE_ACTION_ATTRS);
+    const dateOfPreviousApproval = this.pickDate(body.dcp_dateofpreviousapproval);
+    const lapseDateOfPreviousApproval = this.pickDate(body.dcp_lapsedateofpreviousapproval);
+    const recordationDate = this.pickDate(body.dcp_recordationdate);
 
     await this.crmService.update('dcp_landuseactions', id, {
       ...allowedAttrs,
 
       ...(body.chosen_zoning_resolution_id ? { 'dcp_zoningresolutionsectionactionispursuantto@odata.bind': `/dcp_zoningresolutions(${body.chosen_zoning_resolution_id})` } : {}),
+      dcp_dateofpreviousapproval: dateOfPreviousApproval,
+      dcp_lapsedateofpreviousapproval: lapseDateOfPreviousApproval,
+      dcp_recordationdate: recordationDate,
     });
 
     return {
       dcp_landuseactionid: id,
       allowedAttrs,
+    };
+  }
+
+  // when a user selects a date from the frontend date-picker, this value
+  // is sent to backend as a datestring in an array, so we need to grab
+  // the first item in that array. When the user does not use the date-picker,
+  // and instead the date value comes from CRM (still exists in the body), the
+  // date is just formatted as an isolated datestring and does not need to be reformatted.
+  pickDate(bodyDateField) {
+    if (bodyDateField) {
+      return Array.isArray(bodyDateField) ? bodyDateField[0] : bodyDateField;
+    } else {
+      return null;
     };
   }
 }

--- a/server/src/packages/landuse-form/landuse-form.service.ts
+++ b/server/src/packages/landuse-form/landuse-form.service.ts
@@ -39,7 +39,10 @@ export class LanduseFormService {
     `);
 
     const { records: landuseActionsWithZr } = await this.crmService.get(`dcp_landuseactions`, `
-      $select=${LANDUSE_ACTION_ATTRS.join(',')}
+      $select=${LANDUSE_ACTION_ATTRS.join(',')},
+      dcp_dateofpreviousapproval,
+      dcp_lapsedateofpreviousapproval,
+      dcp_recordationdate,
       &$filter=
         _dcp_landuseid_value eq ${id}
       &$expand=

--- a/server/src/packages/landuse-form/related-actions/related-actions.attrs.ts
+++ b/server/src/packages/landuse-form/related-actions/related-actions.attrs.ts
@@ -4,7 +4,6 @@ export const RELATED_ACTION_ATTRS = [
   'dcp_applicationdescription',
   'dcp_dispositionorstatus',
   'dcp_calendarnumbercalendarnumber',
-  'dcp_applicationdate',
   'dcp_landuseid_value',
   'dcp_landuseid'
 ];

--- a/server/src/packages/landuse-form/related-actions/related-actions.controller.ts
+++ b/server/src/packages/landuse-form/related-actions/related-actions.controller.ts
@@ -31,12 +31,14 @@ import {
     @Patch('/:id')
     async update(@Body() body, @Param('id') id) {
       const allowedAttrs = pick(body, RELATED_ACTION_ATTRS);
+
+      const applicationDate = this.pickDate(body.dcp_applicationdate);
   
-        await this.crmService.update(
-          'dcp_relatedactionses',
-          id,
-          allowedAttrs,
-        );
+      await this.crmService.update('dcp_relatedactionses', id, {
+        ...allowedAttrs,
+    
+        dcp_applicationdate: applicationDate,
+      });
   
       return {
         dcp_relatedactionsid: id,
@@ -47,9 +49,14 @@ import {
     @Post('/')
     create(@Body() body) {
       const allowedAttrs = pick(body, RELATED_ACTION_ATTRS);
+      // because this is a POST, the date field will either be
+      // null or derived from the datepicker (and not coming from crm)
+      // so we can assume if there's a date field that it's within an array
+      const applicationDate = body.dcp_applicationdate ? this.pickDate(body.dcp_applicationdate) : null;
 
       return this.crmService.create('dcp_relatedactionses', {
         ...allowedAttrs,
+        dcp_applicationdate: applicationDate,
         'dcp_landuseid@odata.bind': `/dcp_landuses(${body.landuse_form})`,
       });
     }
@@ -63,5 +70,17 @@ import {
         id,
       };
     }
+
+    // when a user selects a date from the frontend date-picker, this value
+    // is sent to backend as a datestring in an array, so we need to grab
+    // the first item in that array. When the user does not use the date-picker,
+    // and instead the date value comes from CRM (still exists in the body), the
+    // date is just formatted as an isolated datestring and does not need to be reformatted.
+    pickDate(bodyDateField) {
+      if (bodyDateField) {
+        return Array.isArray(bodyDateField) ? bodyDateField[0] : bodyDateField;
+      } else {
+        return null;
+      };
+    };
   }
-  

--- a/server/src/packages/packages.controller.ts
+++ b/server/src/packages/packages.controller.ts
@@ -140,6 +140,7 @@ import { CitypayService } from '../citypay/citypay.service';
       ref: 'dcp_relatedactionsid',
       attributes: [
         ...RELATED_ACTION_ATTRS,
+        'dcp_applicationdate',
       ],
     },
     'landuse-actions': {
@@ -148,6 +149,9 @@ import { CitypayService } from '../citypay/citypay.service';
         ...LANDUSE_ACTION_ATTRS,
 
         'zoning-resolution',
+        'dcp_dateofpreviousapproval',
+        'dcp_lapsedateofpreviousapproval',
+        'dcp_recordationdate',
       ],
       'zoning-resolution': {
         ref: 'dcp_zoningresolutionid',


### PR DESCRIPTION
**Summary**
Implement date-picker component on the Related Actions and Proposed Actions sections on the Land Use Form.

**Task/Bug Number**
[AB#12712](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12712)

**Technical Explanation**
- Implement Ember Flatpicker component throughout the landuse-form. All styling was previously addressed by Andy. 
- When the date value is sent to the backend, it shows up in the body formatted as a date-string within an array. Because of this I had to reformat the date in the related-actions.controller and landuse-actions.controller. Otherwise CRM will throw an error claiming that the date is formatted incorrectly.

**Open to suggestions on how to better go about this formatting issue!** 
