### PR TITLE
8427 addl copy added after Decrease permitted residential floor area

### DIFF
--- a/client/app/components/packages/equitable-development-reporting.hbs
+++ b/client/app/components/packages/equitable-development-reporting.hbs
@@ -118,6 +118,10 @@
           Decrease permitted residential floor area on at least four contiguous city blocks
         </Q.Legend>
 
+        <p class="q-help">
+          This applies to the change in ZSF permitted (not the CEQR increment, and not limited to the proposed project). They need not be complete blocks.
+        </p>
+
         <projectForm.Field
           @attribute="dcpDecpermresiatleastfourcontigcb"
           @type="radio-group"


### PR DESCRIPTION
### Summary
PAS Racial Equity Section: additional guidance under question “Decrease permitted residential floor area on at least four contiguous city blocks”:

#### Tasks/Bug Numbers
 - Related [AB#8374](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8374)
 
<img width="788" alt="Screen Shot 2022-05-09 at 3 47 26 PM" src="https://user-images.githubusercontent.com/11340947/167486193-8e43d825-883c-4f3c-9b13-80d100a42503.png">

