### PR TITLE
2786 Always display Editable and statusdate for active packages

### DIFF
--- a/client/app/components/project/package-list-item.hbs
+++ b/client/app/components/project/package-list-item.hbs
@@ -296,30 +296,28 @@
     Private
   {{/if}}
   <small class="text-gray">
-    {{if (eq @package.statuscode (optionset 'package' 'statuscode' 'code' 'PACKAGE_PREPARATION')) 'Editable since ' 'Submitted '}}
+    {{#if (eq @package.statecode (optionset 'package' 'statecode' 'code' 'ACTIVE'))}}
+      Editable since <Ui::DateDisplay @date={{@package.dcpStatusdate}} @outputFormat="MM/D/YYYY" @errorMessage="Date Unknown"/>
+    {{/if}}
 
-    {{#if (eq @package.statuscode (optionset 'package' 'statuscode' 'code' 'PACKAGE_PREPARATION'))}}
-      <Ui::DateDisplay @date={{@package.dcpStatusdate}} @outputFormat="MM/D/YYYY" @errorMessage="Date Unknown"/>
-    {{else}}
-      {{#if (eq @package.statecode (optionset 'package' 'statecode' 'code' 'INACTIVE'))}}
-        {{#if (in-array
-          (array
-            (optionset 'package' 'statuscode' 'code' 'SUBMITTED')
-            (optionset 'package' 'statuscode' 'code' 'UNDER_REVIEW')
-            (optionset 'package' 'statuscode' 'code' 'REVIEWED_NO_REVISIONS_REQUIRED')
-            (optionset 'package' 'statuscode' 'code' 'CERTIFIED')
-            (optionset 'package' 'statuscode' 'code' 'REVIEWED_REVISIONS_REQUIRED')
-            (optionset 'package' 'statuscode' 'code' 'FINAL_APPROVAL')
-            (optionset 'package' 'statuscode' 'code' 'WITHDRAWN')
-          )
-          @package.statuscode)
-        }}
-          <Ui::DateDisplay
-            @date={{@package.dcpPackagesubmissiondate}}
-            @outputFormat="MM/D/YYYY"
-            @errorMessage="Date Unknown"
-          />
-        {{/if}}
+    {{#if (eq @package.statecode (optionset 'package' 'statecode' 'code' 'INACTIVE'))}}
+      {{#if (in-array
+        (array
+          (optionset 'package' 'statuscode' 'code' 'SUBMITTED')
+          (optionset 'package' 'statuscode' 'code' 'UNDER_REVIEW')
+          (optionset 'package' 'statuscode' 'code' 'REVIEWED_NO_REVISIONS_REQUIRED')
+          (optionset 'package' 'statuscode' 'code' 'CERTIFIED')
+          (optionset 'package' 'statuscode' 'code' 'REVIEWED_REVISIONS_REQUIRED')
+          (optionset 'package' 'statuscode' 'code' 'FINAL_APPROVAL')
+          (optionset 'package' 'statuscode' 'code' 'WITHDRAWN')
+        )
+        @package.statuscode)
+      }}
+        Submitted <Ui::DateDisplay
+          @date={{@package.dcpPackagesubmissiondate}}
+          @outputFormat="MM/D/YYYY"
+          @errorMessage="Date Unknown"
+        />
       {{/if}}
     {{/if}}
   </small>

--- a/client/tests/integration/components/project/package-list-item-test.js
+++ b/client/tests/integration/components/project/package-list-item-test.js
@@ -18,6 +18,7 @@ module('Integration | Component | project/package-list-item', function(hooks) {
       dcpPackageversion: 1,
       dcpVisibility: 717170002,
       dcpStatusdate: packageDate,
+      statecode: 0,
     });
 
     const store = this.owner.lookup('service:store');


### PR DESCRIPTION
Fixes [AB#2786](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/2786)



┆Issue is synchronized with this [Azure issue](https://dev.azure.com/dcp-paperless/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13812/) by [Unito](https://www.unito.io)
