### PR TITLE
13578 Improve Save and Submit UX and implementation 

### DIFF
--- a/client/app/adapters/application.js
+++ b/client/app/adapters/application.js
@@ -1,6 +1,21 @@
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import { inject as service } from '@ember/service';
 import ENV from '../config/environment';
+import PackageModel from '../models/package';
+
+// Taken from
+// https://github.com/emberjs/data/blob/v3.24.0/packages/adapter/addon/-private/utils/serialize-into-hash.js
+function serializeIntoHash(store, modelClass, snapshot, options = { includeId: true }) {
+  const serializer = store.serializerFor(modelClass.modelName);
+
+  if (typeof serializer.serializeIntoHash === 'function') {
+    const data = {};
+    serializer.serializeIntoHash(data, modelClass, snapshot, options);
+    return data;
+  }
+
+  return serializer.serialize(snapshot, options);
+}
 
 export default class ApplicationAdapter extends JSONAPIAdapter {
   @service
@@ -16,5 +31,25 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
     }
 
     return {};
+  }
+
+  // Delete the documents array from Snapshot because
+  // package.documents is read-only.
+  // Discarding it from the update prevents
+  // serialization errors that occur when file upload fails.
+  // When file upload fails, recursive ember-file-upload document objects
+  // are inadvertently placed into the package.documents array.
+  // These recursive objects cannot be serialized, so yield serialization
+  // errors.
+  updateRecord(store, type, snapshot) {
+    if (type === PackageModel) {
+      snapshot.__attributes.documents = [];
+      snapshot._changedAttributes.documents = [];
+    }
+    const data = serializeIntoHash(store, type, snapshot);
+
+    let url = this.buildURL(type.modelName, snapshot.id, snapshot, 'updateRecord');
+
+    return this.ajax(url, 'PATCH', { data });
   }
 }

--- a/client/app/adapters/application.js
+++ b/client/app/adapters/application.js
@@ -1,21 +1,6 @@
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import { inject as service } from '@ember/service';
 import ENV from '../config/environment';
-import PackageModel from '../models/package';
-
-// Taken from
-// https://github.com/emberjs/data/blob/v3.24.0/packages/adapter/addon/-private/utils/serialize-into-hash.js
-function serializeIntoHash(store, modelClass, snapshot, options = { includeId: true }) {
-  const serializer = store.serializerFor(modelClass.modelName);
-
-  if (typeof serializer.serializeIntoHash === 'function') {
-    const data = {};
-    serializer.serializeIntoHash(data, modelClass, snapshot, options);
-    return data;
-  }
-
-  return serializer.serialize(snapshot, options);
-}
 
 export default class ApplicationAdapter extends JSONAPIAdapter {
   @service
@@ -31,25 +16,5 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
     }
 
     return {};
-  }
-
-  // Delete the documents array from Snapshot because
-  // package.documents is read-only.
-  // Discarding it from the update prevents
-  // serialization errors that occur when file upload fails.
-  // When file upload fails, recursive ember-file-upload document objects
-  // are inadvertently placed into the package.documents array.
-  // These recursive objects cannot be serialized, so yield serialization
-  // errors.
-  updateRecord(store, type, snapshot) {
-    if (type === PackageModel) {
-      snapshot.__attributes.documents = [];
-      snapshot._changedAttributes.documents = [];
-    }
-    const data = serializeIntoHash(store, type, snapshot);
-
-    let url = this.buildURL(type.modelName, snapshot.id, snapshot, 'updateRecord');
-
-    return this.ajax(url, 'PATCH', { data });
   }
 }

