### PR TITLE
8209 incr char limits for dcpDevelopmentsiteassumptions

### DIFF
--- a/client/app/components/packages/rwcds-form/with-action-no-action.hbs
+++ b/client/app/components/packages/rwcds-form/with-action-no-action.hbs
@@ -8,7 +8,7 @@
       <form.Field
         @attribute="dcpDevelopmentsiteassumptions"
         @type="text-area"
-        @maxlength="2400"
+        @maxlength="4800"
         id={{Q.questionId}}
       />
 

--- a/client/app/validations/saveable-rwcds-form.js
+++ b/client/app/validations/saveable-rwcds-form.js
@@ -102,7 +102,7 @@ export default {
   dcpDevelopmentsiteassumptions: [
     validateLength({
       min: 0,
-      max: 2400,
+      max: 4800,
       message: 'Text is too long (max {max} characters)',
     }),
   ],

--- a/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
@@ -175,8 +175,8 @@ module('Acceptance | user can click rwcds edit', function(hooks) {
     assert.equal(currentURL(), '/rwcds-form/1/edit');
 
     // no-action
-    await fillIn('[data-test-input="dcpDevelopmentsiteassumptions"]', exceedMaximum(2400, 'String'));
-    assert.dom('[data-test-validation-message="dcpDevelopmentsiteassumptions"').hasText('Text is too long (max 2400 characters)');
+    await fillIn('[data-test-input="dcpDevelopmentsiteassumptions"]', exceedMaximum(4800, 'String'));
+    assert.dom('[data-test-validation-message="dcpDevelopmentsiteassumptions"').hasText('Text is too long (max 4800 characters)');
 
     await fillIn('[data-test-input="dcpDescribethenoactionscenario"]', exceedMaximum(1500, 'String'));
     assert.dom('[data-test-validation-message="dcpDescribethenoactionscenario"').hasText('Text is too long (max 1500 characters)');


### PR DESCRIPTION
### Summary
 - increased limits for dcpDevelopmentsiteassumptions input field from 2400 to 4800 characters
 - updated char limits in tests

#### Tasks/Bug Numbers
 - Fixes [AB#8209](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8209)
