### PR TITLE
13201: add ceqr invoice questionnaire to draft scope of work package

### DIFF
--- a/client/app/components/packages/filed-eas/edit.hbs
+++ b/client/app/components/packages/filed-eas/edit.hbs
@@ -49,19 +49,21 @@
         </saveableForm.Section>
       {{/if}}
 
-      {{#let saveableForm.data.singleCeqrInvoiceQuestionnaire as |ceqrInvoiceQuestionnaire|}}
-        <saveableForm.Section @title="Ceqr Invoice Questionnaire">
-          <saveableForm.SaveableForm
-            @model={{ceqrInvoiceQuestionnaire}}
-            @validators={{array (hash) this.validations.SubmittableCeqrInvoiceQuestionnaireFormValidations}}
-            as |ceqrInvoiceQuestionnaireForm|
-          >
-            <Packages::FiledEas::CeqrInvoiceQuestionnaire
-              @form={{ceqrInvoiceQuestionnaireForm}}
-            />
-          </saveableForm.SaveableForm>
-        </saveableForm.Section>
-      {{/let}}
+      {{#if (gte saveableForm.data.ceqrInvoiceQuestionnaires.length 1)}}
+        {{#let saveableForm.data.singleCeqrInvoiceQuestionnaire as |ceqrInvoiceQuestionnaire|}}
+          <saveableForm.Section @title="Ceqr Invoice Questionnaire">
+            <saveableForm.SaveableForm
+              @model={{ceqrInvoiceQuestionnaire}}
+              @validators={{array (hash) this.validations.SubmittableCeqrInvoiceQuestionnaireFormValidations}}
+              as |ceqrInvoiceQuestionnaireForm|
+            >
+              <Packages::FiledEas::CeqrInvoiceQuestionnaire
+                @form={{ceqrInvoiceQuestionnaireForm}}
+              />
+            </saveableForm.SaveableForm>
+          </saveableForm.Section>
+        {{/let}}
+      {{/if}}
 
       <Packages::FiledEas::AttachedDocuments
         @form={{saveableForm}}

--- a/client/app/components/packages/scope-of-work-draft/edit.hbs
+++ b/client/app/components/packages/scope-of-work-draft/edit.hbs
@@ -45,6 +45,22 @@
         </saveableForm.Section>
       {{/if}}
 
+      {{#if (gte saveableForm.data.ceqrInvoiceQuestionnaires.length 1)}}
+        {{#let saveableForm.data.singleCeqrInvoiceQuestionnaire as |ceqrInvoiceQuestionnaire|}}
+          <saveableForm.Section @title="Ceqr Invoice Questionnaire">
+            <saveableForm.SaveableForm
+              @model={{ceqrInvoiceQuestionnaire}}
+              @validators={{array (hash) this.validations.SubmittableCeqrInvoiceQuestionnaireFormValidations}}
+              as |ceqrInvoiceQuestionnaireForm|
+            >
+              <Packages::FiledEas::CeqrInvoiceQuestionnaire
+                @form={{ceqrInvoiceQuestionnaireForm}}
+              />
+            </saveableForm.SaveableForm>
+          </saveableForm.Section>
+        {{/let}}
+      {{/if}}
+
       <Packages::ScopeOfWorkDraft::AttachedDocuments
         @form={{saveableForm}}
         @model={{@package}}

--- a/client/app/components/packages/scope-of-work-draft/edit.js
+++ b/client/app/components/packages/scope-of-work-draft/edit.js
@@ -2,10 +2,12 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import SubmittablePackageFormValidations from '../../../validations/submittable-package';
+import SubmittableCeqrInvoiceQuestionnaireFormValidations from '../../../validations/submittable-ceqr-invoice-questionnaire-form';
 
 export default class PackagesScopeOfWorkDraftEditComponent extends Component {
   validations = {
     SubmittablePackageFormValidations,
+    SubmittableCeqrInvoiceQuestionnaireFormValidations,
   };
 
   @service

--- a/client/app/routes/scope-of-work-draft.js
+++ b/client/app/routes/scope-of-work-draft.js
@@ -7,7 +7,7 @@ export default class ScopeOfWorkDraftRoute extends Route.extend(AuthenticatedRou
   async model(params) {
     const scopeOfWorkDraftPackage = await this.store.findRecord('package', params.id, {
       reload: true,
-      include: 'project',
+      include: 'project,ceqrInvoiceQuestionnaires',
     });
 
     // manually generate a file factory

--- a/client/mirage/factories/package.js
+++ b/client/mirage/factories/package.js
@@ -89,6 +89,9 @@ export default Factory.extend({
 
   scopeOfWorkDraft: trait({
     dcpPackagetype: 717170008,
+    afterCreate(projectPackage, server) {
+      server.create('ceqr-invoice-questionnaire', { package: projectPackage });
+    },
   }),
 
   deis: trait({

--- a/client/tests/acceptance/user-can-edit-filed-eas-test.js
+++ b/client/tests/acceptance/user-can-edit-filed-eas-test.js
@@ -100,7 +100,7 @@ module('Acceptance | user can edit Filed EAS Packages', function (hooks) {
 
     await visit('/filed-eas/1/edit');
 
-    // filling out necessary fields for submit
+    // filling out necessary fields for submit, also tests ceqr-invoice-questionnaire
     await click('[data-test-radio="dcpIsthesoleaapplicantagovtagency"][data-test-radio-option="Yes"]');
 
     const file = new File(['foo'], 'Zoning Application.pdf', { type: 'text/plain' });

--- a/client/tests/acceptance/user-can-edit-scope-of-work-draft-test.js
+++ b/client/tests/acceptance/user-can-edit-scope-of-work-draft-test.js
@@ -99,6 +99,9 @@ module('Acceptance | user can edit Draft SOW Packages', function (hooks) {
 
     await visit('/scope-of-work-draft/1/edit');
 
+    // filling out necessary fields for submit, also tests ceqr-invoice-questionnaire
+    await click('[data-test-radio="dcpIsthesoleaapplicantagovtagency"][data-test-radio-option="Yes"]');
+
     const file = new File(['foo'], 'Zoning Application.pdf', { type: 'text/plain' });
 
     await selectFiles('#FileUploader1 > input', file);


### PR DESCRIPTION
**Summary**
Add Ceqr Invoice Questionnaire to the Draft Scope of Work Package

**Task/Bug Number**
Fixes [AB#13201](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13201)

**Technical Explanation**
ceqr-invoice-questionnaire component was already created in another PR, so this PR just renders the ceqr-invoice-questionnaire component on the scope-of-work-draft/edit.hbs component. This PR also adds conditional display logic for the Ceqr Invoice Questionnaire on both the Draft Scope of Work and Filed EAS packages. 
