### PR TITLE
Activate "Project" crumb for Edit and Show pages

### DIFF
--- a/client/app/components/ui/breadcrumbs-item.hbs
+++ b/client/app/components/ui/breadcrumbs-item.hbs
@@ -3,9 +3,18 @@
     <span class="show-for-sr">Current:</span>
   {{/if}}
   {{#if @route}}
-    <LinkTo @route={{@route}}>
-      {{@text}}
-    </LinkTo>
+    {{#if @model}}
+      <LinkTo
+        @route={{@route}}
+        @model={{@model}}
+      >
+        {{@text}}
+      </LinkTo>
+    {{else}}
+      <LinkTo @route={{@route}}>
+        {{@text}}
+      </LinkTo>
+    {{/if}}
   {{else}}
     {{@text}}
   {{/if}}

--- a/client/app/templates/deis/edit.hbs
+++ b/client/app/templates/deis/edit.hbs
@@ -1,6 +1,10 @@
 <Ui::Breadcrumbs as |Crumb|>
   <Crumb @text="My Projects" @route='projects' />
-  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb
+    @text={{@model.project.dcpProjectname}}
+    @route='project'
+    @model={{@model.project.id}}
+  />
   <Crumb @text="DEIS" @disabled={{true}} />
   <Crumb @text="Edit" @current={{true}} />
 </Ui::Breadcrumbs>

--- a/client/app/templates/deis/show.hbs
+++ b/client/app/templates/deis/show.hbs
@@ -1,6 +1,10 @@
 <Ui::Breadcrumbs as |Crumb|>
   <Crumb @text="My Projects" @route='projects' />
-  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb
+    @text={{@model.project.dcpProjectname}}
+    @route='project'
+    @model={{@model.project.id}}
+  />
   <Crumb @text="DEIS" @disabled={{true}} />
 </Ui::Breadcrumbs>
 

--- a/client/app/templates/draft-eas/edit.hbs
+++ b/client/app/templates/draft-eas/edit.hbs
@@ -1,6 +1,10 @@
 <Ui::Breadcrumbs as |Crumb|>
   <Crumb @text="My Projects" @route='projects' />
-  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb
+    @text={{@model.project.dcpProjectname}}
+    @route='project'
+    @model={{@model.project.id}}
+  />
   <Crumb @text="Draft EAS" @disabled={{true}} />
   <Crumb @text="Edit" @current={{true}} />
 </Ui::Breadcrumbs>

--- a/client/app/templates/draft-eas/show.hbs
+++ b/client/app/templates/draft-eas/show.hbs
@@ -1,6 +1,10 @@
 <Ui::Breadcrumbs as |Crumb|>
   <Crumb @text="My Projects" @route='projects' />
-  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb
+    @text={{@model.project.dcpProjectname}}
+    @route='project'
+    @model={{@model.project.id}}
+  />
   <Crumb @text="Draft EAS" @disabled={{true}} />
 </Ui::Breadcrumbs>
 

--- a/client/app/templates/feis/edit.hbs
+++ b/client/app/templates/feis/edit.hbs
@@ -1,6 +1,10 @@
 <Ui::Breadcrumbs as |Crumb|>
   <Crumb @text="My Projects" @route='projects' />
-  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb
+    @text={{@model.project.dcpProjectname}}
+    @route='project'
+    @model={{@model.project.id}}
+  />
   <Crumb @text="FEIS" @disabled={{true}} />
   <Crumb @text="Edit" @current={{true}} />
 </Ui::Breadcrumbs>

--- a/client/app/templates/feis/show.hbs
+++ b/client/app/templates/feis/show.hbs
@@ -1,6 +1,10 @@
 <Ui::Breadcrumbs as |Crumb|>
   <Crumb @text="My Projects" @route='projects' />
-  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb
+    @text={{@model.project.dcpProjectname}}
+    @route='project'
+    @model={{@model.project.id}}
+  />
   <Crumb @text="FEIS" @disabled={{true}} />
 </Ui::Breadcrumbs>
 

--- a/client/app/templates/filed-eas/edit.hbs
+++ b/client/app/templates/filed-eas/edit.hbs
@@ -1,6 +1,10 @@
 <Ui::Breadcrumbs as |Crumb|>
   <Crumb @text="My Projects" @route='projects' />
-  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb
+    @text={{@model.project.dcpProjectname}}
+    @route='project'
+    @model={{@model.project.id}}
+  />
   <Crumb @text="Filed EAS" @disabled={{true}} />
   <Crumb @text="Edit" @current={{true}} />
 </Ui::Breadcrumbs>

--- a/client/app/templates/filed-eas/show.hbs
+++ b/client/app/templates/filed-eas/show.hbs
@@ -1,6 +1,10 @@
 <Ui::Breadcrumbs as |Crumb|>
   <Crumb @text="My Projects" @route='projects' />
-  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb
+    @text={{@model.project.dcpProjectname}}
+    @route='project'
+    @model={{@model.project.id}}
+  />
   <Crumb @text="Filed EAS" @disabled={{true}} />
 </Ui::Breadcrumbs>
 

--- a/client/app/templates/landuse-form/edit.hbs
+++ b/client/app/templates/landuse-form/edit.hbs
@@ -1,6 +1,10 @@
 <Ui::Breadcrumbs as |Crumb|>
   <Crumb @text="My Projects" @route='projects' />
-  <Crumb @text={{@model.package.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb
+    @text={{@model.package.project.dcpProjectname}}
+    @route='project'
+    @model={{@model.package.project.id}}
+  />
   <Crumb @text="{{if (eq @model.package.dcpPackagetype
       (optionset 'package' 'dcpPackagetype' 'code' 'DRAFT_LU_PACKAGE'))
       "Draft" "Filed"

--- a/client/app/templates/landuse-form/show.hbs
+++ b/client/app/templates/landuse-form/show.hbs
@@ -1,6 +1,10 @@
 <Ui::Breadcrumbs as |Crumb|>
   <Crumb @text="My Projects" @route='projects' />
-  <Crumb @text={{@model.package.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb
+    @text={{@model.package.project.dcpProjectname}}
+    @route='project'
+    @model={{@model.package.project.id}}
+  />
   <Crumb @text="{{if (eq @model.package.dcpPackagetype
       (optionset 'package' 'dcpPackagetype' 'code' 'DRAFT_LU_PACKAGE'))
       "Draft" "Filed"

--- a/client/app/templates/pas-form/edit.hbs
+++ b/client/app/templates/pas-form/edit.hbs
@@ -1,6 +1,10 @@
 <Ui::Breadcrumbs as |Crumb|>
   <Crumb @text="My Projects" @route='projects' />
-  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb
+    @text={{@model.project.dcpProjectname}}
+    @route='project'
+    @model={{@model.project.id}}
+  />
   <Crumb @text="PAS" @disabled={{true}} />
   <Crumb @text="Edit" @current={{true}} />
 </Ui::Breadcrumbs>

--- a/client/app/templates/pas-form/show.hbs
+++ b/client/app/templates/pas-form/show.hbs
@@ -1,6 +1,10 @@
 <Ui::Breadcrumbs as |Crumb|>
   <Crumb @text="My Projects" @route='projects' />
-  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb
+    @text={{@model.project.dcpProjectname}}
+    @route='project'
+    @model={{@model.project.id}}
+  />
   <Crumb @text="PAS" @current={{true}} />
 </Ui::Breadcrumbs>
 

--- a/client/app/templates/rwcds-form/edit.hbs
+++ b/client/app/templates/rwcds-form/edit.hbs
@@ -1,6 +1,10 @@
 <Ui::Breadcrumbs as |Crumb|>
   <Crumb @text="My Projects" @route='projects' />
-  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb
+    @text={{@model.project.dcpProjectname}}
+    @route='project'
+    @model={{@model.project.id}}
+  />
   <Crumb @text="RWCDS" @disabled={{true}} />
   <Crumb @text="Edit" @current={{true}} />
 </Ui::Breadcrumbs>

--- a/client/app/templates/rwcds-form/show.hbs
+++ b/client/app/templates/rwcds-form/show.hbs
@@ -1,6 +1,10 @@
 <Ui::Breadcrumbs as |Crumb|>
   <Crumb @text="My Projects" @route='projects' />
-  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb
+    @text={{@model.project.dcpProjectname}}
+    @route='project'
+    @model={{@model.project.id}}
+  />
   <Crumb @text="RWCDS" @current={{true}} />
 </Ui::Breadcrumbs>
 

--- a/client/app/templates/scope-of-work-draft/edit.hbs
+++ b/client/app/templates/scope-of-work-draft/edit.hbs
@@ -1,6 +1,10 @@
 <Ui::Breadcrumbs as |Crumb|>
   <Crumb @text="My Projects" @route='projects' />
-  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb
+    @text={{@model.project.dcpProjectname}}
+    @route='project'
+    @model={{@model.project.id}}
+  />
   <Crumb @text="Draft Scope of Work" @disabled={{true}} />
   <Crumb @text="Edit" @current={{true}} />
 </Ui::Breadcrumbs>

--- a/client/app/templates/scope-of-work-draft/show.hbs
+++ b/client/app/templates/scope-of-work-draft/show.hbs
@@ -1,6 +1,10 @@
 <Ui::Breadcrumbs as |Crumb|>
   <Crumb @text="My Projects" @route='projects' />
-  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb
+    @text={{@model.project.dcpProjectname}}
+    @route='project'
+    @model={{@model.project.id}}
+  />
   <Crumb @text="Draft Scope of Work" @disabled={{true}} />
 </Ui::Breadcrumbs>
 

--- a/client/app/templates/technical-memo/edit.hbs
+++ b/client/app/templates/technical-memo/edit.hbs
@@ -1,6 +1,10 @@
 <Ui::Breadcrumbs as |Crumb|>
   <Crumb @text="My Projects" @route='projects' />
-  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb
+    @text={{@model.project.dcpProjectname}}
+    @route='project'
+    @model={{@model.project.id}}
+  />
   <Crumb @text="Technical Memo" @disabled={{true}} />
   <Crumb @text="Edit" @current={{true}} />
 </Ui::Breadcrumbs>

--- a/client/app/templates/technical-memo/show.hbs
+++ b/client/app/templates/technical-memo/show.hbs
@@ -1,6 +1,10 @@
 <Ui::Breadcrumbs as |Crumb|>
   <Crumb @text="My Projects" @route='projects' />
-  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb
+    @text={{@model.project.dcpProjectname}}
+    @route='project'
+    @model={{@model.project.id}}
+  />
   <Crumb @text="Technical Memo" @disabled={{true}} />
 </Ui::Breadcrumbs>
 

--- a/client/app/templates/working-package/edit.hbs
+++ b/client/app/templates/working-package/edit.hbs
@@ -1,6 +1,10 @@
 <Ui::Breadcrumbs as |Crumb|>
   <Crumb @text="My Projects" @route='projects' />
-  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb
+    @text={{@model.project.dcpProjectname}}
+    @route='project'
+    @model={{@model.project.id}}
+  />
   <Crumb @text="Working Package" @disabled={{true}} />
   <Crumb @text="Edit" @current={{true}} />
 </Ui::Breadcrumbs>

--- a/client/app/templates/working-package/show.hbs
+++ b/client/app/templates/working-package/show.hbs
@@ -1,6 +1,10 @@
 <Ui::Breadcrumbs as |Crumb|>
   <Crumb @text="My Projects" @route='projects' />
-  <Crumb @text={{@model.project.dcpProjectname}} @disabled={{true}} />
+  <Crumb
+    @text={{@model.project.dcpProjectname}}
+    @route='project'
+    @model={{@model.project.id}}
+  />
   <Crumb @text="Working Package" @current={{true}} />
 </Ui::Breadcrumbs>
 


### PR DESCRIPTION
### Summary
This PR activates the "Project" crumb for Edit and Show pages
![image](https://user-images.githubusercontent.com/3311663/98177918-7f139800-1eb0-11eb-95b6-90701dd0bb10.png)

Previously, on the Edit or Show page, the breadcrumb for the individual project page was deactivated. This meant that to navigate back up to the Project page, using the application navigation someone had to first return to My Projects and then click the concerned project. This was inconvenient especially if the user directly loads a package (pasting into the browser a Package url like `/rwcds-form/12341234/edit`), since then the back button isn't available.

This change gets rid of an annoyance and helps speed up development time a bit :) 

#### Task/Bug Number
Fixes [AB#13297](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13297)

