### PR TITLE
777: redirect city employees to nyc.id sign-in page regardless of registration status

### DIFF
--- a/client/app/components/auth/sign-in.js
+++ b/client/app/components/auth/sign-in.js
@@ -28,16 +28,22 @@ export default class AuthSignInComponent extends Component {
       isCityEmployee,
     } = await this.args.searchContacts(loginEmail);
 
-    if (isNycidEmailRegistered) {
-      // we can only know email validation after they logged in once.
-      // if it's null, it means we don't know because they've never logged in before (null).
-      if (isNycidValidated === true || isNycidValidated === null) {
-        this.router.transitionTo('auth.login', { queryParams: { loginEmail, isCityEmployee } });
-      } else if (isNycidValidated === false) {
-        this.router.transitionTo('auth.validate', { queryParams: { loginEmail } });
-      }
+    // We should always be redirecting nyc government employees to the NYC.ID login page
+    // (never to the register page) regardless of whether isNycidEmailRegistered is true or false
+    if (isCityEmployee) {
+      this.router.transitionTo('auth.login', { queryParams: { loginEmail, isCityEmployee } });
     } else {
-      this.router.transitionTo('auth.register', { queryParams: { loginEmail } });
+      if (isNycidEmailRegistered) { // eslint-disable-line
+        // we can only know email validation after they logged in once.
+        // if it's null, it means we don't know because they've never logged in before (null).
+        if (isNycidValidated === true || isNycidValidated === null) {
+          this.router.transitionTo('auth.login', { queryParams: { loginEmail } });
+        } else if (isNycidValidated === false) {
+          this.router.transitionTo('auth.validate', { queryParams: { loginEmail } });
+        }
+      } else {
+        this.router.transitionTo('auth.register', { queryParams: { loginEmail } });
+      }
     }
   }
 }

--- a/server/src/contact/nycid/nycid.service.ts
+++ b/server/src/contact/nycid/nycid.service.ts
@@ -29,7 +29,7 @@ export class NycidService {
       // check if the e-mail is validated in nyc.id's system
       ...isNycidValidated,
 
-      is_city_employee: isNycidEmailRegistered && isNycidValidated && email.endsWith('nyc.gov'),
+      is_city_employee: email.endsWith('nyc.gov'),
     };
   }
 


### PR DESCRIPTION
### Summary
If a user is a City Employee they should be redirected to the NYC.ID sign-in page regardless of their NYC ID registration status. This PR updates the rerouting logic to always send City Employees to the sign-in page. 

Just noting some extra information for documentation & research purposes based on email exchange with NYC.ID folks: 

- They confirmed that a city employee will NEVER register on the "register" page that we were originally sending non-registered city employees to. Instead they should always be redirected to the NYC.ID login page where they can select the NYC Employee option button. More information at https://www1.nyc.gov/assets/nyc4d/html/services-nycid/registration.shtml 
- They suggested that we use `GET /account/api/oauth/user.htm` instead of `GET', '/account/api/user.htm` so that we could actually receive information about whether that email existed rather than relying on an "Unauthorized" error. This issue with this is that regardless of whether the city employee's email is registered with NYC.ID or not, we get the same error of `{ accessToken: 'required' }` for both. Whereas when we do not use the `oath` method in the `GET` we're able to differentiate between the two emails' statuses -- with one having an "UnknownEmail" error and the other having an "Unauthorized" error. So while it might still be a workaround, it's better for us to use `GET', '/account/api/user.htm`.

#### Task/Bug Number
Fixes [AB#777](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/777)
