### PR TITLE
Point Search API domain to new heroku-based deployment

### DIFF
--- a/client/config/environment.js
+++ b/client/config/environment.js
@@ -31,7 +31,7 @@ module.exports = function(environment) {
     },
 
     'labs-search': {
-      host: 'https://search-api.planninglabs.nyc',
+      host: 'https://search-api-production.herokuapp.com',
       route: 'search',
       helpers: ['geosearch', 'bbl'],
     },

--- a/client/mirage/config.js
+++ b/client/mirage/config.js
@@ -2,7 +2,7 @@ import { Response } from 'ember-cli-mirage';
 import ENV from '../config/environment';
 
 export default function() {
-  this.passthrough('https://search-api.planninglabs.nyc/**');
+  this.passthrough('https://search-api-production.herokuapp.com/**');
   this.passthrough('/account/**');
   // These comments are here to help you get started. Feel free to delete them.
 


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
I redeployed Search API onto Heroku because it was still on Labs-01 Dokku. This PR updates the Search API endpoint to reflect this change.

#### Tasks/Bug Numbers
 - Fixes AB#1234 https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/804/
<!---
Provide a link to a ticket, if applicable
-->
