### PR TITLE
2785 Set up Post Cert LU Package

### DIFF
--- a/client/app/components/project/package-list-item.hbs
+++ b/client/app/components/project/package-list-item.hbs
@@ -60,6 +60,7 @@
   {{#if (or
     (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' 'DRAFT_LU_PACKAGE'))
     (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' 'FILED_LU_PACKAGE'))
+    (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' 'POST_CERT_LU'))
   )}}
     <LinkTo
       @route={{if (eq @package.statuscode (optionset 'package' 'statuscode' 'code' 'PACKAGE_PREPARATION')) 'landuse-form.edit' 'landuse-form.show'}}
@@ -73,6 +74,9 @@
         >
           <FaIcon @icon="edit" />
           <strong>
+            {{#if (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' 'POST_CERT_LU'))}}
+              Post-Cert
+            {{/if}}
             {{#if (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' 'FILED_LU_PACKAGE'))}}
               Filed
             {{/if}}
@@ -87,6 +91,9 @@
         </button>
       {{else}}
         <strong>
+          {{#if (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' 'POST_CERT_LU'))}}
+            Post-Cert
+          {{/if}}
           {{#if (eq @package.dcpPackagetype (optionset 'package' 'dcpPackagetype' 'code' 'FILED_LU_PACKAGE'))}}
             Filed
           {{/if}}

--- a/client/app/models/package.js
+++ b/client/app/models/package.js
@@ -113,7 +113,8 @@ export default class PackageModel extends Model {
         await this.rwcdsForm.save();
       }
       if (this.dcpPackagetype === DCPPACKAGETYPE.DRAFT_LU_PACKAGE.code
-        || this.dcpPackagetype === DCPPACKAGETYPE.FILED_LU_PACKAGE.code) {
+        || this.dcpPackagetype === DCPPACKAGETYPE.FILED_LU_PACKAGE.code
+        || this.dcpPackagetype === DCPPACKAGETYPE.POST_CERT_LU.code) {
         await this.saveDeletedRecords(recordsToDelete);
         await this.landuseForm.save();
       }
@@ -207,7 +208,8 @@ export default class PackageModel extends Model {
         || this.rwcdsForm.isAffectedZoningResolutionsDirty;
     }
     if (this.dcpPackagetype === DCPPACKAGETYPE.DRAFT_LU_PACKAGE.code
-      || this.dcpPackagetype === DCPPACKAGETYPE.FILED_LU_PACKAGE.code) {
+      || this.dcpPackagetype === DCPPACKAGETYPE.FILED_LU_PACKAGE.code
+      || this.dcpPackagetype === DCPPACKAGETYPE.POST_CERT_LU.code) {
       return isPackageDirty
         || this.landuseForm.hasDirtyAttributes
         || this.landuseForm.isBblsDirty

--- a/client/app/models/project.js
+++ b/client/app/models/project.js
@@ -61,6 +61,7 @@ export default class ProjectModel extends Model {
 
   get landusePackages() {
     const landusePackages = [
+      ...this.postCertLUPackages,
       ...this.filedLandusePackages,
       ...this.draftLandusePackages,
     ];
@@ -84,6 +85,13 @@ export default class ProjectModel extends Model {
       .reverse();
 
     return landusePackages;
+  }
+
+  get postCertLUPackages() {
+    return this.packages
+      .filter((projectPackage) => projectPackage.dcpPackagetype === optionset(['package', 'dcpPackagetype', 'code', 'POST_CERT_LU']))
+      .sortBy('dcpPackageversion')
+      .reverse();
   }
 
   get easPackages() {

--- a/client/app/optionsets/package.js
+++ b/client/app/optionsets/package.js
@@ -88,6 +88,10 @@ export const DCPPACKAGETYPE = {
     code: 717170011,
     label: 'Filed LU Package',
   },
+  POST_CERT_LU: {
+    code: 717170015,
+    label: 'Post-Cert LU',
+  },
   DRAFT_EAS: {
     code: 717170002,
     label: 'Draft EAS',

--- a/client/app/templates/landuse-form/edit.hbs
+++ b/client/app/templates/landuse-form/edit.hbs
@@ -5,10 +5,7 @@
     @route='project'
     @model={{@model.package.project.id}}
   />
-  <Crumb @text="{{if (eq @model.package.dcpPackagetype
-      (optionset 'package' 'dcpPackagetype' 'code' 'DRAFT_LU_PACKAGE'))
-      "Draft" "Filed"
-    }} Land Use"
+  <Crumb @text={{optionset 'package' 'dcpPackagetype' 'label' @model.package.dcpPackagetype}}
     @disabled={{true}}
   />
   <Crumb @text="Edit" @current={{true}} />

--- a/client/app/templates/landuse-form/show.hbs
+++ b/client/app/templates/landuse-form/show.hbs
@@ -5,10 +5,7 @@
     @route='project'
     @model={{@model.package.project.id}}
   />
-  <Crumb @text="{{if (eq @model.package.dcpPackagetype
-      (optionset 'package' 'dcpPackagetype' 'code' 'DRAFT_LU_PACKAGE'))
-      "Draft" "Filed"
-    }} Land Use"
+  <Crumb @text={{optionset 'package' 'dcpPackagetype' 'label' @model.package.dcpPackagetype}}
     @disabled={{true}}
   />
 </Ui::Breadcrumbs>

--- a/server/src/packages/packages.service.ts
+++ b/server/src/packages/packages.service.ts
@@ -25,6 +25,10 @@ export const PACKAGE_TYPE_OPTIONSET = {
     code: 717170011,
     label: 'Filed LU Package',
   },
+  POST_CERT_LU: {
+    code: 717170015,
+    label: 'Post-Cert LU',
+  },
   DRAFT_EAS: {
     code: 717170002,
     label: 'Draft EAS',
@@ -142,6 +146,7 @@ export class PackagesService {
         || firstPackage.dcp_packagetype === PACKAGE_TYPE_OPTIONSET['RWCDS'].code
         || firstPackage.dcp_packagetype === PACKAGE_TYPE_OPTIONSET['DRAFT_LU_PACKAGE'].code
         || firstPackage.dcp_packagetype === PACKAGE_TYPE_OPTIONSET['FILED_LU_PACKAGE'].code
+        || firstPackage.dcp_packagetype === PACKAGE_TYPE_OPTIONSET['POST_CERT_LU'].code
       ) {
         formData = await this.fetchPackageForm(firstPackage);
       }
@@ -188,7 +193,8 @@ export class PackagesService {
       }
 
       if (dcpPackage.dcp_packagetype === PACKAGE_TYPE_OPTIONSET['DRAFT_LU_PACKAGE'].code
-      || dcpPackage.dcp_packagetype === PACKAGE_TYPE_OPTIONSET['FILED_LU_PACKAGE'].code) {
+      || dcpPackage.dcp_packagetype === PACKAGE_TYPE_OPTIONSET['FILED_LU_PACKAGE'].code
+      || dcpPackage.dcp_packagetype === PACKAGE_TYPE_OPTIONSET['POST_CERT_LU'].code) {
         return {
           dcp_landuse: await this.landuseFormService.find(dcpPackage._dcp_landuseapplication_value)
         };


### PR DESCRIPTION
Fixes [AB#2785](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/2785)

Follows pattern of Draft and Filed LU packages to set up Post-Cert Land Use Package