### PR TITLE
13386 Add CEQR to DSOW show page

### DIFF
--- a/client/app/components/packages/filed-eas/show.hbs
+++ b/client/app/components/packages/filed-eas/show.hbs
@@ -44,11 +44,8 @@
           <saveableForm.Section
           @title="Ceqr Invoice Questionnaire" 
           @elementId="ceqr-invoice-questionnaire"
+          data-test-ceqr-invoice-questionnaire
           >
-            <saveableForm.SaveableForm
-              @model={{ceqrInvoiceQuestionnaire}}
-               @validators={{array (hash) (hash)}} 
-            >
             <Ui::Answer @beside={{true}} as |A|>
               <A.Prompt>
                 Is the sole applicant a government agency (City, State, or Federal)?
@@ -97,7 +94,6 @@
               </Ui::Answer>
             {{/if}}
           {{/if}}
-          </saveableForm.SaveableForm>
           </saveableForm.Section>
         {{/let}}
       {{/if}}
@@ -131,8 +127,7 @@
 
   <div class="cell large-4 sticky-sidebar">
     <Messages::Assistance class="large-margin-top" />
-      <saveableForm.PageNav>
-      </saveableForm.PageNav>
+    <saveableForm.PageNav />
   </div>
 </div>
 </SaveableForm>

