### PR TITLE
12777 Fix support for missing manner of dispo. answers.

### DIFF
--- a/client/app/components/packages/landuse-form/show.hbs
+++ b/client/app/components/packages/landuse-form/show.hbs
@@ -883,6 +883,32 @@
             </A.Field>
           </Ui::Answer>
 
+          {{#if (eq
+            @package.landuseForm.dcpMannerofdisposition
+            (optionset 'landuseForm' 'dcpMannerofdisposition' 'code' 'Direct')
+          )}}
+            <Ui::Answer as |A|>
+              <A.Prompt>
+                From (Indicate City Agency)
+              </A.Prompt>
+
+              <A.Field>
+                {{@package.landuseForm.dcpFrom}}
+              </A.Field>
+            </Ui::Answer>
+
+            <Ui::Answer as |A|>
+              <A.Prompt>
+                To (Indicate Sponsor/Developer/Purchaser/Lessee
+                or Local Public Development Corp.)
+              </A.Prompt>
+
+              <A.Field>
+                {{@package.landuseForm.dcpTo}}
+              </A.Field>
+            </Ui::Answer>
+          {{/if}}
+
           <Ui::Answer as |A|>
             <A.Prompt>
               Restrictions and Conditions


### PR DESCRIPTION
### Summary
On the Land Use Form Show page, conditionally displays  the From and To questions if Manner of Dispo is "Direct". 

#### Task/Bug Number
Fixes [AB#12777](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12777)

### Technical Explanation
