### PR TITLE
790 Display optionset warning instead of assertion error

### DIFF
--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -200,7 +200,7 @@ export function optionset([model, optionsetId, returnType, lookupToken]) {
       if (option) {
         return option.code;
       }
-      console.assert(false, 'Invalid call to optionset helper: must provide a valid identifier or label to look up a code.'); // eslint-disable-line
+      console.log(`Warning: Unable to lookup code for optionset ${optionsetId} (model is '${model})' using token '${lookupToken}'`); // eslint-disable-line
       break;
     case 'label':
       if (optionById) {
@@ -212,7 +212,7 @@ export function optionset([model, optionsetId, returnType, lookupToken]) {
       if (option) {
         return option.label;
       }
-      console.assert(false, `Invalid call to optionset helper with identifier ${lookupToken}: must provide a valid identifier or code to look up a label.`); // eslint-disable-line
+      console.log(`Warning: Unable to lookup label for optionset ${optionsetId} (model is '${model}) using token '${lookupToken}'`); // eslint-disable-linent-disable-line
       break;
     default:
       return optionset;


### PR DESCRIPTION
Fixes AB#790

Previously, whenever a `null` was passed to an optionset helper, it would throw an alarming red error message in our console, even if it is OK. This PR changes the message to just warnings.

For one optionset, `null` is a valid option. For others, `nulls` are unavoidable simply because a lot of the model properties start as `null`. 

**Before:**
![image](https://user-images.githubusercontent.com/3311663/104540392-3bd25580-55d4-11eb-8590-6697e64d00ee.png)

**Now:** 
![image](https://user-images.githubusercontent.com/3311663/104540345-20674a80-55d4-11eb-821d-fea00ec5de14.png)

![image](https://user-images.githubusercontent.com/3311663/104540360-2826ef00-55d4-11eb-9d98-f7d093fdaeea.png)
