### PR TITLE
825: disallow users to add the same bbl twice

### DIFF
--- a/client/app/components/packages/project-geography.hbs
+++ b/client/app/components/packages/project-geography.hbs
@@ -14,6 +14,14 @@
   </LabsSearch>
 </div>
 
+{{#if this.bblAlreadyCreated}}
+  <div class="callout alert" data-test-error-saving>
+    <h5 class="text-red-dark">
+      The BBL {{this.duplicateBblNumber}} has already been added to this project. Please try again.
+    </h5>
+  </div>
+{{/if}}
+
 {{#if @bbls}}
   <h5 class="slide-in-top">
     Tax Lots Included in This Project

--- a/client/app/components/packages/project-geography.js
+++ b/client/app/components/packages/project-geography.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 import { bblBreakup } from '../../helpers/bbl-breakup';
 import { BOROUGHS } from '../../optionsets/bbl';
 
@@ -19,8 +20,12 @@ export default class ProjectGeographyComponent extends Component {
   @service
   store;
 
+  @tracked bblAlreadyCreated = false;
+
+  @tracked duplicateBblNumber = '';
+
   @action
-  selectSearchResult(labsSearchResult) {
+  async selectSearchResult(labsSearchResult) {
     // `labsSearchResult` is object with `label` (address) and `bbl` attributes.
     // labsSearchResult.bbl comes back as a number,
     // whereas dcpBblnumber in CRM is stored as a string.
@@ -28,26 +33,36 @@ export default class ProjectGeographyComponent extends Component {
 
     const { borough, block, lot } = bblBreakup(currentBbl);
 
-    const bblObjectToPush = this.store.createRecord('bbl', {
-      dcpBblnumber: currentBbl,
-      dcpDevelopmentsite: null,
-      dcpPartiallot: null,
+    // To avoid duplicate bbls
+    const projectBbls = await this.store.findAll('bbl');
+    const duplicateBbls = projectBbls.filter((bbl) => bbl.dcpBblnumber === currentBbl);
 
-      dcpUserinputborough: NUMERIC_BOROUGH_MAPPING[borough],
-      dcpUserinputblock: block,
-      dcpUserinputlot: lot,
+    if (duplicateBbls.length < 1) {
+      this.bblAlreadyCreated = false;
+      const bblObjectToPush = this.store.createRecord('bbl', {
+        dcpBblnumber: currentBbl,
+        dcpDevelopmentsite: null,
+        dcpPartiallot: null,
 
-      project: this.args.project,
-    });
+        dcpUserinputborough: NUMERIC_BOROUGH_MAPPING[borough],
+        dcpUserinputblock: block,
+        dcpUserinputlot: lot,
 
-    // set local variables for displaying address next to bbl in bbls list
-    const currentAddress = labsSearchResult.label;
-    const formattedAddress = currentAddress.replace(', New York, NY, USA', '');
-    bblObjectToPush.temporaryAddressLabel = formattedAddress;
+        project: this.args.project,
+      });
 
-    // use unshiftObect to push to TOP of array
-    // this sorting is so that when a user adds a new bbl, the bbl does not appear at the
-    // bottom of the screen where they will be unable to see it
-    this.args.bbls.unshiftObject(bblObjectToPush);
+      // set local variables for displaying address next to bbl in bbls list
+      const currentAddress = labsSearchResult.label;
+      const formattedAddress = currentAddress.replace(', New York, NY, USA', '');
+      bblObjectToPush.temporaryAddressLabel = formattedAddress;
+
+      // use unshiftObect to push to TOP of array
+      // this sorting is so that when a user adds a new bbl, the bbl does not appear at the
+      // bottom of the screen where they will be unable to see it
+      this.args.bbls.unshiftObject(bblObjectToPush);
+    } else {
+      this.bblAlreadyCreated = true;
+      this.duplicateBblNumber = currentBbl;
+    }
   }
 }


### PR DESCRIPTION
### Summary
Previously, on the Land Use Form for the Project Area Tax Lot section, users were able to add duplicate BBLs. This should not be allowed. This PR makes it so that when a user tries to add a BBL that already exists on the project a warning message is displayed saying "The BBL {bbl number} has already been added to this project. Please try again."

#### Tasks/Bug Numbers
 - Fixes [AB#825](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/825)

### Technical Explanation
- There is an action that is triggered when a user selects an option from the geosearch dropdown for addresses/BBLs. This action uses `store.createRecord` to create new BBLs. If the selected option is a duplicate, this `createRecord` will not run
- Instead, when the user selects an option from the dropdown that already exists in the `store`, two `tracked` properties are updated. `bblAlreadyCreated` is set to `true` for the purpose of displaying the warning message on the template. And `duplicateBblNumber` is set to the value fo the current bbl number, which is displayed in the text of the warning message. 
