### PR TITLE
8204 increase char limit for dcpRwcdsexplanation data field

### DIFF
--- a/client/app/components/packages/rwcds-form/with-action-no-action.hbs
+++ b/client/app/components/packages/rwcds-form/with-action-no-action.hbs
@@ -150,7 +150,7 @@
               <form.Field
                 @attribute="dcpRwcdsexplanation"
                 @type="text-area"
-                @maxlength="50"
+                @maxlength="2400"
                 id={{Q.questionId}}
               />
             </Ui::Question>

--- a/client/app/validations/saveable-rwcds-form.js
+++ b/client/app/validations/saveable-rwcds-form.js
@@ -67,7 +67,7 @@ export default {
   dcpRwcdsexplanation: [
     validateLength({
       min: 0,
-      max: 50,
+      max: 2400,
       message: 'Text is too long (max {max} characters)',
     }),
   ],

--- a/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
@@ -197,7 +197,7 @@ module('Acceptance | user can click rwcds edit', function(hooks) {
 
     assert.dom('[data-test-validation-message="dcpRwcdsexplanation"]').hasText('This field is required');
 
-    await fillIn('[data-test-input="dcpRwcdsexplanation"]', exceedMaximum(50, 'String'));
-    assert.dom('[data-test-validation-message="dcpRwcdsexplanation"').hasText('Text is too long (max 50 characters)');
+    await fillIn('[data-test-input="dcpRwcdsexplanation"]', exceedMaximum(2400, 'String'));
+    assert.dom('[data-test-validation-message="dcpRwcdsexplanation"').hasText('Text is too long (max 2400 characters)');
   });
 });


### PR DESCRIPTION
### Summary
 - update char limit for dcpRwcdsexplanation data field from 50 to 2400 
- update tests to reflect higher char limit
 - update gitignore to include all DS_Store
 - adjust heading in README.md

#### Tasks/Bug Numbers
 - Fixes [AB#8204](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8204)


