### PR TITLE
13515: update logic for setting subtotal on ceqr-invoice-questionnaire

### DIFF
--- a/client/app/components/packages/ceqr-invoice-questionnaire.hbs
+++ b/client/app/components/packages/ceqr-invoice-questionnaire.hbs
@@ -50,7 +50,7 @@
               @options={{map-by 'code' (optionset 'ceqrInvoiceQuestionnaire' 'dcpSquarefeet' 'list')}}
               @selected={{form.data.dcpSquarefeet}}
               @onChange={{fn (mut form.data.dcpSquarefeet)}}
-              @onClose={{fn (mut form.data.dcpSubtotal) (square-footage-to-subtotal form.data.dcpSquarefeet)}}
+              @onClose={{fn this.setSubtotal (square-footage-to-subtotal form.data.dcpSquarefeet) form.data}}
               as |dcpSquarefeet|
             >
               {{optionset 'ceqrInvoiceQuestionnaire' 'dcpSquarefeet' 'label' dcpSquarefeet}}
@@ -71,6 +71,7 @@
         >
           <RadioGroup
             @options={{optionset 'ceqrInvoiceQuestionnaire' 'dcpProjectmodificationtoapreviousapproval' 'list'}}
+            @onChange={{fn this.setSubtotal (square-footage-to-subtotal form.data.dcpSquarefeet) form.data}}
           />
         </form.Field>
       </Ui::Question>

--- a/client/app/components/packages/ceqr-invoice-questionnaire.js
+++ b/client/app/components/packages/ceqr-invoice-questionnaire.js
@@ -1,0 +1,15 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { optionset } from '../../helpers/optionset';
+
+export default class PackagesCeqrInvoiceQuestionnaireComponent extends Component {
+  @action
+  setSubtotal(subtotalValue, formData) {
+    const { dcpProjectmodificationtoapreviousapproval } = formData;
+    if (dcpProjectmodificationtoapreviousapproval === optionset(['ceqrInvoiceQuestionnaire', 'dcpProjectmodificationtoapreviousapproval', 'code', 'Yes'])) {
+      formData.dcpSubtotal = (subtotalValue * 0.2);
+    } else {
+      formData.dcpSubtotal = subtotalValue;
+    }
+  }
+}


### PR DESCRIPTION
### Summary
Update the logic for setting the subtotal value on the Ceqr Invoice Questionnaire. When a user answers the question "Does the project consist solely of modification actions that are not subject to 197c?" with `No`, the subtotal is set based on the value mapping between square footage and subtotal. When the user answers `Yes` to the above question, the subtotal is 20% of the original value. (e.g. $460 --> $92)

#### Task/Bug Number
Fixes [AB#13515](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13515)

### Technical Explanation
This PR updates the function that is run on the `onClose` tag for the `dcpSquarefeet` dropdown as well as adds a function to the `onChange` tag for the `dcpProjectmodificationtoapreviousapproval` radio buttons. This function sets the `dcpSubtotal` value differently based on whether `dcpProjectmodificationtoapreviousapproval` is set to "Yes" vs. "No"
