### PR TITLE
1309: update project name input on landuse form to point to dcpSitedataprojectname

### DIFF
--- a/client/app/components/packages/landuse-form/project-information.hbs
+++ b/client/app/components/packages/landuse-form/project-information.hbs
@@ -1,18 +1,12 @@
 {{#let @form as |form|}}
-  <form.SaveableForm
-    @model={{@form.data.package.project}}
-    @validators={{array @validations.SaveableProjectFormValidations @validations.SubmittableProjectFormValidations}}
-    as |projectForm|
-  >
-    <Ui::Question @required={{false}} as |Q|>
-      <Q.Label>
-        Project Name
-      </Q.Label>
+  <Ui::Question @required={{false}} as |Q|>
+    <Q.Label>
+      Project Name
+    </Q.Label>
 
-      <projectForm.Field
-        @attribute="dcpProjectname"
-        id={{Q.questionId}}
-      />
-    </Ui::Question>
-  </form.SaveableForm>
+    <form.Field
+      @attribute="dcpSitedataprojectname"
+      id={{Q.questionId}}
+    />
+  </Ui::Question>
 {{/let}}

--- a/client/app/models/landuse-form.js
+++ b/client/app/models/landuse-form.js
@@ -53,6 +53,8 @@ export default class LanduseFormModel extends Model {
 
   @attr dcpSitedatacommunitydistrict;
 
+  @attr dcpSitedataprojectname;
+
   @attr dcpSitedatazoningsectionnumbers;
 
   @attr dcpSitedataexistingzoningdistrict;

--- a/client/app/validations/saveable-landuse-form.js
+++ b/client/app/validations/saveable-landuse-form.js
@@ -19,6 +19,13 @@ export default {
       message: 'Text is too long (max {max} characters)',
     }),
   ],
+  dcpSitedataprojectname: [
+    validateLength({
+      min: 0,
+      max: 50,
+      message: 'Text is too long (max {max} characters)',
+    }),
+  ],
   dcpContactemail: [
     validateLength({
       min: 0,

--- a/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
@@ -489,11 +489,11 @@ module('Acceptance | user can click landuse form edit', function (hooks) {
     await fillIn('[data-test-input="dcpEmail"]', 'tesster@planning.nyc.gov');
 
     // filling out the project name information
-    await fillIn('[data-test-input="dcpProjectname"]', 'new project name');
+    await fillIn('[data-test-input="dcpSitedataprojectname"]', 'new site data project name');
 
     await click('[data-test-save-button]');
 
-    assert.equal(this.server.db.projects.firstObject.dcpProjectname, 'new project name');
+    assert.equal(this.server.db.landuseForms.firstObject.dcpSitedataprojectname, 'new site data project name');
 
     assert.equal(currentURL(), '/landuse-form/1/edit');
   });


### PR DESCRIPTION
### Summary
Update the Project Name field on the Land Use Form to point to `dcpSitedataprojectname` field on the landuse-form entity rather than the `dcp_projectname` field on the project entity. 

#### Tasks/Bug Numbers
Addresses [AB#1309](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/1309)

### Technical Explanation
The field on the project entity`dcp_projectname` gets automatically updated once the `dcp_sitedataprojectname` on the landuse-form entity is saved in CRM. Therefore Labs would not have to do any "copying over" of the data from one field to another on our end.
