### PR TITLE
13515: update subtotal value on ceqr invoice questionnaire based on square footage value

### DIFF
--- a/client/app/components/packages/ceqr-invoice-questionnaire.hbs
+++ b/client/app/components/packages/ceqr-invoice-questionnaire.hbs
@@ -50,6 +50,7 @@
               @options={{map-by 'code' (optionset 'ceqrInvoiceQuestionnaire' 'dcpSquarefeet' 'list')}}
               @selected={{form.data.dcpSquarefeet}}
               @onChange={{fn (mut form.data.dcpSquarefeet)}}
+              @onClose={{fn (mut form.data.dcpSubtotal) (square-footage-to-subtotal form.data.dcpSquarefeet)}}
               as |dcpSquarefeet|
             >
               {{optionset 'ceqrInvoiceQuestionnaire' 'dcpSquarefeet' 'label' dcpSquarefeet}}

--- a/client/app/helpers/square-footage-to-subtotal.js
+++ b/client/app/helpers/square-footage-to-subtotal.js
@@ -1,0 +1,25 @@
+import { helper } from '@ember/component/helper';
+import { optionset } from './optionset';
+
+export function sfOptionset(label) {
+  return optionset(['ceqrInvoiceQuestionnaire', 'dcpSquarefeet', 'code', label]);
+}
+
+export const squareFootageToSubtotalLookup = [
+  { squareFeet: sfOptionset('less than 10,000 square feet'), subTotal: 460 },
+  { squareFeet: sfOptionset('10,000 to 19,999'), subTotal: 1350 },
+  { squareFeet: sfOptionset('20,000 to 39,999'), subTotal: 2940 },
+  { squareFeet: sfOptionset('40,000 to 59,999'), subTotal: 5465 },
+  { squareFeet: sfOptionset('60,000 to 79,999'), subTotal: 8195 },
+  { squareFeet: sfOptionset('80,000 to 99,999'), subTotal: 13660 },
+  { squareFeet: sfOptionset('100,000 to 149,999'), subTotal: 27325 },
+  { squareFeet: sfOptionset('150,000 to 199,999'), subTotal: 47815 },
+  { squareFeet: sfOptionset('200,000 to 299,999'), subTotal: 71415 },
+  { squareFeet: sfOptionset('300,000 to 499,999'), subTotal: 128545 },
+  { squareFeet: sfOptionset('500,000 to 1,000,000'), subTotal: 192820 },
+  { squareFeet: sfOptionset('over 1,000,000 square feet'), subTotal: 314225 },
+];
+
+export default helper(function squareFootageToSubtotal([squareFootageValue]) {
+  return squareFootageToSubtotalLookup.find((lookup) => lookup.squareFeet === squareFootageValue).subTotal;
+});

--- a/client/app/models/ceqr-invoice-questionnaire.js
+++ b/client/app/models/ceqr-invoice-questionnaire.js
@@ -21,4 +21,7 @@ export default class CeqrInvoiceQuestionnaireModel extends Model {
 
   @attr()
   dcpRespectivedecrequired;
+
+  @attr()
+  dcpSubtotal;
 }

--- a/client/tests/integration/helpers/square-footage-to-subtotal-test.js
+++ b/client/tests/integration/helpers/square-footage-to-subtotal-test.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | square-footage-to-subtotal-lookup', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    this.set('inputValue', 717170001);
+
+    await render(hbs`{{square-footage-to-subtotal inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), 460);
+  });
+});

--- a/server/src/packages/ceqr-invoice-questionnaires/ceqr-invoice-questionnaires.attrs.ts
+++ b/server/src/packages/ceqr-invoice-questionnaires/ceqr-invoice-questionnaires.attrs.ts
@@ -4,4 +4,5 @@ export const CEQR_INVOICE_QUESTIONNAIRE_ATTRS = [
   'dcp_squarefeet',
   'dcp_projectmodificationtoapreviousapproval',
   'dcp_respectivedecrequired',
+  'dcp_subtotal',
 ];


### PR DESCRIPTION
### Summary
When a user selects a square footage value range (`dcpSquarefeet`) in the dropdown on the Ceqr Invoice Questionnaire, the subtotal field (`dcpSubtotal`) should be updated based on the square footage value. 

#### Task/Bug Number
Fixes [AB#13515](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13515)

### Technical Explanation
- a function for mutating the `dcpSubtotal` field on the `dcp_ceqrinvoicequestionnaire` entity was added using the `@onClose` tag for the ember-power-select dropdown
- A lookup was needed to set the correct value on `dcpSubtotal` depending on what the user chose for the square footage value. This lookup was stored in a helper called `square-footage-to-subtotal`. This helper employed the use of the `dcpSquarefeet` optionset
