### PR TITLE
8205 - increase char limit in dcpProposedprojectdevelopmentdescription field

### DIFF
--- a/client/app/components/packages/rwcds-form/project-description.hbs
+++ b/client/app/components/packages/rwcds-form/project-description.hbs
@@ -42,7 +42,7 @@
       <form.Field
         @type="text-area"
         @attribute="dcpProposedprojectdevelopmentdescription"
-        @maxlength="1800"
+        @maxlength="2400"
         id={{Q.questionId}}
       />
 

--- a/client/app/validations/saveable-rwcds-form.js
+++ b/client/app/validations/saveable-rwcds-form.js
@@ -32,7 +32,7 @@ export default {
   dcpProposedprojectdevelopmentdescription: [
     validateLength({
       min: 0,
-      max: 1800,
+      max: 2400,
       message: 'Text is too long (max {max} characters)',
     }),
   ],

--- a/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
@@ -122,8 +122,8 @@ module('Acceptance | user can click rwcds edit', function(hooks) {
     await fillIn('[data-test-input="dcpProjectsitedescription"]', exceedMaximum(2400, 'String'));
     assert.dom('[data-test-validation-message="dcpProjectsitedescription"').hasText('Text is too long (max 2400 characters)');
 
-    await fillIn('[data-test-input="dcpProposedprojectdevelopmentdescription"]', exceedMaximum(1800, 'String'));
-    assert.dom('[data-test-validation-message="dcpProposedprojectdevelopmentdescription"').hasText('Text is too long (max 1800 characters)');
+    await fillIn('[data-test-input="dcpProposedprojectdevelopmentdescription"]', exceedMaximum(2400, 'String'));
+    assert.dom('[data-test-validation-message="dcpProposedprojectdevelopmentdescription"').hasText('Text is too long (max 2400 characters)');
 
     await fillIn('[data-test-input="dcpBuildyear"]', exceedMaximum(4, 'Number'));
     assert.dom('[data-test-validation-message="dcpBuildyear"').hasText('Number is too long (max 4 characters)');


### PR DESCRIPTION
 ### Summary
- update dcpProposedprojectdevelopmentdescription field from 1800 to 2400 characters
 - update tests with new character limit

#### Tasks/Bug Numbers
 - Fixes [AB#8205](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8205)
