### PR TITLE
Use correct attr names for entity; join in labels; iterate line items

### DIFF
--- a/client/app/models/invoice.js
+++ b/client/app/models/invoice.js
@@ -5,7 +5,7 @@ export default class InvoiceModel extends Model {
   dcpInvoicedate;
 
   @attr()
-  dcpProjectname;
+  dcpInvoiceprojectname;
 
   @attr()
   dcpName;
@@ -14,17 +14,17 @@ export default class InvoiceModel extends Model {
   dcpSubtotal;
 
   @attr()
-  dcpTwoHundredPercentRule;
+  dcpTwohundredpercentrule;
 
   @attr()
-  dcpProjectFees;
+  dcpProjectfees;
 
   @attr()
-  dcpSupplementalFee;
+  dcpSupplementalfee;
 
   @attr()
   dcpGrandtotal;
 
   @attr()
-  dcpInvoiceApplications;
+  lineitems;
 }

--- a/client/app/templates/invoice.hbs
+++ b/client/app/templates/invoice.hbs
@@ -14,7 +14,7 @@
   </p>
   <p class="cell medium-6">
     Project: <br class="show-for-medium">
-    <strong class="text-xlarge">{{@model.dcpProjectname}}</strong>
+    <strong class="text-xlarge">{{@model.dcpInvoiceprojectname}}</strong>
   </p>
 </div>
 
@@ -27,14 +27,13 @@
     </tr>
   </thead>
   <tbody>
-    {{#each @model.dcpInvoiceApplications as |dcpApplication|}}
-    <tr>
-      <td>{{dcpApplication.dcpApplicationNumber}}</td>
-      <td>{{dcpApplication.dcpAction}}</td>
-      <td class="text-right font-mono">{{dcpApplication.dcpFee}}</td>
-    </tr>
+    {{#each @model.lineitems as |lineitem|}}
+      <tr>
+        <td>{{lineitem.dcp-applicationnumber}}</td>
+        <td>{{lineitem.dcp-action}}</td>
+        <td class="text-right font-mono">{{lineitem.dcp-fee}}</td>
+      </tr>
     {{/each}}
-
 
     <tr>
       <td></td>
@@ -54,12 +53,12 @@
           </Ui::ExternalLink>
         </sup>
       </td>
-      <td class="text-right font-mono">{{@model.dcpTwoHundredPercentRule}}</td>
+      <td class="text-right font-mono">{{@model.dcpTwohundredpercentrule}}</td>
     </tr>
     <tr>
       <td></td>
       <td class="text-right text-weight-bold text-charcoal">Project Fees</td>
-      <td class="text-right font-mono">{{@model.dcpProjectFees}}</td>
+      <td class="text-right font-mono">{{@model.dcpProjectfees}}</td>
     </tr>
     <tr>
       <td></td>
@@ -72,12 +71,12 @@
           </Ui::ExternalLink>
         </sup>
       </td>
-      <td class="text-right font-mono">{{@model.dcpSupplementalFee}}</td>
+      <td class="text-right font-mono">{{@model.dcpSupplementalfee}}</td>
     </tr>
     <tr>
       <td></td>
       <td class="text-right text-weight-bold text-charcoal">Total Amount Due</td>
-      <td class="text-right font-mono text-weight-bold text-large">{{@model.dcpGrandTotal}}</td>
+      <td class="text-right font-mono text-weight-bold text-large">{{@model.dcpGrandtotal}}</td>
     </tr>
   </tbody>
 </table>

--- a/server/src/invoices/invoices.attrs.ts
+++ b/server/src/invoices/invoices.attrs.ts
@@ -1,11 +1,10 @@
 export const INVOICE_ATTRS = [
   'dcp_invoicedate',
-  'dcp_projectname',
+  'dcp_invoiceprojectname',
   'dcp_name',
   'dcp_subtotal',
-  'dcp_two_hundred_percent_rule',
-  'dcp_project_fees',
-  'dcp_supplemental_fee',
+  'dcp_twohundredpercentrule',
+  'dcp_projectfees',
+  'dcp_supplementalfee',
   'dcp_grandtotal',
-  'dcp_invoice_applications',
 ];

--- a/server/src/invoices/invoices.controller.ts
+++ b/server/src/invoices/invoices.controller.ts
@@ -7,6 +7,9 @@ import { INVOICE_ATTRS } from './invoices.attrs';
   id: 'dcp_projectinvoiceid',
   attributes: [
     ...INVOICE_ATTRS,
+
+    // virtual property — see the service. not serialized into a model for simplicity
+    'lineitems',
   ],
 }))
 @Controller('invoices')

--- a/server/src/invoices/invoices.service.ts
+++ b/server/src/invoices/invoices.service.ts
@@ -1,15 +1,22 @@
 import { Injectable } from '@nestjs/common';
 import { CrmService } from '../crm/crm.service';
+import { overwriteCodesWithLabels } from '../_utils/overwrite-codes-with-labels';
+import { INVOICE_ATTRS } from './invoices.attrs';
 
 @Injectable()
 export class InvoicesService {
   constructor(private readonly crmService: CrmService) {}
 
   async getInvoice(id) {
-    const { records: [invoice] } = await this.crmService.get('dcp_projectinvoices', `
+    const { records } = await this.crmService.get('dcp_projectinvoices', `
       $filter=dcp_projectinvoiceid eq ${id}
+      &$expand=dcp_dcp_projectinvoice_dcp_invoicelineitem_projectinvoice
     `);
+    const [invoice] = overwriteCodesWithLabels(records, INVOICE_ATTRS);
 
-    return invoice;
+    return {
+      lineitems: invoice.dcp_dcp_projectinvoice_dcp_invoicelineitem_projectinvoice,
+      ...invoice
+    };
   }
 }


### PR DESCRIPTION
### Summary
Fixes the issue by using the correct, "real" attribute names as they're named on the invoice entity.

Includes the line items of the invoice using an expand. Avoids using a model and simply provides a read-only array of line items. 

Applies the overwriteValuesWithLabels helper to get neater naming for each value.

#### Task/Bug Number
Fixes [AB#13298](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13298)
