### PR TITLE
8312 update char limits of Description of No-Action Scenario input

### DIFF
--- a/client/app/components/packages/rwcds-form/with-action-no-action.hbs
+++ b/client/app/components/packages/rwcds-form/with-action-no-action.hbs
@@ -87,7 +87,7 @@
       <form.Field
         @attribute="dcpDescribethenoactionscenario"
         @type="text-area"
-        @maxlength="1500"
+        @maxlength="2400"
         id={{Q.questionId}}
       />
 

--- a/client/app/validations/saveable-rwcds-form.js
+++ b/client/app/validations/saveable-rwcds-form.js
@@ -60,7 +60,7 @@ export default {
   dcpDescribethenoactionscenario: [
     validateLength({
       min: 0,
-      max: 1500,
+      max: 2400,
       message: 'Text is too long (max {max} characters)',
     }),
   ],

--- a/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
@@ -178,8 +178,8 @@ module('Acceptance | user can click rwcds edit', function(hooks) {
     await fillIn('[data-test-input="dcpDevelopmentsiteassumptions"]', exceedMaximum(4800, 'String'));
     assert.dom('[data-test-validation-message="dcpDevelopmentsiteassumptions"').hasText('Text is too long (max 4800 characters)');
 
-    await fillIn('[data-test-input="dcpDescribethenoactionscenario"]', exceedMaximum(1500, 'String'));
-    assert.dom('[data-test-validation-message="dcpDescribethenoactionscenario"').hasText('Text is too long (max 1500 characters)');
+    await fillIn('[data-test-input="dcpDescribethenoactionscenario"]', exceedMaximum(2400, 'String'));
+    assert.dom('[data-test-validation-message="dcpDescribethenoactionscenario"').hasText('Text is too long (max 2400 characters)');
 
     await click('[data-test-radio="dcpExistingconditions"][data-test-radio-option="No"]');
 


### PR DESCRIPTION
### Summary
##### increased character limits of :
 - dcpDescribethenoactionscenario input field
 - input validation 
 - input test
from from 1500 characters to 2400.

#### Tasks/Bug Numbers
 - Fixes [AB#8312](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8312)
 - Related [AB#2240](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/2240)
