### PR TITLE
8201 add conditional form field previously approved application number to LU form

### DIFF
--- a/client/app/components/packages/landuse-form/proposed-action-editor.hbs
+++ b/client/app/components/packages/landuse-form/proposed-action-editor.hbs
@@ -212,6 +212,21 @@
       </div>
     </div>
 
+    {{#if this.chosenDcpPreviouslyapprovedactioncode.code}}
+      <Ui::Question as |dcpPreviouslyapprovedapplicationnumbersQ|>
+        <dcpPreviouslyapprovedapplicationnumbersQ.Label>
+          Previously Approved Application Number(s)*
+        </dcpPreviouslyapprovedapplicationnumbersQ.Label>
+
+        <landuseActionForm.Field
+          @attribute="dcpPreviouslyapprovedapplicationnumbers"
+          @showCounter={{true}}
+          @maxlength="100"
+          id={{dcpPreviouslyapprovedapplicationnumbersQ.questionId}}
+        />
+      </Ui::Question>
+    {{/if}}
+
     {{#if this.projectHasRequiredActionsAndFollowUpYes}}
 
       <Ui::Question

--- a/client/app/components/packages/landuse-form/show.hbs
+++ b/client/app/components/packages/landuse-form/show.hbs
@@ -616,6 +616,15 @@
 
               <Ui::Answer @beside={{true}} as |A|>
                 <A.Prompt>
+                  Previously Approved Application Number(s)*
+                </A.Prompt>
+                <A.Field>
+                  {{landuseAction.dcpPreviouslyapprovedapplicationnumbers}}
+                </A.Field>
+              </Ui::Answer>
+
+              <Ui::Answer @beside={{true}} as |A|>
+                <A.Prompt>
                   Date of previous approval
                 </A.Prompt>
                 <A.Field>

--- a/client/app/models/landuse-action.js
+++ b/client/app/models/landuse-action.js
@@ -18,6 +18,8 @@ export default class LanduseActionModel extends Model {
 
   @attr dcpNameofzoningresolutionsection;
 
+  @attr dcpPreviouslyapprovedapplicationnumbers;
+
   @attr dcpZoningsectionstobemodified;
 
   @attr('number')

--- a/client/app/validations/saveable-landuse-action-form.js
+++ b/client/app/validations/saveable-landuse-action-form.js
@@ -11,6 +11,13 @@ export default {
       message: 'Text is too long (max {max} characters)',
     }),
   ],
+  dcpPreviouslyapprovedapplicationnumbers: [
+    validateLength({
+      min: 0,
+      max: 100,
+      message: 'Text is too long (max {max} characters)',
+    }),
+  ],
   dcpZoningsectionstobemodified: [
     validateLength({
       min: 0,

--- a/server/src/packages/landuse-form/landuse-actions/landuse-actions.attrs.ts
+++ b/server/src/packages/landuse-form/landuse-actions/landuse-actions.attrs.ts
@@ -18,4 +18,5 @@ export const LANDUSE_ACTION_ATTRS = [
   'dcp_indicatewhetheractionisamodification',
   'dcp_crfnnumber',
   '_dcp_landuseid_value',
+  'dcp_previouslyapprovedapplicationnumbers',
 ];


### PR DESCRIPTION

### Summary
 - Add the conditional field "Previously Approved Application Number(s)  to the Applicant portal Land Use form under the Proposed Actions section.
 - Display the question as "If this is a follow-up Action, indicate the ULURP or CP number of previous approval"
 - When "If this is a follow-up Action, indicate the previously approved Action Code [dcp_previouslyapprovedactioncode]" (field A) is not Null, display conditional question for dcp_previouslyapprovedapplicationnumbers directly below (field A).
 - The "If this is a follow-up Action, indicate the ULURP or CP number of previous approval" field must be:
  - Text
  - Length: 100
  - Not required
  - Default to null

#### Tasks/Bug Numbers
 - Fixes [AB#8201](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8201)

 - Related [AB#3896](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/3896)

