### PR TITLE
Fix invoice filter logic; hide pay button when no invoices need payment

### DIFF
--- a/client/app/components/project/package-section.hbs
+++ b/client/app/components/project/package-section.hbs
@@ -20,21 +20,24 @@
           {{#if invoices}}
             <h4>Invoices</h4>
 
-            {{#each invoices as |invoice|}}
-              <Project::PackageSection::InvoiceInfo
-                @invoice={{invoice}}
-              />
-            {{/each}}
+            <ul>
+              {{#each invoices as |invoice|}}
+                <Project::PackageSection::InvoiceInfo
+                  @invoice={{invoice}}
+                />
+              {{/each}}
+            </ul>
 
-            <br/>
-            <br/>
-            <button
-              type="button"
-              class="secondary button"
-              {{on 'click' (fn this.beginPayment)}}
-            >
-              Pay
-            </button>
+            {{#if this.hasPayableInvoices}}
+              <br/>
+              <button
+                type="button"
+                class="secondary button"
+                {{on 'click' (fn this.beginPayment)}}
+              >
+                Pay
+              </button>
+            {{/if}}
 
             <Ui::GenericModal
               @show={{this.isPaying}}

--- a/client/app/components/project/package-section.js
+++ b/client/app/components/project/package-section.js
@@ -21,6 +21,16 @@ export default class ProjectPackageSectionComponent extends Component {
     return payablePackage;
   }
 
+  get invoices() {
+    return this.args.packages
+      .mapBy('invoices')
+      .reduce((acc, curr) => acc.concat(curr), []);
+  }
+
+  get hasPayableInvoices() {
+    return this.invoices.filter((invoice) => invoice.statuscode === 'Approved').length >= 1;
+  }
+
   @action
   async beginPayment() {
     this.isPaying = true;

--- a/client/app/components/project/package-section/invoice-info.hbs
+++ b/client/app/components/project/package-section/invoice-info.hbs
@@ -1,12 +1,19 @@
-<FaIcon @icon="shopping-cart" class="light-gray" />
-<LinkTo
-  @route="invoice"
-  @model={{@invoice}}
-  @query={{hash header=false}}
->
-  {{@invoice.dcpName}}
-</LinkTo>
+<li>
+  {{#if @invoice.isPaid}}
+    <FaIcon @icon="check" class="light-gray" />
+  {{else}}
+    <FaIcon @icon="shopping-cart" class="light-gray" />
+  {{/if}}
 
-<strong>${{@invoice.dcpGrandtotal}}</strong>
+  <LinkTo
+    @route="invoice"
+    @model={{@invoice}}
+    @query={{hash header=false}}
+  >
+    {{@invoice.dcpName}}
+  </LinkTo>
 
-<em>{{moment-format (utc @invoice.dcpInvoicedate) 'YYYY-MM-DD'}}</em>
+  <strong>{{@invoice.dcpGrandtotal}}</strong>
+
+  <em>{{moment-format (utc @invoice.dcpInvoicedate) 'YYYY-MM-DD'}}</em>
+</li>

--- a/client/app/models/invoice.js
+++ b/client/app/models/invoice.js
@@ -27,4 +27,11 @@ export default class InvoiceModel extends Model {
 
   @attr()
   lineitems;
+
+  @attr()
+  statuscode;
+
+  get isPaid() {
+    return this.statuscode === 'Paid';
+  }
 }

--- a/client/ember-cli-build.js
+++ b/client/ember-cli-build.js
@@ -16,7 +16,7 @@ module.exports = function(defaults) {
       sourcemap: false,
     },
     'ember-composable-helpers': {
-      only: ['toggle', 'map-by', 'reduce'],
+      only: ['toggle', 'map-by', 'reduce', 'includes'],
     },
   });
 

--- a/client/tests/integration/components/project/package-section/invoice-info-test.js
+++ b/client/tests/integration/components/project/package-section/invoice-info-test.js
@@ -16,8 +16,6 @@ module('Integration | Component | project/package-section/invoice-info', functio
       />
     `);
 
-    assert.equal(this.element.textContent.trim(), `$
-
-2020-10-27`);
+    assert.equal(this.element.textContent.trim(), '2020-10-27');
   });
 });

--- a/server/src/invoices/invoices.attrs.ts
+++ b/server/src/invoices/invoices.attrs.ts
@@ -7,4 +7,5 @@ export const INVOICE_ATTRS = [
   'dcp_projectfees',
   'dcp_supplementalfee',
   'dcp_grandtotal',
+  'statuscode',
 ];

--- a/server/src/invoices/invoices.service.ts
+++ b/server/src/invoices/invoices.service.ts
@@ -3,6 +3,10 @@ import { CrmService } from '../crm/crm.service';
 import { overwriteCodesWithLabels } from '../_utils/overwrite-codes-with-labels';
 import { INVOICE_ATTRS } from './invoices.attrs';
 
+export function joinLabels(records) {
+  return overwriteCodesWithLabels(records, INVOICE_ATTRS);
+}
+
 @Injectable()
 export class InvoicesService {
   constructor(private readonly crmService: CrmService) {}
@@ -12,7 +16,7 @@ export class InvoicesService {
       $filter=dcp_projectinvoiceid eq ${id}
       &$expand=dcp_dcp_projectinvoice_dcp_invoicelineitem_projectinvoice
     `);
-    const [invoice] = overwriteCodesWithLabels(records, INVOICE_ATTRS);
+    const [invoice] = joinLabels(records);
 
     return {
       lineitems: invoice.dcp_dcp_projectinvoice_dcp_invoicelineitem_projectinvoice,

--- a/server/src/projects/projects.service.ts
+++ b/server/src/projects/projects.service.ts
@@ -3,6 +3,7 @@ import {
   HttpException,
   HttpStatus,
 } from '@nestjs/common';
+import { joinLabels as joinInvoiceLabels } from '../invoices/invoices.service';
 import { NycidService } from '../contact/nycid/nycid.service';
 import { CrmService } from '../crm/crm.service';
 import { overwriteCodesWithLabels } from '../_utils/overwrite-codes-with-labels';
@@ -32,6 +33,7 @@ const DCP_PROJECTROLES = {
 const DCP_PROJECTINVOICE_CODES = {
   statuscode: {
     APPROVED: 2,
+    PAID: 717170000,
   },
 
   statecode: {
@@ -145,7 +147,8 @@ export class ProjectsService {
             or statuscode eq ${PACKAGE_STATUSCODE.REVIEWED_REVISION_REQUIRED}
           )
         &$expand=dcp_dcp_package_dcp_projectinvoice_package(
-          $filter=statuscode eq ${DCP_PROJECTINVOICE_CODES.statuscode.APPROVED} and statecode eq ${DCP_PROJECTINVOICE_CODES.statecode.ACTIVE}
+          $filter=statuscode eq ${DCP_PROJECTINVOICE_CODES.statuscode.APPROVED}
+            or statuscode eq ${DCP_PROJECTINVOICE_CODES.statuscode.PAID}
         )
       `);
 
@@ -186,7 +189,7 @@ export class ProjectsService {
         ...project,
         packages: projectPackages.map(pkg => ({
           ...pkg,
-          invoices: pkg.dcp_dcp_package_dcp_projectinvoice_package,
+          invoices: joinInvoiceLabels(pkg.dcp_dcp_package_dcp_projectinvoice_package),
         })),
         projectApplicants: project['project-applicants'],
         'project-applicants': projectApplicantsWithContacts,


### PR DESCRIPTION
Show checkmark icon when paid

### Summary
 - Modifies the filtering logic for invoices a little to allow for paid or approved invoices
 - include the statuscode attribute on invoices for icons and filtering
 - hide pay button when no payable invoices exist

#### Task/Bug Number
Fixes [AB#13299](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13299)
