### PR TITLE
13396: update conditional logic on ceqr-invoice-questionnaire

### DIFF
--- a/client/app/components/packages/ceqr-invoice-questionnaire.hbs
+++ b/client/app/components/packages/ceqr-invoice-questionnaire.hbs
@@ -15,72 +15,80 @@
     </form.Field>
   </Ui::Question>
 
-  <Ui::Question as |dcpProjectspolelyconsistactionsnotmeasurableQ|>
-    <dcpProjectspolelyconsistactionsnotmeasurableQ.Legend>
-      Does your project solely consist of action(s) that are not measureable by sq. ft.?
-    </dcpProjectspolelyconsistactionsnotmeasurableQ.Legend>
+  {{#if (eq form.data.dcpIsthesoleaapplicantagovtagency (optionset 'ceqrInvoiceQuestionnaire' 'dcpIsthesoleaapplicantagovtagency' 'code' 'NO'))}}
+    <Ui::Question @required={{true}} as |dcpProjectspolelyconsistactionsnotmeasurableQ|>
+      <dcpProjectspolelyconsistactionsnotmeasurableQ.Legend>
+        Does your project solely consist of action(s) that are not measureable by sq. ft.?
+      </dcpProjectspolelyconsistactionsnotmeasurableQ.Legend>
 
-    <form.Field
-      @attribute="dcpProjectspolelyconsistactionsnotmeasurable"
-      @type="radio-group"
-      as |RadioGroup|
-    >
-      <RadioGroup
-        @options={{optionset 'ceqrInvoiceQuestionnaire' 'dcpProjectspolelyconsistactionsnotmeasurable' 'list'}}
-      />
-    </form.Field>
-  </Ui::Question>
-
-  <div>
-    <h5 class="small-margin-bottom">
-      What is the Square Footage of the Total Project?
-    </h5>
-
-    <label data-test-dcpsquarefeet-picker>
-      <PowerSelect
-        triggerClass="square-feet-dropdown"
-        supportsDataTestProperties={{true}}
-        @placeholder="-- Select Square Footage --"
-        @searchEnabled={{false}}
-        @options={{map-by 'code' (optionset 'ceqrInvoiceQuestionnaire' 'dcpSquarefeet' 'list')}}
-        @selected={{form.data.dcpSquarefeet}}
-        @onChange={{fn (mut form.data.dcpSquarefeet)}}
-        as |dcpSquarefeet|
+      <form.Field
+        @attribute="dcpProjectspolelyconsistactionsnotmeasurable"
+        @type="radio-group"
+        as |RadioGroup|
       >
-        {{optionset 'ceqrInvoiceQuestionnaire' 'dcpSquarefeet' 'label' dcpSquarefeet}}
-      </PowerSelect>
-    </label>
-  </div>
+        <RadioGroup
+          @options={{optionset 'ceqrInvoiceQuestionnaire' 'dcpProjectspolelyconsistactionsnotmeasurable' 'list'}}
+        />
+      </form.Field>
+    </Ui::Question>
 
-  <Ui::Question as |dcpProjectmodificationtoapreviousapprovalQ|>
-    <dcpProjectmodificationtoapreviousapprovalQ.Legend>
-      Does the project consist solely of modification actions that are not subject to 197c? 
-    </dcpProjectmodificationtoapreviousapprovalQ.Legend>
+    {{#if (eq form.data.dcpProjectspolelyconsistactionsnotmeasurable (optionset 'ceqrInvoiceQuestionnaire' 'dcpProjectspolelyconsistactionsnotmeasurable' 'code' 'NO'))}}
+      <Ui::Question @required={{true}} as |dcpSquarefeetQ|>
+        <dcpSquarefeetQ.Label>
+          What is the Square Footage of the Total Project?
+        </dcpSquarefeetQ.Label>
 
-    <form.Field
-      @attribute="dcpProjectmodificationtoapreviousapproval"
-      @type="radio-group"
-      as |RadioGroup|
-    >
-      <RadioGroup
-        @options={{optionset 'ceqrInvoiceQuestionnaire' 'dcpProjectmodificationtoapreviousapproval' 'list'}}
-      />
-    </form.Field>
-  </Ui::Question>
+        <form.Field
+          @attribute="dcpSquarefeet"
+        >
+          <label data-test-dcpsquarefeet-picker>
+            <PowerSelect
+              triggerClass="square-feet-dropdown"
+              supportsDataTestProperties={{true}}
+              @placeholder="-- Select Square Footage --"
+              @searchEnabled={{false}}
+              @options={{map-by 'code' (optionset 'ceqrInvoiceQuestionnaire' 'dcpSquarefeet' 'list')}}
+              @selected={{form.data.dcpSquarefeet}}
+              @onChange={{fn (mut form.data.dcpSquarefeet)}}
+              as |dcpSquarefeet|
+            >
+              {{optionset 'ceqrInvoiceQuestionnaire' 'dcpSquarefeet' 'label' dcpSquarefeet}}
+            </PowerSelect>
+          </label>
+        </form.Field>
+      </Ui::Question>
 
-  <Ui::Question as |dcpRespectivedecrequiredQ|>
-    <dcpRespectivedecrequiredQ.Legend>
-      Does your project produce a need for a CEQR Restrictive Declaration? 
-    </dcpRespectivedecrequiredQ.Legend>
+      <Ui::Question @required={{true}} as |dcpProjectmodificationtoapreviousapprovalQ|>
+        <dcpProjectmodificationtoapreviousapprovalQ.Legend>
+          Does the project consist solely of modification actions that are not subject to 197c? 
+        </dcpProjectmodificationtoapreviousapprovalQ.Legend>
 
-    <form.Field
-      @attribute="dcpRespectivedecrequired"
-      @type="radio-group"
-      as |RadioGroup|
-    >
-      <RadioGroup
-        @options={{optionset 'ceqrInvoiceQuestionnaire' 'dcpRespectivedecrequired' 'list'}}
-      />
-    </form.Field>
-  </Ui::Question>
+        <form.Field
+          @attribute="dcpProjectmodificationtoapreviousapproval"
+          @type="radio-group"
+          as |RadioGroup|
+        >
+          <RadioGroup
+            @options={{optionset 'ceqrInvoiceQuestionnaire' 'dcpProjectmodificationtoapreviousapproval' 'list'}}
+          />
+        </form.Field>
+      </Ui::Question>
+
+      <Ui::Question @required={{true}} as |dcpRespectivedecrequiredQ|>
+        <dcpRespectivedecrequiredQ.Legend>
+          Does your project produce a need for a CEQR Restrictive Declaration? 
+        </dcpRespectivedecrequiredQ.Legend>
+
+        <form.Field
+          @attribute="dcpRespectivedecrequired"
+          @type="radio-group"
+          as |RadioGroup|
+        >
+          <RadioGroup
+            @options={{optionset 'ceqrInvoiceQuestionnaire' 'dcpRespectivedecrequired' 'list'}}
+          />
+        </form.Field>
+      </Ui::Question>
+    {{/if}}
+  {{/if}}
 {{/let}}

--- a/client/app/components/packages/filed-eas/edit.hbs
+++ b/client/app/components/packages/filed-eas/edit.hbs
@@ -49,19 +49,21 @@
         </saveableForm.Section>
       {{/if}}
 
-      {{#let saveableForm.data.singleCeqrInvoiceQuestionnaire as |ceqrInvoiceQuestionnaire|}}
-        <saveableForm.Section @title="Ceqr Invoice Questionnaire">
-          <saveableForm.SaveableForm
-            @model={{ceqrInvoiceQuestionnaire}}
-            @validators={{array (hash) this.validations.SubmittableCeqrInvoiceQuestionnaireFormValidations}}
-            as |ceqrInvoiceQuestionnaireForm|
-          >
-            <Packages::CeqrInvoiceQuestionnaire
-              @form={{ceqrInvoiceQuestionnaireForm}}
-            />
-          </saveableForm.SaveableForm>
-        </saveableForm.Section>
-      {{/let}}
+      {{#if (gte saveableForm.data.ceqrInvoiceQuestionnaires.length 1)}}
+        {{#let saveableForm.data.singleCeqrInvoiceQuestionnaire as |ceqrInvoiceQuestionnaire|}}
+          <saveableForm.Section @title="Ceqr Invoice Questionnaire">
+            <saveableForm.SaveableForm
+              @model={{ceqrInvoiceQuestionnaire}}
+              @validators={{array (hash) this.validations.SubmittableCeqrInvoiceQuestionnaireFormValidations}}
+              as |ceqrInvoiceQuestionnaireForm|
+            >
+              <Packages::CeqrInvoiceQuestionnaire
+                @form={{ceqrInvoiceQuestionnaireForm}}
+              />
+            </saveableForm.SaveableForm>
+          </saveableForm.Section>
+        {{/let}}
+      {{/if}}
 
       <Packages::FiledEas::AttachedDocuments
         @form={{saveableForm}}

--- a/client/app/components/packages/filed-eas/edit.js
+++ b/client/app/components/packages/filed-eas/edit.js
@@ -5,18 +5,6 @@ import SubmittablePackageFormValidations from '../../../validations/submittable-
 import SubmittableCeqrInvoiceQuestionnaireFormValidations from '../../../validations/submittable-ceqr-invoice-questionnaire-form';
 
 export default class PackagesFiledEasEditComponent extends Component {
-  @service
-  store;
-
-  constructor(...args) {
-    super(...args);
-
-    if (this.args.package.ceqrInvoiceQuestionnaires.length < 1) {
-      const newCeqrInvoiceQuestionnaire = this.store.createRecord('ceqr-invoice-questionnaire');
-      this.args.package.ceqrInvoiceQuestionnaires.pushObject(newCeqrInvoiceQuestionnaire);
-    }
-  }
-
   validations = {
     SubmittablePackageFormValidations,
   };

--- a/client/app/components/packages/scope-of-work-draft/edit.hbs
+++ b/client/app/components/packages/scope-of-work-draft/edit.hbs
@@ -45,19 +45,21 @@
         </saveableForm.Section>
       {{/if}}
 
-      {{#let saveableForm.data.singleCeqrInvoiceQuestionnaire as |ceqrInvoiceQuestionnaire|}}
-        <saveableForm.Section @title="Ceqr Invoice Questionnaire">
-          <saveableForm.SaveableForm
-            @model={{ceqrInvoiceQuestionnaire}}
-            @validators={{array (hash) this.validations.SubmittableCeqrInvoiceQuestionnaireFormValidations}}
-            as |ceqrInvoiceQuestionnaireForm|
-          >
-            <Packages::CeqrInvoiceQuestionnaire
-              @form={{ceqrInvoiceQuestionnaireForm}}
-            />
-          </saveableForm.SaveableForm>
-        </saveableForm.Section>
-      {{/let}}
+      {{#if (gte saveableForm.data.ceqrInvoiceQuestionnaires.length 1)}}
+        {{#let saveableForm.data.singleCeqrInvoiceQuestionnaire as |ceqrInvoiceQuestionnaire|}}
+          <saveableForm.Section @title="Ceqr Invoice Questionnaire">
+            <saveableForm.SaveableForm
+              @model={{ceqrInvoiceQuestionnaire}}
+              @validators={{array (hash) this.validations.SubmittableCeqrInvoiceQuestionnaireFormValidations}}
+              as |ceqrInvoiceQuestionnaireForm|
+            >
+              <Packages::CeqrInvoiceQuestionnaire
+                @form={{ceqrInvoiceQuestionnaireForm}}
+              />
+            </saveableForm.SaveableForm>
+          </saveableForm.Section>
+        {{/let}}
+      {{/if}}
 
       <Packages::ScopeOfWorkDraft::AttachedDocuments
         @form={{saveableForm}}

--- a/client/app/components/packages/scope-of-work-draft/edit.js
+++ b/client/app/components/packages/scope-of-work-draft/edit.js
@@ -5,18 +5,6 @@ import SubmittablePackageFormValidations from '../../../validations/submittable-
 import SubmittableCeqrInvoiceQuestionnaireFormValidations from '../../../validations/submittable-ceqr-invoice-questionnaire-form';
 
 export default class PackagesScopeOfWorkDraftEditComponent extends Component {
-  @service
-  store;
-
-  constructor(...args) {
-    super(...args);
-
-    if (this.args.package.ceqrInvoiceQuestionnaires.length < 1) {
-      const newCeqrInvoiceQuestionnaire = this.store.createRecord('ceqr-invoice-questionnaire');
-      this.args.package.ceqrInvoiceQuestionnaires.pushObject(newCeqrInvoiceQuestionnaire);
-    }
-  }
-
   validations = {
     SubmittablePackageFormValidations,
     SubmittableCeqrInvoiceQuestionnaireFormValidations,

--- a/client/app/validations/submittable-ceqr-invoice-questionnaire-form.js
+++ b/client/app/validations/submittable-ceqr-invoice-questionnaire-form.js
@@ -1,11 +1,44 @@
 import {
   validatePresence,
 } from 'ember-changeset-validations/validators';
+import validatePresenceIf from '../validators/required-if-selected';
 
 export default {
   dcpIsthesoleaapplicantagovtagency: [
     validatePresence({
       presence: true,
+      message: 'This field is required',
+    }),
+  ],
+  dcpProjectspolelyconsistactionsnotmeasurable: [
+    validatePresenceIf({
+      presence: true,
+      on: 'dcpIsthesoleaapplicantagovtagency',
+      withValue: 717170001,
+      message: 'This field is required',
+    }),
+  ],
+  dcpSquarefeet: [
+    validatePresenceIf({
+      presence: true,
+      on: 'dcpProjectspolelyconsistactionsnotmeasurable',
+      withValue: 717170001,
+      message: 'This field is required',
+    }),
+  ],
+  dcpProjectmodificationtoapreviousapproval: [
+    validatePresenceIf({
+      presence: true,
+      on: 'dcpProjectspolelyconsistactionsnotmeasurable',
+      withValue: 717170001,
+      message: 'This field is required',
+    }),
+  ],
+  dcpRespectivedecrequired: [
+    validatePresenceIf({
+      presence: true,
+      on: 'dcpProjectspolelyconsistactionsnotmeasurable',
+      withValue: 717170001,
       message: 'This field is required',
     }),
   ],

--- a/client/tests/acceptance/user-can-edit-filed-eas-test.js
+++ b/client/tests/acceptance/user-can-edit-filed-eas-test.js
@@ -150,7 +150,7 @@ module('Acceptance | user can edit Filed EAS Packages', function (hooks) {
 
     await visit('/filed-eas/1/edit');
 
-    await click('[data-test-radio="dcpIsthesoleaapplicantagovtagency"][data-test-radio-option="Yes"]');
+    await click('[data-test-radio="dcpIsthesoleaapplicantagovtagency"][data-test-radio-option="No"]');
     await click('[data-test-radio="dcpProjectspolelyconsistactionsnotmeasurable"][data-test-radio-option="No"]');
     await selectChoose('[data-test-dcpsquarefeet-picker]', 'less than 10,000 square feet');
     await click('[data-test-radio="dcpProjectmodificationtoapreviousapproval"][data-test-radio-option="No"]');

--- a/server/src/packages/ceqr-invoice-questionnaires/ceqr-invoice-questionnaires.controller.ts
+++ b/server/src/packages/ceqr-invoice-questionnaires/ceqr-invoice-questionnaires.controller.ts
@@ -32,14 +32,4 @@ export class CeqrInvoiceQuestionnairesController {
       ...body,
     }
   }
-
-  @Post('/')
-  create(@Body() body) {
-    const allowedAttrs = pick(body, CEQR_INVOICE_QUESTIONNAIRE_ATTRS);
-
-    return this.crmService.create('dcp_ceqrinvoicequestionnaires', {
-      ...allowedAttrs,
-      'dcp_Package@odata.bind': `/dcp_packages(${body.package})`,
-    });
-  }
 }


### PR DESCRIPTION
### Summary
**Remove the automatic creation** of a new ceqr invoice questionnaire every time the user visits the package page. This was implemented before an enhancement in CRM made it obsolete. 

Add **new conditional logic** to the Ceqr Invoice Questionnaire section
- All questions below will only show up if "Is the sole applicant a government agency (City, State, or Federal)?" is checked "No"
- the "What is the Square Footage of the Total Project?" question will only show up if the answer to "Does your project solely consist of action(s) that are not measureable by sq. ft.?" is "No"

### Task/Bug Number
Fixes [AB#13396](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13396), [AB#13397](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13397), [AB#13395](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13395)

### Technical Explanation
- remove the automatic POST of a ceqr-invoice-questionnaire when the user loads the package page
- add conditional logic on the ceqr-invoice-questionnaire.hbs component
