### PR TITLE
set maxlength of dcpHowdidyoudeterminethenoactionscenario to 600

### DIFF
--- a/client/app/components/packages/rwcds-form/with-action-no-action.hbs
+++ b/client/app/components/packages/rwcds-form/with-action-no-action.hbs
@@ -70,7 +70,7 @@
               <form.Field
                 @attribute="dcpHowdidyoudeterminethenoactionscenario"
                 @type="text-area"
-                @maxlength="1500"
+                @maxlength="600"
                 id={{Q.questionId}}
               />
             </Ui::Question>

--- a/client/app/validations/saveable-rwcds-form.js
+++ b/client/app/validations/saveable-rwcds-form.js
@@ -74,7 +74,7 @@ export default {
   dcpHowdidyoudeterminethenoactionscenario: [
     validateLength({
       min: 0,
-      max: 1500,
+      max: 600,
       message: 'Text is too long (max {max} characters)',
     }),
   ],

--- a/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
@@ -183,8 +183,8 @@ module('Acceptance | user can click rwcds edit', function(hooks) {
 
     await click('[data-test-radio="dcpExistingconditions"][data-test-radio-option="No"]');
 
-    await fillIn('[data-test-input="dcpHowdidyoudeterminethenoactionscenario"]', exceedMaximum(1500, 'String'));
-    assert.dom('[data-test-validation-message="dcpHowdidyoudeterminethenoactionscenario"').hasText('Text is too long (max 1500 characters)');
+    await fillIn('[data-test-input="dcpHowdidyoudeterminethenoactionscenario"]', exceedMaximum(600, 'String'));
+    assert.dom('[data-test-validation-message="dcpHowdidyoudeterminethenoactionscenario"').hasText('Text is too long (max 600 characters)');
 
     // with-action
     await fillIn('[data-test-input="dcpDescribethewithactionscenario"]', exceedMaximum(1500, 'String'));


### PR DESCRIPTION
Set maxlength of the RWCDS Form's dcpHowdidyoudeterminethenoactionscenario property to 600 to match CRM

#### Task/Bug Number
TBA
