### PR TITLE
13309 Add ability to clear LU form dropdowns

### DIFF
--- a/client/app/components/packages/applicant-fieldset.hbs
+++ b/client/app/components/packages/applicant-fieldset.hbs
@@ -84,7 +84,7 @@
         </label>
       </div>
 
-      <div class="cell auto medium-2">
+      <div class="cell auto medium-4">
         <label data-test-applicant-state-dropdown>
           State
           <PowerSelect
@@ -95,6 +95,7 @@
             @searchField="label"
             @options={{map-by 'code' (optionset 'applicant' 'dcpState' 'list')}}
             @onChange={{fn (mut @applicant.dcpState)}}
+            @allowClear={{true}}
           as |stateCode|>
             {{optionset 'applicant' 'dcpState' 'label' stateCode}}
           </PowerSelect>

--- a/client/app/components/packages/landuse-form/lead-agency.hbs
+++ b/client/app/components/packages/landuse-form/lead-agency.hbs
@@ -1,23 +1,37 @@
 {{#let @landuseForm as |landuseForm|}}
-  <div>
-    <h5 class="small-margin-bottom">
-      Who is the lead agency?
-    </h5>
+  <div class="grid-x">
+    <div class="cell small-12">
+      <h5 class="small-margin-bottom">
+        Who is the lead agency?
+      </h5>
 
-    <label data-test-lead-agency-picker>
-      <PowerSelect
-        triggerClass="lead-agency-dropdown"
-        supportsDataTestProperties={{true}}
-        @placeholder={{this.searchPlaceholder}}
-        @searchEnabled={{true}}
-        @options={{this.accountNames}}
-        @selected={{this.chosenAccountName}}
-        @onChange={{fn (mut this.chosenAccountName)}}
-        @onClose={{fn (mut landuseForm.data.chosenLeadAgencyId) this.chosenAccountId}}
-        as |accountName|
+      <label data-test-lead-agency-picker>
+        {{!-- REDO: Rework this powerselect to act on Models,
+        the "Ember" way. Remove use of chosenAccountName --}}
+        <PowerSelect
+          triggerClass="lead-agency-dropdown"
+          supportsDataTestProperties={{true}}
+          @placeholder="Search agencies..."
+          @searchEnabled={{true}}
+          @options={{this.accountNames}}
+          @selected={{this.chosenAccountName}}
+          @onChange={{fn (mut this.chosenAccountName)}}
+          @onClose={{fn (mut landuseForm.data.chosenLeadAgencyId) this.chosenAccountId}}
+          as |accountName|
+        >
+          {{accountName}}
+        </PowerSelect>
+      </label>
+    </div>
+
+    <div class="cell text-right">
+      <button
+        type="button"
+        class="dropdown-clear-btn-below"
+        {{on "click" (fn this.clearDropdown landuseForm.data)}}
       >
-        {{accountName}}
-      </PowerSelect>
-    </label>
+        Clear
+      </button>
+    </div>
   </div>
 {{/let}}

--- a/client/app/components/packages/landuse-form/lead-agency.js
+++ b/client/app/components/packages/landuse-form/lead-agency.js
@@ -1,8 +1,9 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class PackagesLanduseFormLeadAgencyComponent extends Component {
-  @tracked chosenAccountName;
+  @tracked chosenAccountName = this.args.landuseForm.data.leadAgency ? this.args.landuseForm.data.leadAgency.name : null;
 
   get accountNames() {
     if (this.args.accounts) {
@@ -10,14 +11,15 @@ export default class PackagesLanduseFormLeadAgencyComponent extends Component {
     } return [];
   }
 
-  get searchPlaceholder() {
-    if (this.args.landuseForm.data.leadAgency) {
-      return this.args.landuseForm.data.leadAgency.name;
-    } return 'Search agencies...';
-  }
-
   get chosenAccountId() {
     const account = this.args.accounts.find((account) => account.name === this.chosenAccountName);
-    return account.id;
+    return account ? account.id : null;
+  }
+
+  @action
+  clearDropdown(landuseFormData) {
+    this.chosenAccountName = null;
+    landuseFormData.chosenLeadAgencyId = null;
+    landuseFormData.leadAgency = null;
   }
 }

--- a/client/app/components/packages/landuse-form/proposed-action-editor.hbs
+++ b/client/app/components/packages/landuse-form/proposed-action-editor.hbs
@@ -178,26 +178,38 @@
 
     {{/if}}
 
-    <div>
-      <h5 class="small-margin-bottom">
-        If this is a follow-up Action, indicate the previously approved Action Code
-      </h5>
+    <div class="grid-x">
+      <div class="cell small-12">
+        <h5 class="small-margin-bottom">
+          If this is a follow-up Action, indicate the previously approved Action Code
+        </h5>
 
-      <label data-test-dcpPreviouslyapprovedactioncode-picker="{{landuseActionForm.data.dcpActioncode}}">
-        <PowerSelect
-          triggerClass="previouslyapprovedactions-dropdown"
-          supportsDataTestProperties={{true}}
-          @placeholder={{this.selectedActionPlaceholder}}
-          @searchEnabled={{false}}
-          @options={{optionset 'landuseAction' 'dcpPreviouslyapprovedactioncode' 'list'}}
-          @selected={{this.actionCode}}
-          @onChange={{fn (mut this.actionCode)}}
-          @onClose={{fn this.setPreviouslyApprovedActionCodeFields this.actionCode.code}}
-          as |landUseAction|
+        <label data-test-dcpPreviouslyapprovedactioncode-picker="{{landuseActionForm.data.dcpActioncode}}">
+          <PowerSelect
+            triggerClass="previouslyapprovedactions-dropdown"
+            supportsDataTestProperties={{true}}
+            @placeholder="-- select an action --"
+            @searchEnabled={{false}}
+            @options={{optionset 'landuseAction' 'dcpPreviouslyapprovedactioncode' 'list'}}
+            @selected={{this.chosenDcpPreviouslyapprovedactioncode}}
+            @onChange={{fn (mut this.chosenDcpPreviouslyapprovedactioncode)}}
+            @onClose={{fn this.setPreviouslyApprovedActionCodeFields this.chosenDcpPreviouslyapprovedactioncode.code}}
+            as |landUseAction|
+          >
+            {{landUseAction.label}}
+          </PowerSelect>
+        </label>
+      </div>
+
+      <div class="cell text-right">
+        <button
+          type="button"
+          class="dropdown-clear-btn-below"
+          {{on "click" (fn this.clearPreviouslyApprovedActionCodeDropdown landuseActionForm.data)}}
         >
-          {{landUseAction.label}}
-        </PowerSelect>
-      </label>
+          Clear
+        </button>
+      </div>
     </div>
 
     {{#if this.projectHasRequiredActionsAndFollowUpYes}}

--- a/client/app/components/packages/landuse-form/proposed-action-editor.js
+++ b/client/app/components/packages/landuse-form/proposed-action-editor.js
@@ -1,9 +1,14 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import { optionset } from '../../../helpers/optionset';
 
 export default class PackagesLanduseFormProposedActionEditorComponent extends Component {
-  actionCode;
+  @tracked chosenDcpPreviouslyapprovedactioncode = this.args.landuseActionForm.data.dcpPreviouslyapprovedactioncode
+    ? {
+      code: this.args.landuseActionForm.data.dcpPreviouslyapprovedactioncode,
+      label: optionset(['landuseAction', 'dcpPreviouslyapprovedactioncode', 'label', this.args.landuseActionForm.data.dcpPreviouslyapprovedactioncode]),
+    } : null;
 
   requiredActionCodes = ['CM', 'LD', 'RA', 'RC', 'RS', 'SA', 'SC', 'SD', 'ZA', 'ZC', 'ZS'];
 
@@ -17,20 +22,21 @@ export default class PackagesLanduseFormProposedActionEditorComponent extends Co
     return this.projectHasRequiredActions && hasPreviousAction;
   }
 
-  get selectedActionPlaceholder() {
-    const previouslyApprovedActionCode = this.args.landuseActionForm.data.dcpPreviouslyapprovedactioncode;
-    if (previouslyApprovedActionCode) {
-      return optionset(['landuseAction', 'dcpPreviouslyapprovedactioncode', 'label', previouslyApprovedActionCode]);
-    } return '-- select an action --';
-  }
-
   @action
   setPreviouslyApprovedActionCodeFields(actionCode) {
     if (actionCode) {
       this.args.landuseActionForm.data.dcpPreviouslyapprovedactioncode = actionCode;
       this.args.landuseActionForm.data.dcpFollowuptopreviousaction = true;
-    } else if (!actionCode && !this.args.landuseActionForm.data.dcpPreviouslyapprovedactioncode) {
+    } else {
+      this.args.landuseActionForm.data.dcpPreviouslyapprovedactioncode = null;
       this.args.landuseActionForm.data.dcpFollowuptopreviousaction = false;
     }
+  }
+
+  @action
+  clearPreviouslyApprovedActionCodeDropdown(landuseActionFormData) {
+    this.chosenDcpPreviouslyapprovedactioncode = null;
+    landuseActionFormData.dcpPreviouslyapprovedactioncode = null;
+    landuseActionFormData.dcpFollowuptopreviousaction = false;
   }
 }

--- a/client/app/components/packages/landuse-form/zoning-map-amendment-fieldset.hbs
+++ b/client/app/components/packages/landuse-form/zoning-map-amendment-fieldset.hbs
@@ -37,6 +37,7 @@
           @placeholder="-- select --"
           @options={{map-by 'code' (optionset 'zoningMapChange' 'dcpExistingzoningdistrictvalue' 'list')}}
           @onChange={{fn (mut form.data.dcpExistingzoningdistrictvalue)}}
+          @allowClear={{true}}
         as |dcpExistingzoningdistrictvalue|>
           {{optionset 'zoningMapChange' 'dcpExistingzoningdistrictvalue' 'label' dcpExistingzoningdistrictvalue}}
         </PowerSelect>

--- a/client/app/components/packages/landuse-form/zoning-map-amendment.hbs
+++ b/client/app/components/packages/landuse-form/zoning-map-amendment.hbs
@@ -27,6 +27,7 @@
             @placeholder="-- select --"
             @options={{map-by 'code' (optionset 'landuseForm' 'dcpTotalzoningareatoberezoned' 'list')}}
             @onChange={{fn (mut form.data.dcpTotalzoningareatoberezoned)}}
+            @allowClear={{true}}
           as |dcpTotalzoningareatoberezoned|>
             {{optionset 'landuseForm' 'dcpTotalzoningareatoberezoned' 'label' dcpTotalzoningareatoberezoned}}
           </PowerSelect>

--- a/client/app/components/packages/landuse-form/zoning-resolution-dropdown.hbs
+++ b/client/app/components/packages/landuse-form/zoning-resolution-dropdown.hbs
@@ -1,24 +1,36 @@
 {{#let @landuseActionForm as |landuseActionForm|}}
-  <div>
-    <h5 class="small-margin-bottom">
-      What Zoning Resolution section is this Action pursuant to?
-    </h5>
+  <div class="grid-x">
+    <div class="cell small-12">
+      <h5 class="small-margin-bottom">
+        What Zoning Resolution section is this Action pursuant to?
+      </h5>
 
-    <label data-test-zoning-resolution-picker="{{landuseActionForm.data.dcpActioncode}}">
-      <PowerSelect
-        triggerClass="zoning-resolution-dropdown"
-        supportsDataTestProperties={{true}}
-        @placeholder={{this.searchPlaceholder}}
-        @searchEnabled={{true}}
-        @searchField="dcpZoningresolution"
-        @options={{@zoningResolutions}}
-        @selected={{this.chosenZoningResolution}}
-        @onChange={{fn (mut this.chosenZoningResolution)}}
-        @onClose={{fn (mut landuseActionForm.data.chosenZoningResolutionId) this.chosenZoningResolution.id}}
-        as |zoningResolution|
+      <label data-test-zoning-resolution-picker="{{landuseActionForm.data.dcpActioncode}}">
+        <PowerSelect
+          triggerClass="zoning-resolution-dropdown"
+          supportsDataTestProperties={{true}}
+          @placeholder="Search Zoning Resolution Sections..."
+          @searchEnabled={{true}}
+          @searchField="dcpZoningresolution"
+          @options={{@zoningResolutions}}
+          @selected={{this.chosenZoningResolution}}
+          @onChange={{fn (mut this.chosenZoningResolution)}}
+          @onClose={{fn (mut landuseActionForm.data.chosenZoningResolutionId) this.chosenZoningResolution.id}}
+          as |zoningResolution|
+        >
+          {{zoningResolution.dcpZoningresolution}}
+        </PowerSelect>
+      </label>
+    </div>
+
+    <div class="cell text-right">
+      <button
+        type="button"
+        class="dropdown-clear-btn-below"
+        {{on "click" (fn this.clearDropdown landuseActionForm.data)}}
       >
-        {{zoningResolution.dcpZoningresolution}}
-      </PowerSelect>
-    </label>
+        Clear
+      </button>
+    </div>
   </div>
 {{/let}}

--- a/client/app/components/packages/landuse-form/zoning-resolution-dropdown.js
+++ b/client/app/components/packages/landuse-form/zoning-resolution-dropdown.js
@@ -1,12 +1,14 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class PackagesLanduseFormZoningResolutionComponent extends Component {
-  @tracked chosenZoningResolution;
+  @tracked chosenZoningResolution = this.args.landuseActionForm.data.zoningResolution || null;
 
-  get searchPlaceholder() {
-    if (this.args.landuseActionForm.data.zoningResolution) {
-      return this.args.landuseActionForm.data.zoningResolution.dcpZoningresolution;
-    } return 'Search Zoning Resolution Sections...';
+  @action
+  clearDropdown(landuseActionFormData) {
+    this.chosenZoningResolution = null;
+    landuseActionFormData.zoningResolution = null;
+    landuseActionFormData.chosenZoningResolutionId = null;
   }
 }

--- a/client/app/styles/app.scss
+++ b/client/app/styles/app.scss
@@ -165,3 +165,9 @@ $sticky-sidebar-offset: 6rem + rem-calc(20);
   font-size: rem-calc(13);
   margin-bottom: 0.25 * $global-margin;
 }
+
+// Companion custom "Clear" button
+// Sits below a dropdown, aligned right 
+.dropdown-clear-btn-below {
+  color: $red-dark;
+}

--- a/client/app/styles/modules/_powerselect-overrides.scss
+++ b/client/app/styles/modules/_powerselect-overrides.scss
@@ -49,3 +49,8 @@
     border: $input-border-focus;
   }
 }
+
+.ember-power-select-clear-btn {
+  top: 5px;
+  right: 35px;
+}

--- a/server/src/crm/crm.service.ts
+++ b/server/src/crm/crm.service.ts
@@ -82,6 +82,10 @@ export class CrmService {
     return this._associate(relationshipName, entitySetName1, guid1, entitySetName2, guid2, headers);
   }
 
+  async disassociateHasOne(singleValuedNavigationProperty, entitySetName, guid) {
+    return this._disassociateSingleValuedNavigationProperty(singleValuedNavigationProperty, entitySetName, guid);
+  }
+
   /**
    * Makes a CRM Web API query using the passed in query in XML format
    *
@@ -399,6 +403,11 @@ export class CrmService {
       "@odata.id": this.host + entitySetName2 + "(" + guid2 + ")"
     };
     return this.create(query, data, headers);
+  }
+
+  async _disassociateSingleValuedNavigationProperty(singleValuedNavigationProperty, entitySetName, guid) {
+    const query = entitySetName + "(" + guid + ")/" + singleValuedNavigationProperty + "/$ref";
+    return this._sendDeleteRequest(query, {});
   }
 
   async generateSharePointAccessToken(): Promise<any> {

--- a/server/src/packages/landuse-form/landuse-actions/landuse-actions.controller.ts
+++ b/server/src/packages/landuse-form/landuse-actions/landuse-actions.controller.ts
@@ -28,15 +28,30 @@ export class LanduseActionsController {
 
   @Patch('/:id')
   async update(@Body() body, @Param('id') id) {
-    const allowedAttrs = pick(body, LANDUSE_ACTION_ATTRS);
+    let allowedAttrs = pick(body, LANDUSE_ACTION_ATTRS);
     const dateOfPreviousApproval = this.pickDate(body.dcp_dateofpreviousapproval);
     const lapseDateOfPreviousApproval = this.pickDate(body.dcp_lapsedateofpreviousapproval);
     const recordationDate = this.pickDate(body.dcp_recordationdate);
 
+    // "chosen_zoning_resolution_id" is the id to a related resource,
+    // but, unlike other attributes, it may not always be included
+    // in the request body.
+    // If a request does not include all of the relationships
+    // for a resource, the server MUST interpret the missing relationships
+    // as if they were included with their current values. It MUST NOT
+    // interpret them as null or empty values.
+    // Therefore, we explicitly check for a null value
+    // (which would imply a key for chosen_zoning_resolution_id),
+    // to avoid assuming that falsiness indicates a disassociation.
+    if (body.chosen_zoning_resolution_id) {
+      allowedAttrs['dcp_zoningresolutionsectionactionispursuantto@odata.bind'] = `/dcp_zoningresolutions(${body.chosen_zoning_resolution_id})`;
+    } else if (body.chosen_zoning_resolution_id === null) {
+      await this.crmService.disassociateHasOne('dcp_zoningresolutionsectionactionispursuantto', 'dcp_landuseactions', id);
+    }
+
     await this.crmService.update('dcp_landuseactions', id, {
       ...allowedAttrs,
 
-      ...(body.chosen_zoning_resolution_id ? { 'dcp_zoningresolutionsectionactionispursuantto@odata.bind': `/dcp_zoningresolutions(${body.chosen_zoning_resolution_id})` } : {}),
       dcp_dateofpreviousapproval: dateOfPreviousApproval,
       dcp_lapsedateofpreviousapproval: lapseDateOfPreviousApproval,
       dcp_recordationdate: recordationDate,


### PR DESCRIPTION
### Summary
Allows users to clear the dropdown selection on the Land Use Form Page. Including for these questions:

  1 PAS/RWCDS/Land Use Form > applicant geographic state
  2 Land Use Form > Zoning Map Amendments section > Total Area of All Zoning Lots
  3 Land Use Form > Zoning Map Amendments section > Existing Zoning District
  4. Land Use Form > Environmental Review section > Lead Agency
  5. Land Use Form > Proposed Actions section > Previously Approved Action code
  6. Land Use Form > Proposed Actions section > Zoning Resolution action is Pursuant to

#### Task/Bug Number
Fixes [AB#13309](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13309)

### Technical Explanation
  - For questions 1-3 above, the solution was simply to set the `@allowClear={{true}}` argument on the Power Selects. This enables a Power Select built-in feature where a user can click an "x" to assign the bound property a null value.  This worked because those properties are simple text or integer values. 

  - For questions 4-6 above, the solution was more complex because they deal with models/objects. Also, the power selects in 4-5 read the options from one model and assign the selected option to another ("target") model. They currently do so by assigning the selected option's ID to an auxiliary, made-up "*chosenId" field on the target model, and relying on the backend to read that chosenId and patch relationships accordingly. Thus, this PR follows that example, and modifies the backend to delete relationships according to the incoming value of the "*chosenId" fields.

  _This whole workflow should be reworked in the future. Ideally, these powerselects read and write to the same model, or polymorphic models. The frontend should associate and disassociate models based on the dropdown selections, so that when the form is saved, the proper JSONAPI compliant requests are generated._

  - Sets up a new `disassociateHasOne()` method on the CRM Service for disconnecting an 1:1 entity relationship

  - Patches up a few Power Select components so that the concerned property is displayed as the selected value on load. Previously they displayed the value as the placeholder, so it would appear gray instead of black.

  - Another future todo: Questions 1-3 and 4-6 have different styles for the "clear" button. One is a black "x", the other is the text "clear". we should design a consistent style for all dropdowns. 