### PR TITLE
8515 updated copy in PAS Racial Equity Section for greater clarity

### DIFF
--- a/client/app/components/packages/equitable-development-reporting.hbs
+++ b/client/app/components/packages/equitable-development-reporting.hbs
@@ -35,7 +35,7 @@
 
       <Ui::Question @required={{false}} as |Q|>
         <Q.Legend>
-          New residential building of 50,000 sf or more
+          New, enlarged, or converted residential building of 50,000 zoning square feet or more.
         </Q.Legend>
 
         <projectForm.Field


### PR DESCRIPTION
### Summary
 updated copy in PAS Racial Equity Section line 38 from "New residential building of 50,000 sf or more" to "to facilitate a new, enlarged, or converted residential building of 50,000 zoning square feet or more"
<img width="874" alt="Screen Shot 2022-05-05 at 1 23 42 PM" src="https://user-images.githubusercontent.com/11340947/166978722-05abbb1a-e160-4b01-8285-d6fb52bce738.png">

#### Tasks/Bug Numbers
 - Fixes [AB#8515](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8515)

 - Related [AB#8374](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8374)

