### PR TITLE
Force reload entire invoice; format raw values

### DIFF
--- a/client/app/components/project/package-section.hbs
+++ b/client/app/components/project/package-section.hbs
@@ -16,85 +16,83 @@
         </ol>
       </div>
       <div class="cell large-6">
-        {{#let (flatten (map-by 'invoices' @packages)) as |invoices|}}
-          {{#if invoices}}
-            <h4>Invoices</h4>
+        {{#if this.invoices}}
+          <h4>Invoices</h4>
 
-            <ul>
-              {{#each invoices as |invoice|}}
-                <Project::PackageSection::InvoiceInfo
-                  @invoice={{invoice}}
-                />
-              {{/each}}
-            </ul>
+          <ul>
+            {{#each this.invoices as |invoice|}}
+              <Project::PackageSection::InvoiceInfo
+                @invoice={{invoice}}
+              />
+            {{/each}}
+          </ul>
 
-            {{#if this.hasPayableInvoices}}
-              <br/>
-              <button
-                type="button"
-                class="secondary button"
-                {{on 'click' (fn this.beginPayment)}}
-              >
-                Pay
-              </button>
-            {{/if}}
-
-            <Ui::GenericModal
-              @show={{this.isPaying}}
-              @closeButtonAction={{fn (mut this.isPaying) false}}
+          {{#if this.hasPayableInvoices}}
+            <br/>
+            <button
+              type="button"
+              class="secondary button"
+              {{on 'click' (fn this.beginPayment)}}
             >
-              <h3>Invoices to be paid</h3>
-
-              {{#each invoices as |invoice|}}
-                <Project::PackageSection::InvoiceInfo
-                  @invoice={{invoice}}
-                />
-              {{/each}}
-
-              <br/>
-              <br/>
-              <h3>Total: ${{reduce (fn this.sum) 0 (map-by 'dcpGrandtotal' invoices)}}</h3>
-
-              <p>
-                The following link will direct you to the CityPay website for payment processing. Before proceeding, be ready with
-                payment information such as routing numbers, account number, or credit card numbers. Credit card payments via CityPay
-                are subject to a 2% processing fee.
-              </p>
-
-              <p>
-                Upon payment, this Project will be considered “Filed” and appear in public searches on <a href="https://zap.planning.nyc.gov/" rel="noreferrer noopener">https://zap.planning.nyc.gov/</a>.
-              </p>
-
-              <div class="grid-x">
-                <div class="cell large-6 small-padding-right">
-                  <a
-                    class="button expanded large {{unless this.paymentLink 'disabled'}}"
-                    href={{this.paymentLink}}
-                    rel="noreferrer noopener"
-                    target="_blank"
-                  >
-                    {{#if this.paymentLink}}
-                      <strong>
-                        Go To CityPay <FaIcon @icon="external-link-alt" />
-                      </strong>
-                    {{else}}
-                      <FaIcon @icon="spinner" @spin={{true}} @pulse={{true}} class="text-silver" />
-                    {{/if}}
-                  </a>
-                </div>
-                <div class="cell large-6 small-padding-left">
-                  <button
-                    type="button"
-                    class="button expanded large secondary"
-                    {{on "click" (fn (mut this.isPaying) false)}}
-                    >
-                    Cancel
-                  </button>
-                </div>
-              </div>
-            </Ui::GenericModal>
+              Pay
+            </button>
           {{/if}}
-        {{/let}}
+
+          <Ui::GenericModal
+            @show={{this.isPaying}}
+            @closeButtonAction={{fn (mut this.isPaying) false}}
+          >
+            <h3>Invoices to be paid</h3>
+
+            {{#each this.invoices as |invoice|}}
+              <Project::PackageSection::InvoiceInfo
+                @invoice={{invoice}}
+              />
+            {{/each}}
+
+            <br/>
+            <br/>
+            <h3>Total: ${{reduce (fn this.sum) 0 (map-by 'dcpGrandtotal' this.invoices)}}</h3>
+
+            <p>
+              The following link will direct you to the CityPay website for payment processing. Before proceeding, be ready with
+              payment information such as routing numbers, account number, or credit card numbers. Credit card payments via CityPay
+              are subject to a 2% processing fee.
+            </p>
+
+            <p>
+              Upon payment, this Project will be considered “Filed” and appear in public searches on <a href="https://zap.planning.nyc.gov/" rel="noreferrer noopener">https://zap.planning.nyc.gov/</a>.
+            </p>
+
+            <div class="grid-x">
+              <div class="cell large-6 small-padding-right">
+                <a
+                  class="button expanded large {{unless this.paymentLink 'disabled'}}"
+                  href={{this.paymentLink}}
+                  rel="noreferrer noopener"
+                  target="_blank"
+                >
+                  {{#if this.paymentLink}}
+                    <strong>
+                      Go To CityPay <FaIcon @icon="external-link-alt" />
+                    </strong>
+                  {{else}}
+                    <FaIcon @icon="spinner" @spin={{true}} @pulse={{true}} class="text-silver" />
+                  {{/if}}
+                </a>
+              </div>
+              <div class="cell large-6 small-padding-left">
+                <button
+                  type="button"
+                  class="button expanded large secondary"
+                  {{on "click" (fn (mut this.isPaying) false)}}
+                  >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </Ui::GenericModal>
+        {{/if}}
       </div>
     </div>
   </div>

--- a/client/app/components/project/package-section.hbs
+++ b/client/app/components/project/package-section.hbs
@@ -52,7 +52,7 @@
 
             <br/>
             <br/>
-            <h3>Total: ${{reduce (fn this.sum) 0 (map-by 'dcpGrandtotal' this.invoices)}}</h3>
+            <h3>Total: ${{to-locale-string this.payablePackage.grandTotal}}</h3>
 
             <p>
               The following link will direct you to the CityPay website for payment processing. Before proceeding, be ready with

--- a/client/app/components/project/package-section.js
+++ b/client/app/components/project/package-section.js
@@ -23,13 +23,11 @@ export default class ProjectPackageSectionComponent extends Component {
 
   get invoices() {
     return this.args.packages
-      .map(pkg => { return pkg.get('invoices').toArray(); })
+      .map((pkg) => pkg.get('invoices').toArray())
       .flat();
   }
 
   get hasPayableInvoices() {
-    console.log(this.invoices);
-
     return this.invoices.filter((invoice) => invoice.statuscode === 'Approved').length >= 1;
   }
 

--- a/client/app/components/project/package-section.js
+++ b/client/app/components/project/package-section.js
@@ -23,11 +23,13 @@ export default class ProjectPackageSectionComponent extends Component {
 
   get invoices() {
     return this.args.packages
-      .mapBy('invoices')
-      .reduce((acc, curr) => acc.concat(curr), []);
+      .map(pkg => { return pkg.get('invoices').toArray(); })
+      .flat();
   }
 
   get hasPayableInvoices() {
+    console.log(this.invoices);
+
     return this.invoices.filter((invoice) => invoice.statuscode === 'Approved').length >= 1;
   }
 

--- a/client/app/components/project/package-section/invoice-info.hbs
+++ b/client/app/components/project/package-section/invoice-info.hbs
@@ -7,8 +7,9 @@
 
   <LinkTo
     @route="invoice"
-    @model={{@invoice}}
+    @model={{@invoice.id}}
     @query={{hash header=false}}
+    target="_blank"
   >
     {{@invoice.dcpName}}
   </LinkTo>

--- a/client/app/helpers/to-locale-string.js
+++ b/client/app/helpers/to-locale-string.js
@@ -1,0 +1,5 @@
+import { helper } from '@ember/component/helper';
+
+export default helper(function toLocaleString(number) {
+  return number.toLocaleString();
+});

--- a/client/app/models/package.js
+++ b/client/app/models/package.js
@@ -77,6 +77,9 @@ export default class PackageModel extends Model {
   @attr({ defaultValue: () => [] })
   documents;
 
+  @attr('number')
+  grandTotal;
+
   get singleCeqrInvoiceQuestionnaire() {
     return this.ceqrInvoiceQuestionnaires.firstObject;
   }

--- a/client/app/routes/invoice.js
+++ b/client/app/routes/invoice.js
@@ -2,6 +2,6 @@ import Route from '@ember/routing/route';
 
 export default class InvoiceRoute extends Route {
   model({ id }) {
-    return this.store.findRecord('invoice', id);
+    return this.store.findRecord('invoice', id, { reload: true });
   }
 }

--- a/client/tests/integration/helpers/to-locale-string-test.js
+++ b/client/tests/integration/helpers/to-locale-string-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | to-locale-string', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // Replace this with your real tests.
+  test('it renders', async function(assert) {
+    this.set('inputValue', '1234');
+
+    await render(hbs`{{to-locale-string inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '1234');
+  });
+});

--- a/server/src/_utils/overwrite-codes-with-labels.ts
+++ b/server/src/_utils/overwrite-codes-with-labels.ts
@@ -5,7 +5,9 @@ const COMMUNITY_DISPLAY_TOKEN = '@OData.Community.Display.V1.FormattedValue';
 // This function maps those values with appropriate labels
 export function overwriteCodesWithLabels(records, targetFields) {
   return records.map(record => {
-    const newRecord = record;
+    const newRecord = {
+      ...record,
+    };
 
     // parent record
     Object.keys(record)
@@ -28,7 +30,9 @@ export function overwriteCodesWithLabels(records, targetFields) {
           // @ts-ignore
           .filter(Boolean)
           .map(record => {
-            const newRecord = record;
+            const newRecord = {
+              ...record,
+            };
 
             Object.keys(record)
               .filter(key => key.includes(COMMUNITY_DISPLAY_TOKEN))

--- a/server/src/invoices/invoices.service.ts
+++ b/server/src/invoices/invoices.service.ts
@@ -3,7 +3,7 @@ import { CrmService } from '../crm/crm.service';
 import { overwriteCodesWithLabels } from '../_utils/overwrite-codes-with-labels';
 import { INVOICE_ATTRS } from './invoices.attrs';
 
-export function joinLabels(records) {
+export function joinLabels(records, attrs = INVOICE_ATTRS) {
   return overwriteCodesWithLabels(records, INVOICE_ATTRS);
 }
 

--- a/server/src/invoices/invoices.service.ts
+++ b/server/src/invoices/invoices.service.ts
@@ -19,7 +19,7 @@ export class InvoicesService {
     const [invoice] = joinLabels(records);
 
     return {
-      lineitems: invoice.dcp_dcp_projectinvoice_dcp_invoicelineitem_projectinvoice,
+      lineitems: overwriteCodesWithLabels(invoice.dcp_dcp_projectinvoice_dcp_invoicelineitem_projectinvoice, ['dcp_fee']),
       ...invoice
     };
   }

--- a/server/src/projects/projects.controller.ts
+++ b/server/src/projects/projects.controller.ts
@@ -42,6 +42,9 @@ import { INVOICE_ATTRS } from '../invoices/invoices.attrs';
     attributes: [
       ...PACKAGE_ATTRS,
 
+      // Virtual property — computed in the projects service
+      'grand_total',
+
       'invoices',
     ],
     invoices: {

--- a/server/src/projects/projects.service.ts
+++ b/server/src/projects/projects.service.ts
@@ -190,6 +190,10 @@ export class ProjectsService {
         packages: projectPackages.map(pkg => ({
           ...pkg,
           invoices: joinInvoiceLabels(pkg.dcp_dcp_package_dcp_projectinvoice_package),
+
+          // NOTE: "virtual" property. Maybe not be available in other requests for pkg data!
+          grand_total: pkg.dcp_dcp_package_dcp_projectinvoice_package
+            .reduce((acc, curr) => curr.dcp_grandtotal + acc, 0),
         })),
         projectApplicants: project['project-applicants'],
         'project-applicants': projectApplicantsWithContacts,


### PR DESCRIPTION
### Summary
Small changes to force reload of the invoice route. Before, it was only getting a partial fragment of the invoice from a previous route, and using that fragment to render the view. This change forces a reload of the entire entity.

#### Task/Bug Number
Fixes [AB#13298](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13298)

Includes bug fix in which "hasPayableInvoice" computed was not calculating correctly because of the nature of ember data's hasMany relationships

