### PR TITLE
8207 increase  char limit for dcpSitehistory input field

### DIFF
--- a/client/app/components/packages/rwcds-form/project-description.hbs
+++ b/client/app/components/packages/rwcds-form/project-description.hbs
@@ -133,7 +133,7 @@
       <form.Field
         @type="text-area"
         @attribute="dcpSitehistory"
-        @maxlength="600"
+        @maxlength="2400"
         id={{Q.questionId}}
       />
 

--- a/client/app/validations/saveable-rwcds-form.js
+++ b/client/app/validations/saveable-rwcds-form.js
@@ -46,7 +46,7 @@ export default {
   dcpSitehistory: [
     validateLength({
       min: 0,
-      max: 600,
+      max: 2400,
       message: 'Text is too long (max {max} characters)',
     }),
   ],

--- a/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
@@ -131,8 +131,8 @@ module('Acceptance | user can click rwcds edit', function(hooks) {
     await fillIn('[data-test-input="dcpRationalbehindthebuildyear"]', exceedMaximum(2400, 'String'));
     assert.dom('[data-test-validation-message="dcpRationalbehindthebuildyear"').hasText('Text is too long (max 2400 characters)');
 
-    await fillIn('[data-test-input="dcpSitehistory"]', exceedMaximum(600, 'String'));
-    assert.dom('[data-test-validation-message="dcpSitehistory"').hasText('Text is too long (max 600 characters)');
+    await fillIn('[data-test-input="dcpSitehistory"]', exceedMaximum(2400, 'String'));
+    assert.dom('[data-test-validation-message="dcpSitehistory"').hasText('Text is too long (max 2400 characters)');
   });
 
   test('Validation messages display for Proposed Actions', async function(assert) {


### PR DESCRIPTION
 ### Summary
 - increased limits for dcpSitehistory input from 600 to 2400 characters, 
 - updated char limits in tests

#### Tasks/Bug Numbers
 - Fixes [AB#8207](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8207)
