### PR TITLE
13266 Add SubmittablePackageValidation for DEAS, FEAS, DEIS, FEIS, Tech Memo, DSOW

### DIFF
--- a/client/app/components/packages/deis/attached-documents.hbs
+++ b/client/app/components/packages/deis/attached-documents.hbs
@@ -9,7 +9,7 @@
   </p>
 
   <Packages::Attachments
-    @package={{@model}}
+    @package={{@form.data}}
     @fileManager={{@model.fileManager}}
     data-test-section="attachments"
   />

--- a/client/app/components/packages/deis/edit.hbs
+++ b/client/app/components/packages/deis/edit.hbs
@@ -1,6 +1,6 @@
 <SaveableForm 
   @model={{@package}} 
-  @validators={{array (hash) (hash)}} 
+  @validators={{array (hash) this.validations.SubmittablePackageFormValidations}}
   as |saveableForm|
 >
 

--- a/client/app/components/packages/deis/edit.js
+++ b/client/app/components/packages/deis/edit.js
@@ -1,8 +1,13 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import SubmittablePackageFormValidations from '../../../validations/submittable-package';
 
 export default class PackagesDeisEditComponent extends Component {
+  validations = {
+    SubmittablePackageFormValidations,
+  };
+
   @service
   router;
 

--- a/client/app/components/packages/draft-eas/attached-documents.hbs
+++ b/client/app/components/packages/draft-eas/attached-documents.hbs
@@ -30,7 +30,7 @@
   </ul>
 
   <Packages::Attachments
-    @package={{@model}}
+    @package={{@form.data}}
     @fileManager={{@model.fileManager}}
     data-test-section="attachments"
   />

--- a/client/app/components/packages/draft-eas/edit.hbs
+++ b/client/app/components/packages/draft-eas/edit.hbs
@@ -1,6 +1,6 @@
 <SaveableForm
   @model={{@package}}
-  @validators={{array (hash) (hash)}}
+  @validators={{array (hash) this.validations.SubmittablePackageFormValidations}}
   as |saveableForm|
 >
   <div class="grid-x grid-margin-x">

--- a/client/app/components/packages/draft-eas/edit.js
+++ b/client/app/components/packages/draft-eas/edit.js
@@ -1,8 +1,13 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import SubmittablePackageFormValidations from '../../../validations/submittable-package';
 
 export default class PackagesDraftEasEditComponent extends Component {
+  validations = {
+    SubmittablePackageFormValidations,
+  };
+
   @service
   router;
 

--- a/client/app/components/packages/feis/attached-documents.hbs
+++ b/client/app/components/packages/feis/attached-documents.hbs
@@ -8,7 +8,7 @@
   </p>
 
   <Packages::Attachments 
-    @package={{@model}} 
+    @package={{@form.data}} 
     @fileManager={{@model.fileManager}} 
     data-test-section="attachments" 
   />

--- a/client/app/components/packages/feis/edit.hbs
+++ b/client/app/components/packages/feis/edit.hbs
@@ -1,6 +1,6 @@
 <SaveableForm
   @model={{@package}}
-  @validators={{array (hash) (hash)}}
+  @validators={{array (hash) this.validations.SubmittablePackageFormValidations}}
   as |saveableForm|
 >
 

--- a/client/app/components/packages/feis/edit.js
+++ b/client/app/components/packages/feis/edit.js
@@ -1,8 +1,13 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import SubmittablePackageFormValidations from '../../../validations/submittable-package';
 
 export default class PackagesFeisEditComponent extends Component {
+  validations = {
+    SubmittablePackageFormValidations,
+  };
+
   @service
   router;
 

--- a/client/app/components/packages/filed-eas/attached-documents.hbs
+++ b/client/app/components/packages/filed-eas/attached-documents.hbs
@@ -41,7 +41,7 @@
     </ul>
 
     <Packages::Attachments
-      @package={{@model}}
+      @package={{@form.data}}
       @fileManager={{@model.fileManager}}
       data-test-section="attachments"
     />

--- a/client/app/components/packages/filed-eas/edit.hbs
+++ b/client/app/components/packages/filed-eas/edit.hbs
@@ -1,6 +1,6 @@
 <SaveableForm
   @model={{@package}}
-  @validators={{array (hash) (hash)}}
+  @validators={{array (hash) this.validations.SubmittablePackageFormValidations}}
   as |saveableForm|
 >
 

--- a/client/app/components/packages/filed-eas/edit.js
+++ b/client/app/components/packages/filed-eas/edit.js
@@ -1,8 +1,13 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import SubmittablePackageFormValidations from '../../../validations/submittable-package';
 
 export default class PackagesFiledEasEditComponent extends Component {
+  validations = {
+    SubmittablePackageFormValidations,
+  };
+
   @service
   router;
 

--- a/client/app/components/packages/scope-of-work-draft/attached-documents.hbs
+++ b/client/app/components/packages/scope-of-work-draft/attached-documents.hbs
@@ -38,7 +38,7 @@
   </ul>
 
   <Packages::Attachments
-    @package={{@model}}
+    @package={{@form.data}}
     @fileManager={{@model.fileManager}}
     data-test-section="attachments"
   />

--- a/client/app/components/packages/scope-of-work-draft/edit.hbs
+++ b/client/app/components/packages/scope-of-work-draft/edit.hbs
@@ -1,6 +1,6 @@
 <SaveableForm 
   @model={{@package}} 
-  @validators={{array (hash) (hash)}} 
+  @validators={{array (hash) this.validations.SubmittablePackageFormValidations}}
   as |saveableForm|
 >
 

--- a/client/app/components/packages/scope-of-work-draft/edit.js
+++ b/client/app/components/packages/scope-of-work-draft/edit.js
@@ -1,8 +1,13 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import SubmittablePackageFormValidations from '../../../validations/submittable-package';
 
 export default class PackagesScopeOfWorkDraftEditComponent extends Component {
+  validations = {
+    SubmittablePackageFormValidations,
+  };
+
   @service
   router;
 

--- a/client/app/components/packages/technical-memo/attached-documents.hbs
+++ b/client/app/components/packages/technical-memo/attached-documents.hbs
@@ -3,7 +3,7 @@
   data-test-attached-documents
 >
   <Packages::Attachments
-    @package={{@model}}
+    @package={{@form.data}}
     @fileManager={{@model.fileManager}}
     data-test-section="attachments"
   />

--- a/client/app/components/packages/technical-memo/edit.hbs
+++ b/client/app/components/packages/technical-memo/edit.hbs
@@ -1,6 +1,6 @@
 <SaveableForm
   @model={{@package}}
-  @validators={{array (hash) (hash)}}
+  @validators={{array (hash) this.validations.SubmittablePackageFormValidations}}
   as |saveableForm|
 >
   <div class="grid-x grid-margin-x">

--- a/client/app/components/packages/technical-memo/edit.js
+++ b/client/app/components/packages/technical-memo/edit.js
@@ -1,8 +1,13 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import SubmittablePackageFormValidations from '../../../validations/submittable-package';
 
 export default class PackagesTechnicalMemoEditComponent extends Component {
+  validations = {
+    SubmittablePackageFormValidations,
+  };
+
   @service
   router;
 


### PR DESCRIPTION
### Summary
I incorrectly (showed @CeciliaCY how to) set up the Attachments section for the Draft EAS, Filed EAS, DEIS, FEIS, Tech Memo and DSOW sections. I needed to add a Submittable Package Validation to ensure that users upload at least one document before they can submit.  As shown in PR #836 

#### Task/Bug Number
Fixes [AB#13266](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13266)