--- a/client/app/components/packages/filed-eas/show.hbs
+++ b/client/app/components/packages/filed-eas/show.hbs
@@ -42,9 +42,9 @@
       {{#if (gte saveableForm.data.ceqrInvoiceQuestionnaires.length 1)}}
         {{#let saveableForm.data.singleCeqrInvoiceQuestionnaire as |ceqrInvoiceQuestionnaire|}}
           <saveableForm.Section
-          @title="Ceqr Invoice Questionnaire" 
-          @elementId="ceqr-invoice-questionnaire"
-          data-test-ceqr-invoice-questionnaire
+            @title="Ceqr Invoice Questionnaire" 
+            @elementId="ceqr-invoice-questionnaire"
+            data-test-ceqr-invoice-questionnaire
           >
             <Ui::Answer @beside={{true}} as |A|>
               <A.Prompt>

--- a/client/app/components/packages/scope-of-work-draft/show.hbs
+++ b/client/app/components/packages/scope-of-work-draft/show.hbs
@@ -44,10 +44,8 @@
             <saveableForm.Section
               @title="Ceqr Invoice Questionnaire" 
               @elementId="ceqr-invoice-questionnaire"
+              data-test-ceqr-invoice-questionnaire
             >
-              <saveableForm.SaveableForm
-                @model={{ceqrInvoiceQuestionnaire}}
-              >
                 <Ui::Answer @beside={{true}} as |A|>
                   <A.Prompt>
                     Is the sole applicant a government agency (City, State, or Federal)?
@@ -96,7 +94,6 @@
                   </Ui::Answer>
                 {{/if}}
               {{/if}}
-             </saveableForm.SaveableForm>
             </saveableForm.Section>
           {{/let}}
         {{/if}}

--- a/client/app/components/packages/scope-of-work-draft/show.hbs
+++ b/client/app/components/packages/scope-of-work-draft/show.hbs
@@ -42,12 +42,11 @@
       {{#if (gte saveableForm.data.ceqrInvoiceQuestionnaires.length 1)}}
           {{#let saveableForm.data.singleCeqrInvoiceQuestionnaire as |ceqrInvoiceQuestionnaire|}}
             <saveableForm.Section
-            @title="Ceqr Invoice Questionnaire" 
-            @elementId="ceqr-invoice-questionnaire"
+              @title="Ceqr Invoice Questionnaire" 
+              @elementId="ceqr-invoice-questionnaire"
             >
               <saveableForm.SaveableForm
                 @model={{ceqrInvoiceQuestionnaire}}
-                @validators={{array (hash) (hash)}} 
               >
                 <Ui::Answer @beside={{true}} as |A|>
                   <A.Prompt>
@@ -131,8 +130,7 @@
 
     <div class="cell large-4 sticky-sidebar">
       <Messages::Assistance class="large-margin-top" />
-      <saveableForm.PageNav>
-      </saveableForm.PageNav>
+      <saveableForm.PageNav />
     </div>
   </div>
 </SaveableForm>

--- a/client/app/components/packages/scope-of-work-draft/show.hbs
+++ b/client/app/components/packages/scope-of-work-draft/show.hbs
@@ -1,71 +1,139 @@
-<div class="grid-x grid-margin-x">
-  <div class="cell large-8">
-    <section class="form-section">
-      <h1 class="header-large">
-        Draft Scope of Work (DSOW) Information Confirmation
-        <small
-          class="text-weight-normal"
-          data-test-package-dcpPackageversion
+<SaveableForm 
+  @model={{@package}}
+  @validators={{array (hash) (hash)}} 
+  as |saveableForm|
+>
+
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-8">
+      <section class="form-section">
+        <h1 class="header-large">
+          Draft Scope of Work (DSOW) Information Confirmation
+          <small
+            class="text-weight-normal"
+            data-test-package-dcpPackageversion
+          >
+            {{if @package.dcpPackageversion (concat '(V' @package.dcpPackageversion ')')}}
+          </small>
+        </h1>
+
+        <h2 class="no-margin"
+          data-test-project-dcpProjectname
         >
-          {{if @package.dcpPackageversion (concat '(V' @package.dcpPackageversion ')')}}
-        </small>
-      </h1>
+          {{@package.project.dcpProjectname}}
+          <small
+            class="text-weight-normal"
+            data-test-project-dcpName
+          >
+            {{if @package.project.dcpName (concat '(' @package.project.dcpName ')')}}
+          </small>
+        </h2>
 
-      <h2 class="no-margin"
-        data-test-project-dcpProjectname
-      >
-        {{@package.project.dcpProjectname}}
-        <small
-          class="text-weight-normal"
-          data-test-project-dcpName
+        <p
+          class="text-large text-dark-gray"
+          data-test-project-dcpBorough
+          data-test-package-statuscode
         >
-          {{if @package.project.dcpName (concat '(' @package.project.dcpName ')')}}
-        </small>
-      </h2>
+          {{optionset 'bbl' 'boroughs' 'label' @package.project.dcpBorough}} |
+          {{optionset 'package' 'statuscode' 'label' @package.statuscode}}
+        </p>
+      </section>
 
-      <p
-        class="text-large text-dark-gray"
-        data-test-project-dcpBorough
-        data-test-package-statuscode
-      >
-        {{optionset 'bbl' 'boroughs' 'label' @package.project.dcpBorough}} |
-        {{optionset 'package' 'statuscode' 'label' @package.statuscode}}
-      </p>
-    </section>
-
-    <section class="form-section"
-      data-test-attached-documents
-    >
-      <h2 class="section-header">
-        <span id="attachments" class="section-anchor"></span>
-        Attached Documents
-      </h2>
-
-      <ul class="no-bullet">
-        {{#each @package.documents as |document idx|}}
-          <li class="ruled-adjacent tight">
-            <a
-              href={{concat (get-env-variable 'host') '/documents' document.serverRelativeUrl}}
-              target="_blank"
-              rel="noopener noreferrer"
-              data-test-document-name={{idx}}
+      {{#if (gte saveableForm.data.ceqrInvoiceQuestionnaires.length 1)}}
+          {{#let saveableForm.data.singleCeqrInvoiceQuestionnaire as |ceqrInvoiceQuestionnaire|}}
+            <saveableForm.Section
+            @title="Ceqr Invoice Questionnaire" 
+            @elementId="ceqr-invoice-questionnaire"
             >
-              <strong>
-                {{document.name}}
-              </strong>
-            </a>
-            <small class="text-gray">
-              {{document.timeCreated}}
-            </small>
-          </li>
-        {{/each}}
-      </ul>
-    </section>
-  </div>
+              <saveableForm.SaveableForm
+                @model={{ceqrInvoiceQuestionnaire}}
+                @validators={{array (hash) (hash)}} 
+              >
+                <Ui::Answer @beside={{true}} as |A|>
+                  <A.Prompt>
+                    Is the sole applicant a government agency (City, State, or Federal)?
+                  </A.Prompt>
+                  <A.Field>
+                    {{optionset 'ceqrInvoiceQuestionnaire' 'dcpIsthesoleaapplicantagovtagency' 'label' ceqrInvoiceQuestionnaire.dcpIsthesoleaapplicantagovtagency}}
+                  </A.Field>
+                </Ui::Answer>
 
-  <div class="cell large-4 sticky-sidebar">
-    <Messages::Assistance class="large-margin-top" />
-  </div>
-</div>
+                {{#if (eq ceqrInvoiceQuestionnaire.dcpIsthesoleaapplicantagovtagency (optionset 'ceqrInvoiceQuestionnaire' 'dcpIsthesoleaapplicantagovtagency' 'code' 'NO'))}}
+                  <Ui::Answer @beside={{true}} as |A|>
+                    <A.Prompt>
+                      Does your project solely consist of action(s) that are not measureable by sq. ft.?
+                    </A.Prompt>
+                    <A.Field>
+                      {{optionset 'ceqrInvoiceQuestionnaire' 'dcpProjectspolelyconsistactionsnotmeasurable' 'label' ceqrInvoiceQuestionnaire.dcpProjectspolelyconsistactionsnotmeasurable}}
+                    </A.Field>
+                  </Ui::Answer>
 
+                {{#if (eq ceqrInvoiceQuestionnaire.dcpProjectspolelyconsistactionsnotmeasurable (optionset 'ceqrInvoiceQuestionnaire' 'dcpProjectspolelyconsistactionsnotmeasurable' 'code' 'NO'))}}
+                  <Ui::Answer @beside={{true}} as |A|>
+                    <A.Prompt>
+                      What is the Square Footage of the Total Project?
+                    </A.Prompt>
+                    <A.Field>
+                    {{optionset 'ceqrInvoiceQuestionnaire' 'dcpSquarefeet' 'label' ceqrInvoiceQuestionnaire.dcpSquarefeet}}
+                    </A.Field>
+                  </Ui::Answer>
+
+                  <Ui::Answer @beside={{true}} as |A|>
+                    <A.Prompt>
+                      Does the project consist solely of modification actions that are not subject to 197c? 
+                    </A.Prompt>
+                    <A.Field>
+                      {{optionset 'ceqrInvoiceQuestionnaire' 'dcpProjectmodificationtoapreviousapproval' 'label' ceqrInvoiceQuestionnaire.dcpProjectmodificationtoapreviousapproval}}
+                    </A.Field>
+                  </Ui::Answer>
+
+                  <Ui::Answer @beside={{true}} as |A|>
+                    <A.Prompt>
+                      Does your project produce a need for a CEQR Restrictive Declaration? 
+                    </A.Prompt>
+                    <A.Field>
+                    {{optionset 'ceqrInvoiceQuestionnaire' 'dcpRespectivedecrequired' 'label' ceqrInvoiceQuestionnaire.dcpRespectivedecrequired}}
+                    </A.Field>
+                  </Ui::Answer>
+                {{/if}}
+              {{/if}}
+             </saveableForm.SaveableForm>
+            </saveableForm.Section>
+          {{/let}}
+        {{/if}}
+        
+      <saveableForm.Section
+        @title="Attached Documents" 
+        @elementId="attachments"
+        data-test-attached-documents
+      >
+        <ul class="no-bullet">
+          {{#each @package.documents as |document idx|}}
+            <li class="ruled-adjacent tight">
+              <a
+                href={{concat (get-env-variable 'host') '/documents' document.serverRelativeUrl}}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-test-document-name={{idx}}
+              >
+                <strong>
+                  {{document.name}}
+                </strong>
+              </a>
+              <small class="text-gray">
+                {{document.timeCreated}}
+              </small>
+            </li>
+          {{/each}}
+        </ul>
+      </saveableForm.Section>
+    </div>
+
+    <div class="cell large-4 sticky-sidebar">
+      <Messages::Assistance class="large-margin-top" />
+      <saveableForm.PageNav>
+      </saveableForm.PageNav>
+    </div>
+  </div>
+</SaveableForm>
 {{yield}}

--- a/client/tests/acceptance/user-can-edit-filed-eas-test.js
+++ b/client/tests/acceptance/user-can-edit-filed-eas-test.js
@@ -128,6 +128,18 @@ module('Acceptance | user can edit Filed EAS Packages', function (hooks) {
     assert.dom('[data-test-attached-documents]').exists();
   });
 
+  test('User sees CEQR on the Filed EAS Show page', async function (assert) {
+    this.server.create('project', {
+      packages: [
+        this.server.create('package', 'toDo', 'scopeOfWorkDraft'),
+      ],
+    });
+
+    await visit('/scope-of-work-draft/1');
+
+    assert.dom('[data-test-ceqr-invoice-questionnaire]').exists();
+  });
+
   test('User sees Attached Documents on the Filed EAS Show page', async function (assert) {
     this.server.create('project', {
       packages: [

--- a/client/tests/acceptance/user-can-edit-scope-of-work-draft-test.js
+++ b/client/tests/acceptance/user-can-edit-scope-of-work-draft-test.js
@@ -127,6 +127,18 @@ module('Acceptance | user can edit Draft SOW Packages', function (hooks) {
     assert.dom('[data-test-attached-documents]').exists();
   });
 
+  test('User sees CEQR on the Draft SOW Show page', async function (assert) {
+    this.server.create('project', {
+      packages: [
+        this.server.create('package', 'toDo', 'scopeOfWorkDraft'),
+      ],
+    });
+
+    await visit('/scope-of-work-draft/1');
+
+    assert.dom('[data-test-ceqr-invoice-questionnaire]').exists();
+  });
+
   test('User sees Attached Documents on the Draft SOW Show page', async function (assert) {
     this.server.create('project', {
       packages: [


### PR DESCRIPTION
### Summary
13386 Display the CEQR Questionnaire on the submitted DSOW form

#### Task/Bug Number
[Fixes AB#13386](https://dcp-paperless.visualstudio.com/ZAP%20Portals/_workitems/edit/13386)

### Technical Explanation
Add CEQR section in show.hbs based on edit.hbs. Also add SaveableForm to enable dynamic nav on the right. Similar to #895 