### PR TITLE
8202 incr char limits for dcpLotnumberstring 

### DIFF
--- a/client/app/components/packages/landuse-form/subject-sites-fieldset.hbs
+++ b/client/app/components/packages/landuse-form/subject-sites-fieldset.hbs
@@ -66,7 +66,7 @@
 
           <form.Field
             @attribute="dcpLotnumberstring"
-            @maxlength="100"
+            @maxlength="250"
             @showCounter={{true}}
             id={{dcpLotnumberstringQ.id}}
           />

--- a/client/app/validations/saveable-sitedatah-form.js
+++ b/client/app/validations/saveable-sitedatah-form.js
@@ -42,7 +42,7 @@ export default {
   dcpLotnumberstring: [
     validateLength({
       min: 0,
-      max: 20,
+      max: 250,
       message: 'Number is too long (max {max} characters)',
     }),
   ],

--- a/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-landuse-form-edit-test.js
@@ -668,6 +668,9 @@ module('Acceptance | user can click landuse form edit', function (hooks) {
     await click('[data-test-radio="dcpSitetobedisposed"][data-test-radio-option="No"]');
     await fillIn('[data-test-input="dcpProposeduses"]', '12345');
 
+    await fillIn('[data-test-input="dcpLotnumberstring"]', exceedMaximum(250, 'String'));
+    assert.dom('[data-test-validation-message="dcpLotnumberstring"]').hasText('Number is too long (max 250 characters)');
+
     assert.dom('[data-test-save-button]').hasNoAttribute('disabled');
 
     saveForm();


### PR DESCRIPTION
### Summary 
- increased limits for dcpLotnumberstring input field from 100 to 250 characters 
 - updated char limits in validation from 20 to 250
 - add test for validation of char max length

#### Tasks/Bug Numbers
 - Fixes [AB#8202](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8202)
