### PR TITLE
13238 Saturate Project Packages with Documents

### DIFF
--- a/server/src/projects/projects.controller.ts
+++ b/server/src/projects/projects.controller.ts
@@ -43,6 +43,7 @@ import { INVOICE_ATTRS } from '../invoices/invoices.attrs';
       ...PACKAGE_ATTRS,
 
       'invoices',
+      'documents',
     ],
     invoices: {
       ref: 'dcp_projectinvoiceid',

--- a/server/src/projects/projects.module.ts
+++ b/server/src/projects/projects.module.ts
@@ -6,14 +6,15 @@ import { ConfigModule } from '../config/config.module';
 import { AuthModule } from '../auth/auth.module';
 import { ProjectsController } from './projects.controller';
 import { ProjectApplicantController } from './project-applicants/project-applicant.controller';
-import { NycidService } from 'src/contact/nycid/nycid.service';
+import { DocumentModule } from '../document/document.module';
 
 @Module({
   imports: [
+    AuthModule,
     CrmModule,
     ConfigModule,
     ContactModule,
-    AuthModule,
+    DocumentModule,
   ],
   providers: [ProjectsService],
   exports: [ProjectsService],


### PR DESCRIPTION
### Summary
This PR makes sure that when a user visits the individual Project page, the sideloaded Packages will have a `documents` property that is hydrated with associated documents. 
![image](https://user-images.githubusercontent.com/3311663/98424419-81a7f600-2046-11eb-9df5-0ea4900963a8.png)

This is in preparation to list out documents by package on the individual Project page.

This PR also unifies document saturation+munging code to the document service

#### Task/Bug Number
Fixes [AB#13238](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13238)

### Technical Explanation
  - Notice how `this.documentService.packageWithDocuments(<package>)` is now referenced in both the Packages and Projects services! The documents array creation is shared by both of those services, so it made sense to move it into one function inside the Document service. 