### PR TITLE
2784 Applicant Portal LU Form: Update field type for Existing Zoning Districts field under Zoning Map Amendment

### DIFF
--- a/client/app/components/packages/landuse-form/show.hbs
+++ b/client/app/components/packages/landuse-form/show.hbs
@@ -1489,7 +1489,7 @@
                   Existing Zoning District(s)
                 </A.Prompt>
                 <A.Field>
-                  {{zoningMapChange.dcpExistingzoningdistrictvalue}}
+                  {{zoningMapChange.dcpExistingzoningdistrictvaluenew}}
                 </A.Field>
               </Ui::Answer>
 

--- a/client/app/components/packages/landuse-form/zoning-map-amendment-fieldset.hbs
+++ b/client/app/components/packages/landuse-form/zoning-map-amendment-fieldset.hbs
@@ -23,25 +23,17 @@
 
 
     <Ui::Question
-    as |dcpExistingzoningdistrictvalueQ|>
-      <dcpExistingzoningdistrictvalueQ.Label
-        data-test-applicant-state-dropdown
-      >
+    as |dcpExistingzoningdistrictvaluenewQ|>
+      <dcpExistingzoningdistrictvaluenewQ.Label>
         Existing Zoning District(s)
-      </dcpExistingzoningdistrictvalueQ.Label>
+      </dcpExistingzoningdistrictvaluenewQ.Label>
       
-      <label data-test-dcpExistingzoningdistrictvalue-dropdown>
-        <PowerSelect
-          supportsDataTestProperties={{true}}
-          @selected={{form.data.dcpExistingzoningdistrictvalue}}
-          @placeholder="-- select --"
-          @options={{map-by 'code' (optionset 'zoningMapChange' 'dcpExistingzoningdistrictvalue' 'list')}}
-          @onChange={{fn (mut form.data.dcpExistingzoningdistrictvalue)}}
-          @allowClear={{true}}
-        as |dcpExistingzoningdistrictvalue|>
-          {{optionset 'zoningMapChange' 'dcpExistingzoningdistrictvalue' 'label' dcpExistingzoningdistrictvalue}}
-        </PowerSelect>
-      </label>
+      <form.Field
+        @attribute="dcpExistingzoningdistrictvaluenew"
+        @maxlength="30"
+        @showCounter={{true}}
+        id={{dcpExistingzoningdistrictvaluenewQ.id}}
+      />
     </Ui::Question>
 
     <Ui::Question

--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -152,7 +152,7 @@ const OPTIONSET_LOOKUP = {
     dcpIsthesiteimprovedunimprovedorpartlyimp: LANDUSE_GEOGRAPHY_OPTIONSETS.DCPISTHESITEIMPROVEDUNIMPROVEDORPARTLYIMP,
   },
   zoningMapChange: {
-    dcpExistingzoningdistrictvalue: ZONING_MAP_CHANGE_OPTIONSETS.DCPEXISTINGZONINGDISTRICTVALUE,
+    dcpExistingzoningdistrictvaluenew: ZONING_MAP_CHANGE_OPTIONSETS.DCPEXISTINGZONINGDISTRICTVALUE,
   },
   relatedAction: {
     // Actually a boolean field in CRM, not picklist

--- a/client/app/models/zoning-map-change.js
+++ b/client/app/models/zoning-map-change.js
@@ -32,7 +32,7 @@ export default class ZoningMapChangeModel extends Model {
 
   @attr dcpZoningmapchangesid;
 
-  @attr dcpExistingzoningdistrictvalue;
+  @attr dcpExistingzoningdistrictvaluenew;
 
   @attr dcpName;
 }

--- a/client/app/validations/saveable-zoning-map-change.js
+++ b/client/app/validations/saveable-zoning-map-change.js
@@ -17,4 +17,11 @@ export default {
       message: 'Number is too long (max {max} characters)',
     }),
   ],
+  dcpExistingzoningdistrictvaluenew: [
+    validateLength({
+      min: 0,
+      max: 30,
+      message: 'Number is too long (max {max} characters)',
+    }),
+  ],
 };

--- a/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
@@ -1222,7 +1222,11 @@ module('Acceptance | user can click landuse form edit', function (hooks) {
     await fillIn('[data-test-input="dcpZoningsectionmapsnumber"]', 'zoning section num 1234');
     assert.dom('[data-test-validation-message="dcpZoningsectionmapsnumber"]').doesNotExist();
 
-    await selectChoose('[data-test-dcpExistingzoningdistrictvalue-dropdown]', 'R2A');
+    await fillIn('[data-test-input="dcpExistingzoningdistrictvaluenew"]', exceedMaximum(30, 'String'));
+    assert.dom('[data-test-validation-message="dcpExistingzoningdistrictvaluenew"]').exists();
+
+    await fillIn('[data-test-input="dcpExistingzoningdistrictvaluenew"]', 'zoning district R2A');
+    assert.dom('[data-test-validation-message="dcpExistingzoningdistrictvaluenew"]').doesNotExist();
 
     await fillIn('[data-test-input="dcpProposedzoningmapvalue"]', exceedMaximum(100, 'String'));
     assert.dom('[data-test-validation-message="dcpProposedzoningmapvalue"]').exists();
@@ -1234,7 +1238,7 @@ module('Acceptance | user can click landuse form edit', function (hooks) {
 
     assert.equal(this.server.db.landuseForms.firstObject.dcpTotalzoningareatoberezoned, 717170006);
     assert.equal(this.server.db.zoningMapChanges.firstObject.dcpZoningsectionmapsnumber, 'zoning section num 1234');
-    assert.equal(this.server.db.zoningMapChanges.firstObject.dcpExistingzoningdistrictvalue, 717170004);
+    assert.equal(this.server.db.zoningMapChanges.firstObject.dcpExistingzoningdistrictvaluenew, 'zoning district R2A');
     assert.equal(this.server.db.zoningMapChanges.firstObject.dcpProposedzoningmapvalue, 'some zoning map value');
 
     await click('[data-test-remove-zoning-map-change-button]');

--- a/server/src/packages/landuse-form/zoning-map-changes/zoning-map-change.attrs.ts
+++ b/server/src/packages/landuse-form/zoning-map-changes/zoning-map-change.attrs.ts
@@ -13,6 +13,6 @@ export const ZONING_MAP_CHANGE_ATTRS = [
   'dcp_number',
   'utcconversiontimezonecode',
   'dcp_zoningmapchangesid',
-  'dcp_existingzoningdistrictvalue',
+  'dcp_existingzoningdistrictvaluenew',
   'dcp_name',
 ];


### PR DESCRIPTION
Updates variable name and input field to prepare for CRM update.

Closes [AB#2784](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/2784)