### PR TITLE
2787 Display submission date for inactive, post-submission packages

### DIFF
--- a/client/app/components/project/package-list-item.hbs
+++ b/client/app/components/project/package-list-item.hbs
@@ -297,7 +297,31 @@
   {{/if}}
   <small class="text-gray">
     {{if (eq @package.statuscode (optionset 'package' 'statuscode' 'code' 'PACKAGE_PREPARATION')) 'Editable since ' 'Submitted '}}
-    <Ui::DateDisplay @date={{@package.dcpStatusdate}} @outputFormat="MM/D/YYYY" @errorMessage="Date Unknown"/>
+
+    {{#if (eq @package.statuscode (optionset 'package' 'statuscode' 'code' 'PACKAGE_PREPARATION'))}}
+      <Ui::DateDisplay @date={{@package.dcpStatusdate}} @outputFormat="MM/D/YYYY" @errorMessage="Date Unknown"/>
+    {{else}}
+      {{#if (eq @package.statecode (optionset 'package' 'statecode' 'code' 'INACTIVE'))}}
+        {{#if (in-array
+          (array
+            (optionset 'package' 'statuscode' 'code' 'SUBMITTED')
+            (optionset 'package' 'statuscode' 'code' 'UNDER_REVIEW')
+            (optionset 'package' 'statuscode' 'code' 'REVIEWED_NO_REVISIONS_REQUIRED')
+            (optionset 'package' 'statuscode' 'code' 'CERTIFIED')
+            (optionset 'package' 'statuscode' 'code' 'REVIEWED_REVISIONS_REQUIRED')
+            (optionset 'package' 'statuscode' 'code' 'FINAL_APPROVAL')
+            (optionset 'package' 'statuscode' 'code' 'WITHDRAWN')
+          )
+          @package.statuscode)
+        }}
+          <Ui::DateDisplay
+            @date={{@package.dcpPackagesubmissiondate}}
+            @outputFormat="MM/D/YYYY"
+            @errorMessage="Date Unknown"
+          />
+        {{/if}}
+      {{/if}}
+    {{/if}}
   </small>
 </li>
 

--- a/client/app/models/package.js
+++ b/client/app/models/package.js
@@ -68,6 +68,9 @@ export default class PackageModel extends Model {
   @attr('date')
   dcpStatusdate;
 
+  @attr('date')
+  dcpPackagesubmissiondate;
+
   @attr('number')
   statecode;
 

--- a/server/src/packages/packages.attrs.ts
+++ b/server/src/packages/packages.attrs.ts
@@ -10,5 +10,6 @@ export const PACKAGE_ATTRS = [
   'dcp_packageid',
   'dcp_name',
   'dcp_statusdate',
+  'dcp_packagesubmissiondate',
   'dcp_packagenotes',
 ];


### PR DESCRIPTION
Fixes [AB#2787](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/2787) 