### PR TITLE
771: validation message appears if user includes dashes in phone numbers

### DIFF
--- a/client/app/components/packages/applicant-fieldset.hbs
+++ b/client/app/components/packages/applicant-fieldset.hbs
@@ -115,9 +115,14 @@
 
     <label>
       Phone
+
+      <p class="q-help">
+        No dashes, parentheses, or special characters.
+      </p>
       <form.Field
         @attribute="dcpPhone"
-        type="number"
+        type="text"
+        @maxlength="10"
       />
     </label>
 

--- a/client/app/components/packages/landuse-form/primary-contact.hbs
+++ b/client/app/components/packages/landuse-form/primary-contact.hbs
@@ -22,9 +22,13 @@
         Phone
       </Q.Label>
 
+      <p class="q-help">
+        No dashes, parentheses, or special characters.
+      </p>
+
       <form.Field
         @attribute="dcpContactphone"
-        type="number"
+        type="text"
         @maxlength="10"
         id={{Q.questionId}}
       />

--- a/client/app/validations/saveable-applicant-form.js
+++ b/client/app/validations/saveable-applicant-form.js
@@ -58,6 +58,7 @@ export default {
     }),
     validateFormat({
       type: 'phone',
+      regex: /[0-9]{10}/,
       // Set allowBlank=true so that the validation message
       // only appears after user first types sometihng.
       // This field still indicates it is 'required'

--- a/client/app/validations/saveable-landuse-form.js
+++ b/client/app/validations/saveable-landuse-form.js
@@ -44,6 +44,7 @@ export default {
     }),
     validateFormat({
       type: 'phone',
+      regex: /[0-9]{10}/,
       // Set allowBlank=true so that the validation message
       // only appears after user first types sometihng.
       // This field still indicates it is 'required'

--- a/client/tests/acceptance/pas-form-validation-messages-display-test.js
+++ b/client/tests/acceptance/pas-form-validation-messages-display-test.js
@@ -202,16 +202,12 @@ module('Acceptance | pas form validation messages display', function(hooks) {
     assert.dom('[data-test-validation-message="dcpZipcode"]').doesNotExist();
   });
 
-  test('User cannot fill in letters for Applicant phone number or ZIP on the PAS Form', async function(assert) {
+  test('User cannot fill in letters for Applicant ZIP on the PAS Form', async function(assert) {
     this.server.create('project', 1, 'toDo');
 
     await visit('/pas-form/1/edit');
 
     await click('[data-test-add-applicant-button]');
-
-    await fillIn('[data-test-input="dcpPhone"]', 'asdfg');
-
-    assert.dom('[data-test-input="dcpPhone"]').hasNoValue();
 
     await fillIn('[data-test-input="dcpPhone"]', '2127203300');
 


### PR DESCRIPTION
### Summary
Phone number fields (e.g. `dcpContactphone` on the landuse entity and `dcp_phone` on the applicant entity) are stored as strings in CRM. When the user includes dashes in their phone number entry, the input will not save to the database. Unfortunately, the validation addon that we use stops working when the user includes a dash in the input -- the validation message disappears and the user can then type as many numbers as they want.

In order to avoid this, this PR has:
- added a `regex` field to the validation that matches a 10 digit phone number with only numbers (and no special characters)
- changed the input type of the field to be `text` because for some reason the hyphen issue was only happening when the input type was `number`. This is a drawback because the user can now enter alphabet characters. BUT the validation message will appear and let them know that's not allowed. 

**Note**: Another addon was suggested called `ember-phone-input` but this addon is a little too advanced for our purposes here as it is mainly focused on reformatting based on the country of the phone number. The addon also still allows the user to enter text (which is the drawback of changing the input type to `text` as opposed to `number`), so if we're still having that issue with the addon, we might as well avoid incorporating another addon into the app that we'd have to maintain. 

#### Task/Bug Number
Fixes AB#771
