### PR TITLE
8606 increase char limit for the dcpRationalbehindthebuildyear field

### DIFF
--- a/client/app/components/packages/rwcds-form/project-description.hbs
+++ b/client/app/components/packages/rwcds-form/project-description.hbs
@@ -105,7 +105,7 @@
       <form.Field
         @type="text-area"
         @attribute="dcpRationalbehindthebuildyear"
-        @maxlength="300"
+        @maxlength="2400"
         id={{Q.questionId}}
       />
 

--- a/client/app/validations/saveable-rwcds-form.js
+++ b/client/app/validations/saveable-rwcds-form.js
@@ -18,7 +18,7 @@ export default {
   dcpRationalbehindthebuildyear: [
     validateLength({
       min: 0,
-      max: 300,
+      max: 2400,
       message: 'Text is too long (max {max} characters)',
     }),
   ],

--- a/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
@@ -128,8 +128,8 @@ module('Acceptance | user can click rwcds edit', function(hooks) {
     await fillIn('[data-test-input="dcpBuildyear"]', exceedMaximum(4, 'Number'));
     assert.dom('[data-test-validation-message="dcpBuildyear"').hasText('Number is too long (max 4 characters)');
 
-    await fillIn('[data-test-input="dcpRationalbehindthebuildyear"]', exceedMaximum(300, 'String'));
-    assert.dom('[data-test-validation-message="dcpRationalbehindthebuildyear"').hasText('Text is too long (max 300 characters)');
+    await fillIn('[data-test-input="dcpRationalbehindthebuildyear"]', exceedMaximum(2400, 'String'));
+    assert.dom('[data-test-validation-message="dcpRationalbehindthebuildyear"').hasText('Text is too long (max 2400 characters)');
 
     await fillIn('[data-test-input="dcpSitehistory"]', exceedMaximum(600, 'String'));
     assert.dom('[data-test-validation-message="dcpSitehistory"').hasText('Text is too long (max 600 characters)');


### PR DESCRIPTION
 ### Summary
- update dcpRationalbehindthebuildyear field from 300 to 2400 characters
 - update tests with new character limit

#### Tasks/Bug Numbers
- Fixes [AB#8206](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8206)