### PR TITLE
8208 incr char limits for dcpPurposeandneedfortheproposedaction

### DIFF
--- a/client/app/components/packages/rwcds-form/proposed-project-actions.hbs
+++ b/client/app/components/packages/rwcds-form/proposed-project-actions.hbs
@@ -30,7 +30,7 @@
         <form.Field
           @attribute="dcpPurposeandneedfortheproposedaction"
           @type="text-area"
-          @maxlength="1500"
+          @maxlength="2400"
           id={{Q.questionId}}
         />
       </Ui::Question>

--- a/client/app/validations/saveable-rwcds-form.js
+++ b/client/app/validations/saveable-rwcds-form.js
@@ -53,7 +53,7 @@ export default {
   dcpPurposeandneedfortheproposedaction: [
     validateLength({
       min: 0,
-      max: 1500,
+      max: 2400,
       message: 'Text is too long (max {max} characters)',
     }),
   ],

--- a/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
@@ -152,8 +152,8 @@ module('Acceptance | user can click rwcds edit', function(hooks) {
     await fillIn('[data-test-input="dcpZrsectiontitle"]', exceedMaximum(100, 'String'));
     assert.dom('[data-test-validation-message="dcpZrsectiontitle"]').hasText('Text is too long (max 100 characters)');
 
-    await fillIn('[data-test-input="dcpPurposeandneedfortheproposedaction"]', exceedMaximum(1500, 'String'));
-    assert.dom('[data-test-validation-message="dcpPurposeandneedfortheproposedaction"]').hasText('Text is too long (max 1500 characters)');
+    await fillIn('[data-test-input="dcpPurposeandneedfortheproposedaction"]', exceedMaximum(2400, 'String'));
+    assert.dom('[data-test-validation-message="dcpPurposeandneedfortheproposedaction"]').hasText('Text is too long (max 2400 characters)');
 
     assert.dom('[data-test-validation-message="dcpWhichactionsfromotheragenciesaresought"]').doesNotExist();
     await click('[data-test-radio="dcpIsapplicantseekingaction"][data-test-radio-option="Yes"]');


### PR DESCRIPTION
### Summary
  - increased limits for dcpPurposeandneedfortheproposedaction input field from 1500 - 2400 characters
 - updated char limits in tests

#### Tasks/Bug Numbers
 - Fixes [AB#8208](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8208)
