### PR TITLE
13591: update dcpPublicstatus label from Prefiled to Noticed to match CRM

### DIFF
--- a/client/app/models/project.js
+++ b/client/app/models/project.js
@@ -15,7 +15,7 @@ export default class ProjectModel extends Model {
 
   @attr statuscode;
 
-  // e.g. 'Prefiled', 'Filed', 'In Public Review', 'Completed'
+  // e.g. 'Noticed', 'Filed', 'In Public Review', 'Completed'
   @attr dcpPublicstatus;
 
   @attr dcpVisibility;

--- a/client/app/optionsets/project.js
+++ b/client/app/optionsets/project.js
@@ -1,7 +1,7 @@
 export const DCPPUBLICSTATUS = {
-  PREFILED: {
+  NOTICED: {
     code: 717170005,
-    label: 'Prefiled',
+    label: 'Noticed',
   },
   FILED: {
     code: 717170000,


### PR DESCRIPTION
### Summary
There was recently an update in CRM that changed the label for `dcpPublicstatus` from "Prefiled" to "Noticed". This PR implements that change in the app

#### Task/Bug Number
Fixes [AB#13591](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13591)
