### PR TITLE
8307 increase the char limit for the dcpDescribethewithactionscenario input

### DIFF
--- a/client/app/components/packages/rwcds-form/with-action-no-action.hbs
+++ b/client/app/components/packages/rwcds-form/with-action-no-action.hbs
@@ -171,7 +171,7 @@
       <form.Field
         @attribute="dcpDescribethewithactionscenario"
         @type="text-area"
-        @maxlength="1500"
+        @maxlength="2400"
         id={{Q.questionId}}
       />
 

--- a/client/app/validations/saveable-rwcds-form.js
+++ b/client/app/validations/saveable-rwcds-form.js
@@ -11,7 +11,7 @@ export default {
   dcpDescribethewithactionscenario: [
     validateLength({
       min: 0,
-      max: 1500,
+      max: 2400,
       message: 'Text is too long (max {max} characters)',
     }),
   ],

--- a/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
+++ b/client/tests/acceptance/user-can-click-rwcds-form-edit-test.js
@@ -187,8 +187,8 @@ module('Acceptance | user can click rwcds edit', function(hooks) {
     assert.dom('[data-test-validation-message="dcpHowdidyoudeterminethenoactionscenario"').hasText('Text is too long (max 2400 characters)');
 
     // with-action
-    await fillIn('[data-test-input="dcpDescribethewithactionscenario"]', exceedMaximum(1500, 'String'));
-    assert.dom('[data-test-validation-message="dcpDescribethewithactionscenario"').hasText('Text is too long (max 1500 characters)');
+    await fillIn('[data-test-input="dcpDescribethewithactionscenario"]', exceedMaximum(2400, 'String'));
+    assert.dom('[data-test-validation-message="dcpDescribethewithactionscenario"').hasText('Text is too long (max 2400 characters)');
 
     await fillIn('[data-test-input="dcpHowdidyoudeterminethiswithactionscena"]', exceedMaximum(2400, 'String'));
     assert.dom('[data-test-validation-message="dcpHowdidyoudeterminethiswithactionscena"').hasText('Text is too long (max 2400 characters)');


### PR DESCRIPTION
### Summary
increase the char limit from 1500 to 2400 
 - for the dcpDescribethewithactionscenario input 
 - update validation with the new max limit
 - update test with the new max limit

#### Tasks/Bug Numbers
 - Fixes #1042 

 - Related #2244
 