### PR TITLE
13527: remove the reformatting of dates into strings for milestones to allow for sorting

### DIFF
--- a/client/app/components/project/milestones/milestone-group-item.hbs
+++ b/client/app/components/project/milestones/milestone-group-item.hbs
@@ -6,14 +6,18 @@
     {{/unless}}
 
     {{#if (eq @status "Not Started")}} 
-      Planned start date: {{@milestone.dcpPlannedstartdate}} <br>
+      Planned start date: <Ui::DateDisplay @date={{@milestone.dcpPlannedstartdate}} @outputFormat="MM/D/YYYY"
+      @errorMessage="Date Unknown" /> <br>
     {{else}}
-      Actual start date: {{@milestone.dcpActualstartdate}}<br>
+      Actual start date: <Ui::DateDisplay @date={{@milestone.dcpActualstartdate}} @outputFormat="MM/D/YYYY"
+      @errorMessage="Date Unknown" /> <br>
     {{/if}}
     {{#if (eq @status "Completed")}} 
-      Actual completion date: {{@milestone.dcpActualenddate}}
+      Actual completion date:  <Ui::DateDisplay @date={{@milestone.dcpActualenddate}} @outputFormat="MM/D/YYYY"
+      @errorMessage="Date Unknown" /> <br>
     {{else}}
-      Planned completion date: {{@milestone.dcpPlannedcompletiondate}}
+      Planned completion date: <Ui::DateDisplay @date={{@milestone.dcpPlannedcompletiondate}} @outputFormat="MM/D/YYYY"
+      @errorMessage="Date Unknown" /> <br>
     {{/if}}
 
     {{#if @milestone.targetDuration}}

--- a/client/app/components/project/milestones/milestone-group.hbs
+++ b/client/app/components/project/milestones/milestone-group.hbs
@@ -26,7 +26,7 @@
       </button>
       {{#if this._showMilestones}}
         <ul class="no-bullet">
-          {{#each @groupedMilestones as |milestone|}}
+          {{#each this.sortedGroupedMilestones as |milestone|}}
             <li>
               <Project::Milestones::MilestoneGroupItem @milestone={{milestone}} @status={{@status}} />
             </li>

--- a/client/app/components/project/milestones/milestone-group.js
+++ b/client/app/components/project/milestones/milestone-group.js
@@ -11,6 +11,14 @@ export default class ProjectMilestonesMilestoneGroupComponent extends Component 
     this._showMilestones = !this._showMilestones;
   }
 
+  get sortedGroupedMilestones() {
+    const { groupedMilestones, status } = this.args;
+    if (status === 'Not Started') {
+      return groupedMilestones.sortBy('dcpPlannedstartdate');
+    // "In Progress" and "Completed" milestones
+    } return groupedMilestones.sortBy('dcpActualstartdate');
+  }
+
   groupsToShow = [
     'Completed',
     'In Progress',

--- a/server/src/projects/projects.attrs.ts
+++ b/server/src/projects/projects.attrs.ts
@@ -11,11 +11,19 @@ export const PROJECT_ATTRS = [
   'dcp_dcp_project_dcp_projectapplicant_Project',
 ];
 
-export const MILESTONE_ATTRS = [
-  'statuscode',
+export const MILESTONE_DATE_ATTRS = [
   'dcp_actualstartdate',
   'dcp_actualenddate',
   'dcp_plannedcompletiondate',
   'dcp_plannedstartdate',
-  '_dcp_milestone_value',
+];
+
+export const MILESTONE_NON_DATE_ATTRS = [
+ 'statuscode',
+ '_dcp_milestone_value',
+]
+
+export const MILESTONE_ATTRS = [
+   ...MILESTONE_DATE_ATTRS,
+   ...MILESTONE_NON_DATE_ATTRS,
 ];

--- a/server/src/projects/projects.service.ts
+++ b/server/src/projects/projects.service.ts
@@ -7,7 +7,7 @@ import { joinLabels as joinInvoiceLabels } from '../invoices/invoices.service';
 import { NycidService } from '../contact/nycid/nycid.service';
 import { CrmService } from '../crm/crm.service';
 import { overwriteCodesWithLabels } from '../_utils/overwrite-codes-with-labels';
-import { MILESTONE_ATTRS } from './projects.attrs';
+import { MILESTONE_ATTRS, MILESTONE_NON_DATE_ATTRS } from './projects.attrs';
 
 const APPLICANT_ACTIVE_STATUS_CODE = 1;
 const PROJECT_ACTIVE_STATE_CODE = 0;
@@ -229,7 +229,10 @@ export class ProjectsService {
 
           ...projectMilestone,
         }));
-      const formattedProjectMilestones = overwriteCodesWithLabels(projectMilestones, [...MILESTONE_ATTRS]);
+
+      // we use MILESTONE_NON_DATE_ATTRS because if we include dates when we reformat below, 
+      // then the dates end up being sent to the frontend as strings, so we exclude them here
+      const formattedProjectMilestones = overwriteCodesWithLabels(projectMilestones, [...MILESTONE_NON_DATE_ATTRS]);
 
       return {
         ...project,


### PR DESCRIPTION
### Summary
Make sure that milestones list on the individual project page are sorted by Planned Start Date for "Not Started" milestones and by Actual Start Date for milestones that are "In Progress" or "Completed"

#### Task/Bug Number
Fixes [AB#13527](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13527)

### Technical Explanation
- Previously we were reformatting all fields from `dcp_projectmilestone` entity. This caused four date fields to be reformatted into strings when sent to the frontend. This PR removes this reformatting so that the dates in the frontend are formatted as dates. We then instead use `date-display` helper to reformat them to strings for display purposes on the template. 
- A new computed property was added called `sortedGroupedMilestones` which sorts the milestones based off of their start date

