### PR TITLE
13282 Addressing Confirmation prompt saying Draft LU instead of Filed LU

### DIFF
--- a/client/app/components/packages/landuse-form/edit.hbs
+++ b/client/app/components/packages/landuse-form/edit.hbs
@@ -164,7 +164,9 @@
         @continueButtonTitle="Continue Editing"
         data-test-confirm-submit-button={{true}}
       >
-        <h6>Confirm Draft Land Use Form Submission</h6>
+        <h6>Confirm {{if (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' 'DRAFT_LU_PACKAGE'))
+            "Draft" "Filed"
+          }} Land Use Form Submission</h6>
         <p class="header-large medium-margin-top small-margin-bottom">
           Are you sure?
         </p>


### PR DESCRIPTION
### Summary
13282 Addressing Confirmation prompt saying Draft LU instead of Filed LU

#### Task/Bug Number
Fixes AB#[13282](https://dcp-paperless.visualstudio.com/ZAP%20Portals/_workitems/edit/13282)

### Technical Explanation
Add if condition to show draft and file depending on dcpPackagetype
