### PR TITLE
Made question appear only when conditions are met

### DIFF
--- a/client/app/components/packages/landuse-form/environmental-review.hbs
+++ b/client/app/components/packages/landuse-form/environmental-review.hbs
@@ -29,9 +29,9 @@
         @attribute="dcpCeqrtype"
         @type="radio-group"
         id={{dcpCeqrtypeQ.questionId}}
-        as |dcpCeqrtypeRadioGroup|
+        as |DcpCeqrtypeRadioGroup|
       >
-        <dcpCeqrtypeRadioGroup
+        <DcpCeqrtypeRadioGroup
           @options={{optionset 'landuseForm' 'dcpCeqrtype' 'list'}}
           @onChange={{fn (mut @form.data.dcpTypecategory) ""}}
           as |dcpCeqrtype|
@@ -52,7 +52,7 @@
               />     
             </Ui::Question>
           {{/if}}
-        </dcpCeqrtypeRadioGroup>
+        </DcpCeqrtypeRadioGroup>
       </form.Field>
     </Ui::Question>
 

--- a/client/app/components/packages/landuse-form/environmental-review.hbs
+++ b/client/app/components/packages/landuse-form/environmental-review.hbs
@@ -19,35 +19,41 @@
     </Ui::Question>
 
     <Ui::Question
-      data-test-ceqr-type-radio-group
-      as |Q|
+      as |dcpCeqrtypeQ|
     >
-      <Q.Label>
+      <dcpCeqrtypeQ.Label>
         What is the CEQR type?
-      </Q.Label>
+      </dcpCeqrtypeQ.Label>
 
       <form.Field
         @attribute="dcpCeqrtype"
         @type="radio-group"
-        id={{Q.questionId}}
-        as |RadioGroup|
+        id={{dcpCeqrtypeQ.questionId}}
+        as |dcpCeqrtypeRadioGroup|
       >
-        <RadioGroup
+        <dcpCeqrtypeRadioGroup
           @options={{optionset 'landuseForm' 'dcpCeqrtype' 'list'}}
-        />
+          @onChange={{fn (mut @form.data.dcpTypecategory) ""}}
+          as |dcpCeqrtype|
+        >
+          {{#if (eq
+            dcpCeqrtype
+            (optionset 'landuseForm' 'dcpCeqrtype' 'code' 'Type II')
+          )}}
+            <Ui::Question as |DcpTypeIICategory|>
+              <DcpTypeIICategory.Label>
+                What is the Type II Category?
+              </DcpTypeIICategory.Label>
+                
+              <form.Field
+                @attribute="dcpTypecategory"
+                @maxlength="100"
+                id={{DcpTypeIICategory.questionId}}
+              />     
+            </Ui::Question>
+          {{/if}}
+        </dcpCeqrtypeRadioGroup>
       </form.Field>
-    </Ui::Question>
-
-    <Ui::Question as |Q|>
-      <Q.Label>
-        What is the Type II Category?
-      </Q.Label>
-        
-      <form.Field
-        @attribute="dcpTypecategory"
-        @maxlength="100"
-        id={{Q.questionId}}
-      />     
     </Ui::Question>
 
   {{!NOTE: "What is the date of determination?" question here}}


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
User is now able to see the "What is the Type II Category " question if and only if he/she selects "Type II" from the "What is the CEQR type?" Question 

#### Tasks/Bug Numbers
 - Fixes [AB#1709](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/1709)


### Technical Explanation


### Any other info you think would help a reviewer understand this PR?
