### PR TITLE
13570 Fix (number) validations for Proposed Actions

### DIFF
--- a/client/app/components/packages/landuse-form/edit.js
+++ b/client/app/components/packages/landuse-form/edit.js
@@ -12,6 +12,7 @@ import SaveableRelatedActionFormValidations from '../../../validations/saveable-
 import SubmittableRelatedActionFormValidations from '../../../validations/submittable-related-action-form';
 import SaveableSitedatahFormValidations from '../../../validations/saveable-sitedatah-form';
 import SubmittableSitedatahFormValidations from '../../../validations/submittable-sitedatah-form';
+import SaveableLanduseActionFormValidations from '../../../validations/saveable-landuse-action-form';
 import SubmittableLanduseActionFormValidations from '../../../validations/submittable-landuse-action-form';
 import SaveableLanduseGeographyValidations from '../../../validations/saveable-landuse-geography';
 import SubmittableLanduseGeographyValidations from '../../../validations/submittable-landuse-geography';
@@ -34,6 +35,7 @@ export default class LandUseFormComponent extends Component {
     SubmittableRelatedActionFormValidations,
     SaveableSitedatahFormValidations,
     SubmittableSitedatahFormValidations,
+    SaveableLanduseActionFormValidations,
     SubmittableLanduseActionFormValidations,
     SaveableLanduseGeographyValidations,
     SubmittableLanduseGeographyValidations,

--- a/client/app/components/packages/landuse-form/proposed-actions.hbs
+++ b/client/app/components/packages/landuse-form/proposed-actions.hbs
@@ -79,7 +79,7 @@
       {{#each @form.data.landuseActions as |landuseAction|}}
         <form.SaveableForm
           @model={{landuseAction}}
-          @validators={{array (hash) @validations.SaveableLanduseFormValidations @validations.SubmittableLanduseActionFormValidations}}
+          @validators={{array @validations.SaveableLanduseActionFormValidations @validations.SubmittableLanduseActionFormValidations}}
           as |landuseActionForm|
         >
           <Packages::LanduseForm::ProposedActionEditor

--- a/client/app/models/landuse-action.js
+++ b/client/app/models/landuse-action.js
@@ -20,15 +20,20 @@ export default class LanduseActionModel extends Model {
 
   @attr dcpZoningsectionstobemodified;
 
-  @attr dcpNumberofzoninglotsaffected;
+  @attr('number')
+  dcpNumberofzoninglotsaffected;
 
-  @attr dcpSquarefootageofzoninglotsaffected;
+  @attr('number')
+  dcpSquarefootageofzoninglotsaffected;
 
-  @attr dcpSquarefootageoftheproposeddevelopment;
+  @attr('number')
+  dcpSquarefootageoftheproposeddevelopment;
 
-  @attr dcpSquarefootassociatedwithtransferbonus;
+  @attr('number')
+  dcpSquarefootassociatedwithtransferbonus;
 
-  @attr dcpNumberofdu;
+  @attr('number')
+  dcpNumberofdu;
 
   @attr dcpIstheactiontoauthorizeorpermitanopenuse;
 

--- a/client/app/validations/saveable-landuse-action-form.js
+++ b/client/app/validations/saveable-landuse-action-form.js
@@ -37,7 +37,8 @@ export default {
       lte: 100,
       gte: 0,
       allowBlank: true,
-      message: 'Number must be in range ({gte} - {lte})',
+      integer: true,
+      message: 'Number must be a whole number in range ({gte} - {lte})',
     }),
   ],
   dcpSquarefootageoftheproposeddevelopment: [
@@ -45,7 +46,8 @@ export default {
       lte: 2147483647,
       gte: 0,
       allowBlank: true,
-      message: 'Number must be in range ({gte} - {lte})',
+      integer: true,
+      message: 'Number must be a whole number in range ({gte} - {lte})',
     }),
   ],
   dcpSquarefootassociatedwithtransferbonus: [
@@ -53,7 +55,8 @@ export default {
       lte: 2147483647,
       gte: -2147483648,
       allowBlank: true,
-      message: 'Number must be in range ({gte} - {lte})',
+      integer: true,
+      message: 'Number must a whole number in range ({gte} - {lte})',
     }),
   ],
   dcpNumberofdu: [
@@ -61,7 +64,8 @@ export default {
       lte: 10000,
       gte: 0,
       allowBlank: true,
-      message: 'Number must be in range ({gte} - {lte})',
+      integer: true,
+      message: 'Number must be a whole number in range ({gte} - {lte})',
     }),
   ],
   dcpSquarefootageofzoninglotsaffected: [
@@ -69,7 +73,8 @@ export default {
       lte: 2147483647,
       gte: 0,
       allowBlank: true,
-      message: 'Number must be in range ({gte} - {lte})',
+      integer: true,
+      message: 'Number must be a whole number between ({gte} - {lte})',
     }),
   ],
 };


### PR DESCRIPTION
### Summary
- CRM requires 5 of the Proposed Actions fields to be Integers, not strings. Previously they were sent to the backend as strings and yielding an error on Save.
-  The validations for the Proposed Actions form were not set up properly. This PR sets up the validations properly.

#### Task/Bug Number
Fixes [AB#13570](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13570)