--- a/client/app/adapters/package.js
+++ b/client/app/adapters/package.js
@@ -1,0 +1,53 @@
+import JSONAPIAdapter from '@ember-data/adapter/json-api';
+import { inject as service } from '@ember/service';
+import ENV from '../config/environment';
+
+// Taken from
+// https://github.com/emberjs/data/blob/v3.24.0/packages/adapter/addon/-private/utils/serialize-into-hash.js
+function serializeIntoHash(store, modelClass, snapshot, options = { includeId: true }) {
+  const serializer = store.serializerFor(modelClass.modelName);
+
+  if (typeof serializer.serializeIntoHash === 'function') {
+    const data = {};
+    serializer.serializeIntoHash(data, modelClass, snapshot, options);
+    return data;
+  }
+
+  return serializer.serialize(snapshot, options);
+}
+
+export default class PackageAdapter extends JSONAPIAdapter {
+  @service
+  session;
+
+  host = ENV.host;
+
+  get headers() {
+    if (this.session.isAuthenticated) {
+      return {
+        Authorization: `Bearer ${this.session.data.authenticated.access_token}`,
+      };
+    }
+
+    return {};
+  }
+
+  // Delete the documents array from Snapshot because
+  // package.documents is read-only.
+  // Discarding it from the update prevents
+  // serialization errors that occur when file upload fails.
+  // When file upload fails, recursive ember-file-upload document objects
+  // are inadvertently placed into the package.documents array.
+  // These recursive objects cannot be serialized, so yield serialization
+  // errors.
+  updateRecord(store, type, snapshot) {
+    snapshot.__attributes.documents = [];
+    snapshot._changedAttributes.documents = [];
+
+    const data = serializeIntoHash(store, type, snapshot);
+
+    let url = this.buildURL(type.modelName, snapshot.id, snapshot, 'updateRecord');
+
+    return this.ajax(url, 'PATCH', { data });
+  }
+}

