### PR TITLE
8420 added guidance copy to PAS equity form 

### DIFF
--- a/client/app/components/packages/equitable-development-reporting.hbs
+++ b/client/app/components/packages/equitable-development-reporting.hbs
@@ -57,7 +57,17 @@
       <Ui::Question @required={{false}} as |Q|>
         <Q.Legend>
           Increase permitted residential floor area by at least 50,000 square feet
+          <span>
+            <FaIcon @icon="info-circle" @prefix="fas" class="ember-tooltip-target"/>
+            <EmberTooltip @event="hover" @side="right">
+              Proposed change in permitted zoning square feet (residential) in entire project area (includes development site and any other sites affected). To get permitted zoning square feet, multiply area of all sites affected by applicable Floor Area Ratio. Zoning Handbook or Urban Renewal Plan can help with identifying floor area ratio.
+            </EmberTooltip>
+          </span>
         </Q.Legend>
+
+        <p class="q-help">
+          This applies to the change in ZSF permitted (not the CEQR increment, and not limited to the proposed project).
+        </p>
 
         <projectForm.Field
           @attribute="dcpIncreasepermitresatleast50000sf"


### PR DESCRIPTION
### Summary
Add the below text as additional guidance under question “Increase permitted residential floor area by at least 50,000 square feet”
additional copy added in the `equitable-development-reporting.hbs` file

#### Tasks/Bug Numbers
 - Fixes [AB#8420](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8420)

 - Related [AB#8374](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8374)

<img width="825" alt="Screen Shot 2022-05-06 at 5 07 34 PM" src="https://user-images.githubusercontent.com/11340947/167216708-f53e83a4-128d-4a5e-860c-4ad2d88bc745.png">

<img width="922" alt="Screen Shot 2022-05-06 at 5 07 43 PM" src="https://user-images.githubusercontent.com/11340947/167216719-ef011a6a-e225-433a-a979-e33fe3b3cb17.png">


