### PR TITLE
8426 added guidance copy to PAS equity form below non-res fl area 200K

### DIFF
--- a/client/app/components/packages/equitable-development-reporting.hbs
+++ b/client/app/components/packages/equitable-development-reporting.hbs
@@ -74,7 +74,18 @@
       <Ui::Question @required={{false}} as |Q|>
         <Q.Legend>
           Increase permitted non-residential floor area by at least 200,000 square feet
+          <span>
+            <FaIcon @icon="info-circle" @prefix="fas" class="ember-tooltip-target"/>
+            <EmberTooltip @event="hover" @side="right">
+              Proposed change in permitted zoning square feet (residential) in entire project area (includes development site and any other sites affected). To get permitted zoning square feet, multiply area of all sites affected by applicable Floor Area Ratio. Zoning Handbook or Urban Renewal Plan can help with identifying floor area ratio.
+            </EmberTooltip>
+          </span>
         </Q.Legend>
+
+        <p class="q-help">
+          This applies to the change in zoning square feet permitted (not the CEQR increment, and not limited to the proposed project).
+        </p>
+
 
         <projectForm.Field
           @attribute="dcpIncreasepermitnonresiatleast200000sf"

--- a/client/app/styles/app.scss
+++ b/client/app/styles/app.scss
@@ -172,3 +172,13 @@ $sticky-sidebar-offset: 6rem + rem-calc(20);
 .dropdown-clear-btn-below {
   color: $red-dark;
 }
+
+// Styling for tooltip "i" icons
+// note: over the top specificity was required to overwrite the fa defaults
+span.ember-tooltip-target > svg.svg-inline--fa.fa-info-circle.fa-w-16.ember-view.ember-tooltip-target {
+  color: #828891;
+  height: 13.33px;
+  width: 13.33px;
+  margin-bottom: 5px;
+}
+


### PR DESCRIPTION
### Summary
Add the below text as additional guidance under question “Increase permitted non-residential floor area by at least 200,000 square feet”
 - utilized svg and tooltip as per gilal designs in figma

Additional copy added in the `equitable-development-reporting.hbs` file

#### Tasks/Bug Numbers
 - Fixes [AB#8426](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8426)

 - Related [AB#8374](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8374)
 
<img width="834" alt="Screen Shot 2022-05-06 at 4 04 02 PM" src="https://user-images.githubusercontent.com/11340947/167209273-5d3f72d1-dde2-4e43-9e38-12cca4fad92e.png">

<img width="849" alt="Screen Shot 2022-05-06 at 4 04 15 PM" src="https://user-images.githubusercontent.com/11340947/167209298-cdd9db98-d053-4403-9b9a-495a3b12ae8c.png">