--- a/client/app/components/packages/deis/deis-error.hbs
+++ b/client/app/components/packages/deis/deis-error.hbs
@@ -1,4 +1,4 @@
-{{#if @package.adapterError}}
+{{#if (or @package.adapterError @package.fileUploadErrors)}}
   <div class="callout alert" data-test-error-saving>
     <h5 class="text-red-dark">
       <FaIcon
@@ -11,6 +11,9 @@
 
     <Errors::List
       @errors={{@package.adapterError.errors}}
+    />
+    <Errors::List
+      @errors={{@package.fileUploadErrors}}
     />
 
     <p class="text-red-dark text-small">

--- a/client/app/components/packages/deis/edit.js
+++ b/client/app/components/packages/deis/edit.js
@@ -24,6 +24,8 @@ export default class PackagesDeisEditComponent extends Component {
   async submitPackage() {
     await this.args.package.submit();
 
-    this.router.transitionTo('deis.show', this.args.package.id);
+    if (!this.args.package.adapterError && !this.args.package.fileUploadErrors) {
+      this.router.transitionTo('deis.show', this.args.package.id);
+    }
   }
 }

--- a/client/app/components/packages/draft-eas/draft-eas-error.hbs
+++ b/client/app/components/packages/draft-eas/draft-eas-error.hbs
@@ -1,4 +1,4 @@
-{{#if @package.adapterError}}
+{{#if (or @package.adapterError @package.fileUploadErrors)}}
   <div class="callout alert" data-test-error-saving>
     <h5 class="text-red-dark">
       <FaIcon
@@ -11,6 +11,9 @@
 
     <Errors::List
       @errors={{@package.adapterError.errors}}
+    />
+    <Errors::List
+      @errors={{@package.fileUploadErrors}}
     />
 
     <p class="text-red-dark text-small">

--- a/client/app/components/packages/draft-eas/edit.js
+++ b/client/app/components/packages/draft-eas/edit.js
@@ -24,6 +24,8 @@ export default class PackagesDraftEasEditComponent extends Component {
   async submitPackage() {
     await this.args.package.submit();
 
-    this.router.transitionTo('draft-eas.show', this.args.package.id);
+    if (!this.args.package.adapterError && !this.args.package.fileUploadErrors) {
+      this.router.transitionTo('draft-eas.show', this.args.package.id);
+    }
   }
 }

--- a/client/app/components/packages/error.hbs
+++ b/client/app/components/packages/error.hbs
@@ -1,4 +1,4 @@
-{{#if @package.adapterError}}
+{{#if (or @package.adapterError @package.fileUploadErrors)}}
   <div class="callout alert" data-test-error-saving>
     <h5 class="text-red-dark">
       <FaIcon
@@ -11,6 +11,9 @@
 
     <Errors::List
       @errors={{@package.adapterError.errors}}
+    />
+    <Errors::List
+      @errors={{@package.fileUploadErrors}}
     />
 
     <p class="text-red-dark text-small">

--- a/client/app/components/packages/feis/edit.js
+++ b/client/app/components/packages/feis/edit.js
@@ -24,6 +24,8 @@ export default class PackagesFeisEditComponent extends Component {
   async submitPackage() {
     await this.args.package.submit();
 
-    this.router.transitionTo('feis.show', this.args.package.id);
+    if (!this.args.package.adapterError && !this.args.package.fileUploadErrors) {
+      this.router.transitionTo('feis.show', this.args.package.id);
+    }
   }
 }

--- a/client/app/components/packages/feis/feis-error.hbs
+++ b/client/app/components/packages/feis/feis-error.hbs
@@ -1,4 +1,4 @@
-{{#if @package.adapterError}}
+{{#if (or @package.adapterError @package.fileUploadErrors)}}
   <div class="callout alert" data-test-error-saving>
     <h5 class="text-red-dark">
       <FaIcon
@@ -11,6 +11,9 @@
 
     <Errors::List
       @errors={{@package.adapterError.errors}}
+    />
+    <Errors::List
+      @errors={{@package.fileUploadErrors}}
     />
 
     <p class="text-red-dark text-small">

--- a/client/app/components/packages/filed-eas/edit.js
+++ b/client/app/components/packages/filed-eas/edit.js
@@ -29,6 +29,8 @@ export default class PackagesFiledEasEditComponent extends Component {
   async submitPackage() {
     await this.args.package.submit();
 
-    this.router.transitionTo('filed-eas.show', this.args.package.id);
+    if (!this.args.package.singleCeqrInvoiceQuestionnaire.adapterError && !this.args.package.adapterError && !this.args.package.fileUploadErrors) {
+      this.router.transitionTo('filed-eas.show', this.args.package.id);
+    }
   }
 }

--- a/client/app/components/packages/filed-eas/filed-eas-error.hbs
+++ b/client/app/components/packages/filed-eas/filed-eas-error.hbs
@@ -1,4 +1,4 @@
-{{#if @package.adapterError}}
+{{#if (or @package.adapterError @package.fileUploadErrors)}}
   <div class="callout alert" data-test-error-saving>
     <h5 class="text-red-dark">
       <FaIcon
@@ -11,6 +11,9 @@
 
     <Errors::List
       @errors={{@package.adapterError.errors}}
+    />
+    <Errors::List
+      @errors={{@package.fileUploadErrors}}
     />
 
     <p class="text-red-dark text-small">

--- a/client/app/components/packages/landuse-form/edit.js
+++ b/client/app/components/packages/landuse-form/edit.js
@@ -80,7 +80,9 @@ export default class LandUseFormComponent extends Component {
   async submitPackage() {
     await this.args.package.submit();
 
-    this.router.transitionTo('landuse-form.show', this.args.package.id);
+    if (!this.landuseForm.adapterError && !this.package.adapterError && !this.package.fileUploadErrors) {
+      this.router.transitionTo('landuse-form.show', this.args.package.id);
+    }
   }
 
   @action

--- a/client/app/components/packages/landuse-form/landuse-form-error.hbs
+++ b/client/app/components/packages/landuse-form/landuse-form-error.hbs
@@ -1,4 +1,4 @@
-{{#if (or @package.landuseForm.adapterError @package.adapterError)}}
+{{#if (or @package.landuseForm.adapterError @package.adapterError @package.fileUploadErrors)}}
   <div class="callout alert" data-test-error-saving>
     <h5 class="text-red-dark">
       <FaIcon
@@ -13,6 +13,9 @@
       />
       <Errors::List
         @errors={{@package.adapterError.errors}}
+      />
+      <Errors::List
+        @errors={{@package.fileUploadErrors}}
       />
       <p class="text-red-dark text-small">
         Please try again. If the problem persists, please contact NYC Planning at <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or <a href="tel:212-720-3300" class="nowrap">212-720-3300</a>.

--- a/client/app/components/packages/pas-form/edit.js
+++ b/client/app/components/packages/pas-form/edit.js
@@ -56,7 +56,9 @@ export default class PasFormComponent extends Component {
   async submitPackage() {
     await this.args.package.submit();
 
-    this.router.transitionTo('pas-form.show', this.args.package.id);
+    if (!this.pasForm.adapterError && !this.package.adapterError && !this.package.fileUploadErrors) {
+      this.router.transitionTo('pas-form.show', this.args.package.id);
+    }
   }
 
   @action

--- a/client/app/components/packages/pas-form/pas-form-error.hbs
+++ b/client/app/components/packages/pas-form/pas-form-error.hbs
@@ -1,4 +1,4 @@
-{{#if (or @package.pasForm.adapterError @package.adapterError)}}
+{{#if (or @package.pasForm.adapterError @package.adapterError @package.fileUploadErrors)}}
   <div class="callout alert" data-test-error-saving>
     <h5 class="text-red-dark">
       <FaIcon
@@ -13,6 +13,9 @@
       />
       <Errors::List
         @errors={{@package.adapterError.errors}}
+      />
+      <Errors::List
+        @errors={{@package.fileUploadErrors}}
       />
       <p class="text-red-dark text-small">
         Please try again. If the problem persists, please contact NYC Planning at <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or <a href="tel:212-720-3300" class="nowrap">212-720-3300</a>.

--- a/client/app/components/packages/rwcds-form/edit.js
+++ b/client/app/components/packages/rwcds-form/edit.js
@@ -17,6 +17,11 @@ export default class PackagesRwcdsFormEditComponent extends Component {
   @service
   router;
 
+  get rwcdsForm() {
+    return this.args.package.rwcdsForm || {};
+  }
+
+
   @action
   async savePackage() {
     try {
@@ -30,6 +35,8 @@ export default class PackagesRwcdsFormEditComponent extends Component {
   async submitPackage() {
     await this.args.package.submit();
 
-    this.router.transitionTo('rwcds-form.show', this.args.package.id);
+    if (!this.rwcdsForm.adapterError && !this.args.package.adapterError && !this.args.package.fileUploadErrors) {
+      this.router.transitionTo('rwcds-form.show', this.args.package.id);
+    }
   }
 }

--- a/client/app/components/packages/rwcds-form/rwcds-form-error.hbs
+++ b/client/app/components/packages/rwcds-form/rwcds-form-error.hbs
@@ -1,4 +1,4 @@
-{{#if (or @package.rwcdsForm.adapterError @package.adapterError)}}
+{{#if (or @package.rwcdsForm.adapterError @package.adapterError @package.fileUploadErrors)}}
   <div class="callout alert" data-test-error-saving>
     <h5 class="text-red-dark">
       <FaIcon
@@ -13,6 +13,9 @@
       />
       <Errors::List
         @errors={{@package.adapterError.errors}}
+      />
+      <Errors::List
+        @errors={{@package.fileUploadErrors}}
       />
       <p class="text-red-dark text-small">
         Please try again. If the problem persists, please contact City Planning at <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or <a href="tel:212-720-3300" class="nowrap">212-720-3300</a>.

--- a/client/app/components/packages/scope-of-work-draft/edit.js
+++ b/client/app/components/packages/scope-of-work-draft/edit.js
@@ -26,6 +26,8 @@ export default class PackagesScopeOfWorkDraftEditComponent extends Component {
   async submitPackage() {
     await this.args.package.submit();
 
-    this.router.transitionTo('scope-of-work-draft.show', this.args.package.id);
+    if (!this.args.package.singleCeqrInvoiceQuestionnaire.adapterError && !this.args.package.adapterError && !this.args.package.fileUploadErrors) {
+      this.router.transitionTo('scope-of-work-draft.show', this.args.package.id);
+    }
   }
 }

--- a/client/app/components/packages/scope-of-work-draft/scope-of-work-draft-error.hbs
+++ b/client/app/components/packages/scope-of-work-draft/scope-of-work-draft-error.hbs
@@ -1,4 +1,4 @@
-{{#if @package.adapterError}}
+{{#if (or @package.adapterError @package.fileUploadErrors)}}
   <div class="callout alert" data-test-error-saving>
     <h5 class="text-red-dark">
       <FaIcon
@@ -11,6 +11,9 @@
 
     <Errors::List
       @errors={{@package.adapterError.errors}}
+    />
+    <Errors::List
+      @errors={{@package.fileUploadErrors}}
     />
 
     <p class="text-red-dark text-small">

--- a/client/app/components/packages/technical-memo/edit.js
+++ b/client/app/components/packages/technical-memo/edit.js
@@ -24,6 +24,8 @@ export default class PackagesTechnicalMemoEditComponent extends Component {
   async submitPackage() {
     await this.args.package.submit();
 
-    this.router.transitionTo('technical-memo.show', this.args.package.id);
+    if (!this.args.package.adapterError && !this.args.package.fileUploadErrors) {
+      this.router.transitionTo('technical-memo.show', this.args.package.id);
+    }
   }
 }

--- a/client/app/components/packages/technical-memo/technical-memo-error.hbs
+++ b/client/app/components/packages/technical-memo/technical-memo-error.hbs
@@ -1,4 +1,4 @@
-{{#if @package.adapterError}}
+{{#if (or @package.adapterError @package.fileUploadErrors)}}
   <div class="callout alert" data-test-error-saving>
     <h5 class="text-red-dark">
       <FaIcon
@@ -11,6 +11,9 @@
 
     <Errors::List
       @errors={{@package.adapterError.errors}}
+    />
+    <Errors::List
+      @errors={{@package.fileUploadErrors}}
     />
 
     <p class="text-red-dark text-small">

--- a/client/app/components/packages/working-package/edit.js
+++ b/client/app/components/packages/working-package/edit.js
@@ -24,6 +24,8 @@ export default class PackagesWorkingPackageEditComponent extends Component {
   async submitPackage() {
     await this.args.package.submit();
 
-    this.router.transitionTo('working-package.show', this.args.package.id);
+    if (!this.args.package.adapterError && !this.args.package.fileUploadErrors) {
+      this.router.transitionTo('working-package.show', this.args.package.id);
+    }
   }
 }

--- a/client/app/models/package.js
+++ b/client/app/models/package.js
@@ -113,13 +113,13 @@ export default class PackageModel extends Model {
       console.log('Error saving a Form or Ceqr Invoice Questionnaire: ', e);
     }
 
+    await super.save();
+
     try {
       await this.fileManager.save();
     } catch (e) {
       console.log('Error saving files: ', e);
     }
-
-    await super.save();
 
     await this.reload();
 

--- a/client/app/models/package.js
+++ b/client/app/models/package.js
@@ -1,5 +1,6 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 import FileManager from '../services/file-manager';
 import {
   STATUSCODE,
@@ -23,6 +24,14 @@ export default class PackageModel extends Model {
       );
     }
   }
+
+  // Since file upload doesn't perform requests through
+  // an Ember Model save() process, it doesn't automatically
+  // hydrate the package.adapterError property. When an error occurs
+  // during upload we have to manually hydrate a custom error property
+  // to trigger the error box displayed to the user.
+  @tracked
+  fileUploadErrors = null;
 
   @service
   session;
@@ -119,6 +128,14 @@ export default class PackageModel extends Model {
       await this.fileManager.save();
     } catch (e) {
       console.log('Error saving files: ', e);
+
+      // See comment on the tracked fileUploadError property
+      // definition above.
+      this.fileUploadErrors = [{
+        code: 'UPLOAD_DOC_FAILED',
+        title: 'Failed to upload documents',
+        detail: 'An error occured while  uploading your documents. Please refresh and retry.',
+      }];
     }
 
     await this.reload();

--- a/client/app/models/package.js
+++ b/client/app/models/package.js
@@ -90,25 +90,35 @@ export default class PackageModel extends Model {
   }
 
   async save(recordsToDelete) {
-    await this.fileManager.save();
-    if (this.dcpPackagetype === DCPPACKAGETYPE.PAS_PACKAGE.code) {
-      await this.saveDeletedRecords(recordsToDelete);
-      await this.pasForm.save();
+    try {
+      if (this.dcpPackagetype === DCPPACKAGETYPE.PAS_PACKAGE.code) {
+        await this.saveDeletedRecords(recordsToDelete);
+        await this.pasForm.save();
+      }
+      if (this.dcpPackagetype === DCPPACKAGETYPE.RWCDS.code) {
+        await this.rwcdsForm.save();
+      }
+      if (this.dcpPackagetype === DCPPACKAGETYPE.DRAFT_LU_PACKAGE.code
+        || this.dcpPackagetype === DCPPACKAGETYPE.FILED_LU_PACKAGE.code) {
+        await this.saveDeletedRecords(recordsToDelete);
+        await this.landuseForm.save();
+      }
+      if (this.dcpPackagetype === DCPPACKAGETYPE.FILED_EAS.code) {
+        await this.saveDirtySingleCeqrInvoiceQuestionnaire();
+      }
+      if (this.dcpPackagetype === DCPPACKAGETYPE.DRAFT_SCOPE_OF_WORK.code) {
+        await this.saveDirtySingleCeqrInvoiceQuestionnaire();
+      }
+    } catch (e) {
+      console.log('Error saving a Form or Ceqr Invoice Questionnaire: ', e);
     }
-    if (this.dcpPackagetype === DCPPACKAGETYPE.RWCDS.code) {
-      await this.rwcdsForm.save();
+
+    try {
+      await this.fileManager.save();
+    } catch (e) {
+      console.log('Error saving files: ', e);
     }
-    if (this.dcpPackagetype === DCPPACKAGETYPE.DRAFT_LU_PACKAGE.code
-      || this.dcpPackagetype === DCPPACKAGETYPE.FILED_LU_PACKAGE.code) {
-      await this.saveDeletedRecords(recordsToDelete);
-      await this.landuseForm.save();
-    }
-    if (this.dcpPackagetype === DCPPACKAGETYPE.FILED_EAS.code) {
-      await this.saveDirtySingleCeqrInvoiceQuestionnaire();
-    }
-    if (this.dcpPackagetype === DCPPACKAGETYPE.DRAFT_SCOPE_OF_WORK.code) {
-      await this.saveDirtySingleCeqrInvoiceQuestionnaire();
-    }
+
     await super.save();
 
     await this.reload();

--- a/client/app/models/package.js
+++ b/client/app/models/package.js
@@ -99,6 +99,8 @@ export default class PackageModel extends Model {
   }
 
   async save(recordsToDelete) {
+    let formAdapterError = false;
+
     try {
       if (this.dcpPackagetype === DCPPACKAGETYPE.PAS_PACKAGE.code) {
         await this.saveDeletedRecords(recordsToDelete);
@@ -120,6 +122,8 @@ export default class PackageModel extends Model {
       }
     } catch (e) {
       console.log('Error saving a Form or Ceqr Invoice Questionnaire: ', e);
+
+      formAdapterError = true;
     }
 
     try {
@@ -142,9 +146,11 @@ export default class PackageModel extends Model {
       }];
     }
 
-    await this.reload();
+    if (!formAdapterError && !this.adapterError && !this.fileUploadErrors) {
+      await this.reload();
 
-    this._synchronizeDocuments();
+      this._synchronizeDocuments();
+    }
   }
 
   get isSingleCeqrInvoiceQuestionnaireDirty() {

--- a/client/app/models/package.js
+++ b/client/app/models/package.js
@@ -122,7 +122,11 @@ export default class PackageModel extends Model {
       console.log('Error saving a Form or Ceqr Invoice Questionnaire: ', e);
     }
 
-    await super.save();
+    try {
+      await super.save();
+    } catch (e) {
+      console.log('Error saving package: ', e);
+    }
 
     try {
       await this.fileManager.save();

--- a/client/mirage/config.js
+++ b/client/mirage/config.js
@@ -31,7 +31,27 @@ export default function() {
   this.get('/logout');
 
   this.get('/packages');
-  this.get('/packages/:id');
+  this.get('/packages/:id', (schema, request) => {
+    const { params: { id } } = request;
+
+    const foundPackage = schema.packages.find(id);
+
+    foundPackage.documents = [
+      {
+        name: 'PAS Form.pdf',
+        timeCreated: '2021-01-09T02:54:28Z',
+        serverRelativeUrl: '/sites/dcppfsuat2/dcp_package/2021Q0246_EIS_1_5C1BCD9B6E23EB11A813001DD8309FA8/testUploadFile3.txt',
+      },
+      {
+        name: 'Action Changes.excel',
+        timeCreated: '2021-01-09T02:07:31Z',
+        serverRelativeUrl: '/sites/dcppfsuat2/dcp_package/2021Q0246_EIS_1_5C1BCD9B6E23EB11A813001DD8309FA8/fake-23.shp',
+      },
+    ];
+
+    return foundPackage;
+  });
+
   this.get('/applicants');
   this.get('/applicants/:id');
   this.patch('/applicants/:id');


### PR DESCRIPTION
The Save and Submit functionality faced a couple problems, which needed to be teased apart:

1.  **The attachments component is adding `filesToUpload` files to the `package.documents` array.** This is likely due to the need to validate the number of documents to upload ( >= 1), but can cause problems if a package is saved and the documents property is serialized. When the user selects files for upload, they are represented as `ember-file-upload` `fileQueue` objects. These complex fileQueue objects are being added to the `package.documents` array alongside our custom document objects (simply consisting of `name`, `timeCreated`, and `relativeUrl` properties). When the `fileQueue` objects are serialized, they error out because these objects are recursive.

    The error yielded is `TypeError: Cannot convert circular structure to JSON`

    For now, this. refactor needs to be handled in another ticket/PR. This PR creates the scaffolding to do so. For starters, it prevents the TypeError by fix #2 below.  

2. **The package model is trying to write to the `documents` property upon being saved.**  This should not be the case because the documents property is read-only. `ember-file-upload` handles the uploading of files (performing PATCH requests to the applicant portal API), while Ember Data handles retrieving the most up-to-date list of package documents from the API (sending GET package requests, which include the documents property).  

    - **FIX:** **This PR prevents the troublesome writing to that property by customizing the Package Adapter's `updateRecord` method.** For Package models, the `updateRecord` method will now empty out the `documents` property in the Snapshot of the Package.
  
      A snapshot is like a frozen image of a model, and is used to help avoid issues with async/promises when serializing models. You can read a little more about snapshots here: https://davidtang.io/2016-02-27-what-are-ember-data-snapshots/
      
      I did try completely `delete`-ing the documents property from the snapshot, but some other opaque part of the Ember Data `save` process still tried to reference the documents property, so would yield an error.
      
3. **Errors to file upload were not displayed to the user because the POST operation is not through Ember Data.** Since the POST requests for file upload are generated by ember-file-upload instead of a `Model.save()`,  any returned server errors are not hydrating/injected into the Package Model's `adapterError` property. The `*-error` handlebars components checks the `adapterError` property on Packages and Forms to determine whether to show an error box to the user.
    - **FIX:**  T**his PR adds a `fileUploadErrors` property to Packages, to mimic the adapterError property.** This fileUploadErrors property specifically tracks server errors yielded from the file upload process. The `*-error` handlebar components for all forms were also updated to check and display errors from this property.
  
      (I did try tracking the adapterErrors property, but that yielded errors. Probably because Ember did not intend for it to be directly set).  
    
4. **A file upload error would stop the form and package from saving.** This was a bad user experience because users were not made aware their upload failed (due to problem #3), and would lose all their entered form information upon closing the window. 
    - **FIX:**  **To better assist the user, this PR ensures that file, form, and package save processes will fail independently, and not affect one another.** This is implemented by wrapping each save process in its own try/catch statement. This way, files will still upload if there is a form error, and vice versa. 
  
      Wrapping each save process in a try/catch had another benefit: it prevented errors from being "hidden" by a previous error. It may be that multiple of the save processes would fail, but only the first one is captured by the outermost try/catch in the `@savePackage` action of the form `edit.js` file.
  
      The consequence of `try/catch`-ing each save is that execution continues, so the save process must take ownership of checking for error before proceeding with further operations. More on this in point #5 and #6. Another unfortunate side effect is the need to place a band-aid patch in mirage, described in #7. 
    
5. **The Submit process relied on an uncaught error to stop submission and page transition. With the previous changes, it meant submission continues despite an error.** This problem revealed itself thanks to our test suite.  The Submit process calls Save, and then calls a page transition. However, previously there were zero try/catch statements in entire Save process. Submission would stop if an error occurred anywhere.  Now that we use try/catch statements around parts of the Save process, submission and page transition will continue even if there are errors.

    - **FIX:**  **This PR ensures that the Submit process checks for package, form and file `adapterError`s before transitioning to the Show page.** On error, the user will stay on the page and can inspect the error box for any errors.
    
6. **Similarly, due to the independent failures, the Save process continued to reload the Package model despite errors.  The model reload would reset the Package and Form adapterError.**

    - **FIX:**  **This PR ensures that the Save process checks for package, form and file `adapterError`s before reloading the Package model and synchronizing the package fileManager to the documents property.**
    

7. For some reason, the `updateRecord` method on the Package Adapter is called in Mirage when performing resource GET. Due to the modification of the Snapshot, it's clearing out the `package.documents` property returned from the Mirage server. When a package is loaded from the mmirage server, it doesn't contain any documents.
    - **TEMPORARY FIX:**  **In `mirage/config.js`, for the `get('/packages/:id')` endpoint, I've assigned a hardcoded array of documents to  `package.documents` to satisfy our tests.**  This will simulate a package GET response from CRM. The document names match that of the documents hardcoded in the Package Factory's `withExistingDocuments` trait. This should be revisited and investigate why updateRecord, which sends data to the server, would affect resource retrieval.