### PR TITLE
8575 add tooltip omitted in ADO #8427

### DIFF
--- a/client/app/components/packages/equitable-development-reporting.hbs
+++ b/client/app/components/packages/equitable-development-reporting.hbs
@@ -116,6 +116,22 @@
       <Ui::Question @required={{false}} as |Q|>
         <Q.Legend>
           Decrease permitted residential floor area on at least four contiguous city blocks
+          <span>
+            <FaIcon @icon="info-circle" @prefix="fas" class="ember-tooltip-target"/>
+            <EmberTooltip @event="hover" @side="right">
+              <p class="q-help">
+                Data points needed:
+              </p>
+              <ol class="text-small" type="a">
+                <li>Number of contiguous zoning blocks affected by actions (in part and/or wholly)</li>
+                <li>Change in permitted zoning square feet (residential) in entire project area (includes development site and any other sites affected).</li>
+
+              </ol>
+              <p class="q-help">
+                To get permitted zoning square feet, multiply area of all sites affected by applicable Floor Area Ratio. Zoning Handbook or Urban Renewal Plan can help with identifying floor area ratio.
+              </p>
+            </EmberTooltip>
+          </span>
         </Q.Legend>
 
         <p class="q-help">


### PR DESCRIPTION
### Summary
add tootip to pas equity section after decrease permitted floor area omitted in #1057 

#### Tasks/Bug Numbers
 - Fixes [AB#8575](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8575)
 - Related [AB#8427](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8427)
 - Parent  [AB#8374](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8374)
 - 
<img width="968" alt="Screen Shot 2022-05-10 at 1 35 33 PM" src="https://user-images.githubusercontent.com/11340947/167689745-cb5b1d37-e8c5-4fd8-98ab-7f9a3e794444.png">

