### PR TITLE
13394 Display the CEQR Questionnaire on the submitted Filed EAS form

### DIFF
--- a/client/app/components/packages/filed-eas/show.hbs
+++ b/client/app/components/packages/filed-eas/show.hbs
@@ -57,6 +57,7 @@
                 {{optionset 'ceqrInvoiceQuestionnaire' 'dcpIsthesoleaapplicantagovtagency' 'label' ceqrInvoiceQuestionnaire.dcpIsthesoleaapplicantagovtagency}}
               </A.Field>
             </Ui::Answer>
+
             {{#if (eq ceqrInvoiceQuestionnaire.dcpIsthesoleaapplicantagovtagency (optionset 'ceqrInvoiceQuestionnaire' 'dcpIsthesoleaapplicantagovtagency' 'code' 'NO'))}}
               <Ui::Answer @beside={{true}} as |A|>
                 <A.Prompt>
@@ -104,6 +105,7 @@
     <saveableForm.Section
       @title="Attached Documents" 
       @elementId="attachments"
+      data-test-attached-documents
     >
       <ul class="no-bullet">
         {{#each @package.documents as |document idx|}}

--- a/client/app/components/packages/filed-eas/show.hbs
+++ b/client/app/components/packages/filed-eas/show.hbs
@@ -1,3 +1,9 @@
+<SaveableForm 
+  @model={{@package}}
+  @validators={{array (hash) (hash)}} 
+  as |saveableForm|
+>
+
 <div class="grid-x grid-margin-x">
   <div class="cell large-8">
     <section class="form-section">
@@ -33,14 +39,72 @@
       </p>
     </section>
 
-    <section class="form-section"
-      data-test-attached-documents
-    >
-      <h2 class="section-header">
-        <span id="attachments" class="section-anchor"></span>
-        Attached Documents
-      </h2>
+      {{#if (gte saveableForm.data.ceqrInvoiceQuestionnaires.length 1)}}
+        {{#let saveableForm.data.singleCeqrInvoiceQuestionnaire as |ceqrInvoiceQuestionnaire|}}
+          <saveableForm.Section
+          @title="Ceqr Invoice Questionnaire" 
+          @elementId="ceqr-invoice-questionnaire"
+          >
+            <saveableForm.SaveableForm
+              @model={{ceqrInvoiceQuestionnaire}}
+               @validators={{array (hash) (hash)}} 
+            >
+            <Ui::Answer @beside={{true}} as |A|>
+              <A.Prompt>
+                Is the sole applicant a government agency (City, State, or Federal)?
+              </A.Prompt>
+              <A.Field>
+                {{optionset 'ceqrInvoiceQuestionnaire' 'dcpIsthesoleaapplicantagovtagency' 'label' ceqrInvoiceQuestionnaire.dcpIsthesoleaapplicantagovtagency}}
+              </A.Field>
+            </Ui::Answer>
+            {{#if (eq ceqrInvoiceQuestionnaire.dcpIsthesoleaapplicantagovtagency (optionset 'ceqrInvoiceQuestionnaire' 'dcpIsthesoleaapplicantagovtagency' 'code' 'NO'))}}
+              <Ui::Answer @beside={{true}} as |A|>
+                <A.Prompt>
+                  Does your project solely consist of action(s) that are not measureable by sq. ft.?
+                </A.Prompt>
+                <A.Field>
+                  {{optionset 'ceqrInvoiceQuestionnaire' 'dcpProjectspolelyconsistactionsnotmeasurable' 'label' ceqrInvoiceQuestionnaire.dcpProjectspolelyconsistactionsnotmeasurable}}
+                </A.Field>
+              </Ui::Answer>
 
+            {{#if (eq ceqrInvoiceQuestionnaire.dcpProjectspolelyconsistactionsnotmeasurable (optionset 'ceqrInvoiceQuestionnaire' 'dcpProjectspolelyconsistactionsnotmeasurable' 'code' 'NO'))}}
+              <Ui::Answer @beside={{true}} as |A|>
+                <A.Prompt>
+                  What is the Square Footage of the Total Project?
+                </A.Prompt>
+                <A.Field>
+                 {{optionset 'ceqrInvoiceQuestionnaire' 'dcpSquarefeet' 'label' ceqrInvoiceQuestionnaire.dcpSquarefeet}}
+                </A.Field>
+              </Ui::Answer>
+
+              <Ui::Answer @beside={{true}} as |A|>
+                <A.Prompt>
+                  Does the project consist solely of modification actions that are not subject to 197c? 
+                </A.Prompt>
+                <A.Field>
+                  {{optionset 'ceqrInvoiceQuestionnaire' 'dcpProjectmodificationtoapreviousapproval' 'label' ceqrInvoiceQuestionnaire.dcpProjectmodificationtoapreviousapproval}}
+                </A.Field>
+              </Ui::Answer>
+
+              <Ui::Answer @beside={{true}} as |A|>
+                <A.Prompt>
+                  Does your project produce a need for a CEQR Restrictive Declaration? 
+                </A.Prompt>
+                <A.Field>
+                 {{optionset 'ceqrInvoiceQuestionnaire' 'dcpRespectivedecrequired' 'label' ceqrInvoiceQuestionnaire.dcpRespectivedecrequired}}
+                </A.Field>
+              </Ui::Answer>
+            {{/if}}
+          {{/if}}
+          </saveableForm.SaveableForm>
+          </saveableForm.Section>
+        {{/let}}
+      {{/if}}
+
+    <saveableForm.Section
+      @title="Attached Documents" 
+      @elementId="attachments"
+    >
       <ul class="no-bullet">
         {{#each @package.documents as |document idx|}}
           <li class="ruled-adjacent tight">
@@ -60,12 +124,14 @@
           </li>
         {{/each}}
       </ul>
-    </section>
+    </saveableForm.Section>
   </div>
 
   <div class="cell large-4 sticky-sidebar">
     <Messages::Assistance class="large-margin-top" />
+      <saveableForm.PageNav>
+      </saveableForm.PageNav>
   </div>
 </div>
-
+</SaveableForm>
 {{yield}}


### PR DESCRIPTION
### Summary
13394 Display the CEQR Questionnaire on the submitted Filed EAS form

#### Task/Bug Number
Fixes [AB#13394](https://dcp-paperless.visualstudio.com/ZAP%20Portals/_workitems/edit/13394)

### Technical Explanation
Add CEQR section in show.hbs based on edit.hbs. Also add SaveableForm to enable dynamic nav on the right.