### PR TITLE
Assume Sharepoint Folder name uses raw Package Name

### DIFF
--- a/server/src/document/document.controller.ts
+++ b/server/src/document/document.controller.ts
@@ -54,16 +54,12 @@ export class DocumentController {
 
     const { records: [ { dcp_name: packageName }]} = packageRecord;
 
-    // Here, we make sure the packageName matches the format used by Sharepoint
-    // document folders that hold documents from previous revisions.
-    const strippedPackageName = packageName.replace(/-/g, '').replace(/\s+/g, '').replace(/'+/g,'');
-
     // We upload documents to the Sharepoint folder that holds documents from
     // previous revisions. This way, the revision folder holds both documents
     // from current and past revisions. When retrieving documents, we can then
     // only look up this one folder, instead of two separate folders (one for
     // previous revision documents and one for current revision documents).
-    const folderName = `${strippedPackageName}_${instanceId.toUpperCase().replace(/-/g, '')}`;
+    const folderName = `${packageName}_${instanceId.toUpperCase().replace(/-/g, '')}`;
 
     return this.documentService.uploadDocument('dcp_package',
       instanceId,

--- a/server/src/document/document.service.ts
+++ b/server/src/document/document.service.ts
@@ -287,8 +287,7 @@ async getParentSiteLocation() {
   // revision into this folder.
   async findPackageSharepointDocuments(packageName, id: string) {
     try {
-      const strippedPackageName = packageName.replace(/-/g, '').replace(/\s+/g, '').replace(/'+/g, '').replace(/^\~|\#|\%|\&|\*|\{|\}|\\|\:|\<|\>|\?|\/|\||\"/g, '');
-      const folderIdentifier = `${strippedPackageName}_${id.toUpperCase().replace(/-/g, '')}`;
+      const folderIdentifier = `${packageName}_${id.toUpperCase().replace(/-/g, '')}`;
 
       const { value: documents } = await this.crmService.getSharepointFolderFiles(`dcp_package/${folderIdentifier}`);
 


### PR DESCRIPTION
### Summary
After Sprint 10, it sounds like Microsoft consultants are moving towards just using the raw `dcp_name` property to create the Sharepoint Folder name. Waiting for confirmation.

#### Task/Bug Number
Fixes [AB#12715](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/12715)

### Technical Details
  - After Sprint 10 CRM enhancements, App Portal should no longer need to remove spaces and dashes from `dcp_name`
  - We are removing the apostrophe replacement because after Sprint 10 CRM enhancements, the raw `dcp_name` value should be used to generate the sharepoint folder name.
  - We are removing the special character replacement (`.replace(/^\~|\#|\%|\&|\*|\{|\}|\\|\:|\<|\>|\?|\/|\||\"/g, '');`) because supposedly there should no longer be any special characters in package names. The `dcp_name` property is now auto generated. The user selects the "package type" portion of `dcp_name` from a constrained dropdown. None of the options have special characters. @allthesignals  I remember you had implemented the special character removal in response to a user-reported issue. Do you remember the situation? Do you see any issue with deleting the special character removal? 

--- 

**Update: ** I have manually tested and verified things are working as expected for Draft Land Use revisions, transfer to Filed Land use, and Filed land use revisions