### PR TITLE
8203 incr char limits for Historic District Name

### DIFF
--- a/client/app/components/packages/landuse-form/project-area.hbs
+++ b/client/app/components/packages/landuse-form/project-area.hbs
@@ -195,7 +195,7 @@
 
                 <form.Field
                   @attribute="dcpSitedatarenewalarea"
-                  @maxlength="60"
+                  @maxlength="100"
                   @showCounter={{true}}
                   id={{dcpSitedatarenewalareaQ.questionId}}
                 />

--- a/client/app/validations/saveable-landuse-form.js
+++ b/client/app/validations/saveable-landuse-form.js
@@ -127,7 +127,7 @@ export default {
   dcpSitedatarenewalarea: [
     validateLength({
       min: 0,
-      max: 60,
+      max: 100,
       message: 'Text is too long (max {max} characters)',
     }),
   ],

--- a/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
@@ -148,6 +148,9 @@ module('Acceptance | user can click landuse form edit', function (hooks) {
 
     assert.dom('[data-test-input="dcpSitedatarenewalarea"]').exists();
 
+    await fillIn('[data-test-input="dcpSitedatarenewalarea"]', exceedMaximum(100, 'String'));
+    assert.dom('[data-test-validation-message="dcpSitedatarenewalarea"]').hasText('Text is too long (max 100 characters)');
+
     assert.equal(currentURL(), '/landuse-form/1/edit');
   });
 


### PR DESCRIPTION
### Summary
 - increased character limit for the dcpSitedatarenewalarea field
 - added test for dcpSitedatarenewalarea input field maximum
 - updated test max char amount

#### Tasks/Bug Numbers
 - Fixes [AB#8203](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8203)