### PR TITLE
Remove serializer transform; put logic in service

### DIFF
--- a/server/src/projects/projects.controller.ts
+++ b/server/src/projects/projects.controller.ts
@@ -76,28 +76,6 @@ import { INVOICE_ATTRS } from '../invoices/invoices.attrs';
       ...TEAMMEMBER_ATTRS,
     ],
   },
-  
-  // remap verbose navigation link names to	
-  // more concise names	
-  transform(project) {	
-    try {	
-      return {	
-        ...project,	
-        packages: project.dcp_dcp_project_dcp_package_project,	
-        projectApplicants: project['project-applicants'],	
-      };	
-    } catch(e) {	
-      if (e instanceof HttpException) {	
-        throw e;	
-      } else {	
-        throw new HttpException({	
-          code: 'PROJECTS_ERROR',	
-          title: 'Failed load project(s)',	
-          detail: `An error occurred while loading one or more projects. ${e.message}`,	
-        }, HttpStatus.INTERNAL_SERVER_ERROR);	
-      }	
-    }	
-  },
 }))
 @UseGuards(AuthenticateGuard)
 @UsePipes(JsonApiDeserializePipe)

--- a/server/src/projects/projects.service.ts
+++ b/server/src/projects/projects.service.ts
@@ -69,7 +69,13 @@ export class ProjectsService {
             $filter= statuscode eq ${APPLICANT_ACTIVE_STATUS_CODE}
           )
       `);
-      return this.overwriteCodesWithLabels(records);
+
+      return this.overwriteCodesWithLabels(records)
+        .map(project => ({
+          ...project,
+          packages: project.dcp_dcp_project_dcp_package_project,
+          projectApplicants: project['project-applicants'],
+        }));
     } catch(e) {
       const errorMessage = `Unable to find projects for current user. ${e.message}`;
       throw new HttpException({


### PR DESCRIPTION
### Summary
The controller serializer was handling munging for everything. This was excluding certain munging necessary for project-specific requests.

This change makes the service responsible for each serialization needed. For example, the /projects view needs to code packages correctly. But projects/:id includes a lot more info.

#### Task/Bug Number
Fixes [AB#13299](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13299)
