### PR TITLE
858 fix redirect to /projects on return from nycid

### DIFF
--- a/client/app/routes/auth/sync.js
+++ b/client/app/routes/auth/sync.js
@@ -15,10 +15,10 @@ export default class AuthSyncRoute extends Route {
 
     const contact = await this.store.findRecord('contact', authenticated.contactId);
 
-    if (window.document.referrer.includes('/account/user/profile.htm?returnOnSave=true')) {
+    if (window.document.referrer.includes('nyc.gov')) {
       await contact.save();
-
-      this.transitionTo(to);
     }
+
+    this.transitionTo(to);
   }
 }


### PR DESCRIPTION
### Summary
After a user clicks on the "NYC.ID Profile" button, they are taken to an NYCID-managed page where they can edit their NYCID profile information. 
![image](https://user-images.githubusercontent.com/3311663/110035193-31892980-7cf0-11eb-91c3-f31c17e42be4.png)
If they click "Back" or "Submit" on that page, they are taken back to the root auth route of applicant portal
![image](https://user-images.githubusercontent.com/3311663/110035454-8f1d7600-7cf0-11eb-94a0-dade966c9848.png)
![image](https://user-images.githubusercontent.com/3311663/110035399-79a84c00-7cf0-11eb-83d8-4cd39441ce5f.png)

This is incorrect behavior, and instead it should reroute them to the user's projects page. 

This PR makes sure the correct reroute happens.

#### Tasks/Bug Numbers
 - Fixes [AB#858](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/858)

### Technical Explanation
Previously, in `client/app/routes/auth/sync.js` the model hook assumes if a user returns from NYCID, the `window.document.referrer` value contains the subroute and query parameters when on NYCID (e.g. "/account/user/profile.htm?returnOnSave=true"). However, upon my inspection it only contains the domain ("nyc.gov" or "accounts-nonprd.nyc.gov"). I updated conditional code to rely on the `nyc.gov` value, instead of the original assumed subroute and query params.

I also made sure that a transition (to the specified "to" query param) happens regardless, since there is no visual on the auth/sync route that is helpful to the user. 

<!---
  a. In technical terms, what was wrong, what is the fix, and why does it make things better? 
  b. If you can point to a specific line or file exhibiting the original problem, that would be great!
  c. Provide entrypoint of new solution, if different than (b).
  d. Provide overview of any new architecture.
       - How are components stringed together?
       - What is the new hierarchy? 
       - Any new components?
  e. Provide links and explanations for any new technical concepts, APIs and terms.
      Especially if you had to do some research yourself.
   List any ad-hoc, miscellaneous updates included
-->

### Any other info you think would help a reviewer understand this PR?
