### PR TITLE
768 Remove unnecessary argument to remove* actions in landuseForm *-fieldsets

### DIFF
--- a/client/app/components/packages/applicant-fieldset.hbs
+++ b/client/app/components/packages/applicant-fieldset.hbs
@@ -129,7 +129,7 @@
     <button
       type="button"
       class="delete-fieldset"
-      {{on "click" (fn @removeApplicant @applicant)}}
+      {{on "click" @removeApplicant}}
       data-test-remove-applicant-button
     >
       Remove {{@applicant.friendlyEntityName}}

--- a/client/app/components/packages/landuse-form/proposed-site-characteristics-fieldset.hbs
+++ b/client/app/components/packages/landuse-form/proposed-site-characteristics-fieldset.hbs
@@ -224,7 +224,7 @@
     <button
       type="button"
       class="delete-fieldset"
-      {{on "click" (fn @removeLanduseGeography @landuseGeography)}}
+      {{on "click" @removeLanduseGeography}}
       data-test-remove-landuse-geography-button
     >
       Remove Proposed Site

--- a/client/app/components/packages/landuse-form/subject-sites-fieldset.hbs
+++ b/client/app/components/packages/landuse-form/subject-sites-fieldset.hbs
@@ -257,7 +257,7 @@
     <button
       type="button"
       class="delete-fieldset"
-      {{on "click" (fn @removeSitedatahForm @sitedatahForm)}}
+      {{on "click" @removeSitedatahForm}}
       data-test-remove-sitedatah-form-button
     >
       Remove Subject Site

--- a/client/app/components/packages/landuse-form/zoning-map-amendment-fieldset.hbs
+++ b/client/app/components/packages/landuse-form/zoning-map-amendment-fieldset.hbs
@@ -61,7 +61,7 @@
     <button
       type="button"
       class="delete-fieldset"
-      {{on "click" (fn @removeZoningMapChange form.data)}}
+      {{on "click" @removeZoningMapChange}}
       data-test-remove-zoning-map-change-button
     >
       Delete Zoning Map Change

--- a/client/app/components/packages/landuse-form/zoning-text-amendment-fieldset.hbs
+++ b/client/app/components/packages/landuse-form/zoning-text-amendment-fieldset.hbs
@@ -28,7 +28,7 @@
     <button
       type="button"
       class="delete-fieldset"
-      {{on "click" (fn @removeZrSection @zrSection)}}
+      {{on "click" @removeZrSection}}
       data-test-remove-zr-section-button
     >
       Delete ZR Section

--- a/client/app/components/packages/related-action-fieldset.hbs
+++ b/client/app/components/packages/related-action-fieldset.hbs
@@ -97,7 +97,7 @@
     <button
       type="button"
       class="delete-fieldset"
-      {{on "click" (fn @removeRelatedAction @relatedAction)}}
+      {{on "click" @removeRelatedAction}}
       data-test-remove-related-action-button
     >
       Remove Related Action


### PR DESCRIPTION
The `*-fieldset.hbs` files were passing an unnecessary extra argument to already "fully applied" `@remove*` actions. The remove actions only take two arguments, and parent component of these fieldsets already passed those two arguments.

Fixes AB#768
