### PR TITLE
8578 housekeeping and cleanup for applicant portal tasks

### DIFF
--- a/client/app/components/packages/equitable-development-reporting.hbs
+++ b/client/app/components/packages/equitable-development-reporting.hbs
@@ -18,7 +18,7 @@
 
       <Ui::Question @required={{false}} as |Q|>
         <Q.Legend>
-          Non-residential use of at least 50,000 sf floor area
+          Non-residential use of at least 50,000 zoning square feet floor area
         </Q.Legend>
 
         <projectForm.Field
@@ -60,17 +60,22 @@
 
       <Ui::Question @required={{false}} as |Q|>
         <Q.Legend>
-          Increase permitted residential floor area by at least 50,000 square feet
+          Increase permitted residential floor area by at least 50,000 zoning square feet
           <span>
             <FaIcon @icon="info-circle" @prefix="fas" class="ember-tooltip-target"/>
             <EmberTooltip @event="hover" @side="right">
-              Proposed change in permitted zoning square feet (residential) in entire project area (includes development site and any other sites affected). To get permitted zoning square feet, multiply area of all sites affected by applicable Floor Area Ratio. Zoning Handbook or Urban Renewal Plan can help with identifying floor area ratio.
+              <p>
+                Proposed change in permitted zoning square feet (residential) in entire project area (includes development site and any other sites affected).
+              </p>
+              <p>
+                To get permitted zoning square feet, multiply area of all sites affected by applicable Floor Area Ratio. Zoning Handbook or Urban Renewal Plan can help with identifying floor area ratio.
+              </p>
             </EmberTooltip>
           </span>
         </Q.Legend>
 
         <p class="q-help">
-          This applies to the change in ZSF permitted (not the CEQR increment, and not limited to the proposed project).
+          This applies to the change in zoning square feet permitted (not the CEQR increment, and not limited to the proposed project).
         </p>
 
         <projectForm.Field
@@ -87,11 +92,16 @@
 
       <Ui::Question @required={{false}} as |Q|>
         <Q.Legend>
-          Increase permitted non-residential floor area by at least 200,000 square feet
+          Increase permitted non-residential floor area by at least 200,000 zoning square feet
           <span>
             <FaIcon @icon="info-circle" @prefix="fas" class="ember-tooltip-target"/>
             <EmberTooltip @event="hover" @side="right">
-              Proposed change in permitted zoning square feet (residential) in entire project area (includes development site and any other sites affected). To get permitted zoning square feet, multiply area of all sites affected by applicable Floor Area Ratio. Zoning Handbook or Urban Renewal Plan can help with identifying floor area ratio.
+              <p>
+                Proposed change in permitted zoning square feet (residential) in entire project area (includes development site and any other sites affected).
+              </p>
+              <p>
+                To get permitted zoning square feet, multiply area of all sites affected by applicable Floor Area Ratio. Zoning Handbook or Urban Renewal Plan can help with identifying floor area ratio.
+              </p>
             </EmberTooltip>
           </span>
         </Q.Legend>
@@ -135,7 +145,7 @@
         </Q.Legend>
 
         <p class="q-help">
-          This applies to the change in ZSF permitted (not the CEQR increment, and not limited to the proposed project). They need not be complete blocks.
+          This applies to the change in zoning square feet permitted (not the CEQR increment, and not limited to the proposed project). They need not be complete blocks.
         </p>
 
         <projectForm.Field


### PR DESCRIPTION
housekeeping and cleanup for applicant portal tasks
 - updated copy from "at least 50,000 sf floor area" to "at least 50,000 zoning square feet floor area"
 - updated copy from "square feet" to  "zoning square feet"  for both "Increase permitted residential floor area" and "Increase permitted non-residential floor area".
 - tooltips updated to two paragraphs for both "Increase permitted residential floor area" and "Increase permitted non-residential floor area",
 - updated copy from ZSF to zoning square feet for "Increase permitted residential floor area" and "Decrease permitted residential floor area"

#### Tasks/Bug Numbers
 - Fixes [AB#8579](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8579)

##### screenshot with all copy updates in this PR:
<img width="692" alt="Screen Shot 2022-05-10 at 5 29 14 PM" src="https://user-images.githubusercontent.com/11340947/167725071-110c52b7-9622-4519-b81c-8bf457c620c5.png">


##### tooltip updates in this PR:
<img width="809" alt="Screen Shot 2022-05-10 at 5 29 27 PM" src="https://user-images.githubusercontent.com/11340947/167725222-10f48132-4343-424c-a466-9320bec7e3f5.png">
<img width="865" alt="Screen Shot 2022-05-10 at 5 29 35 PM" src="https://user-images.githubusercontent.com/11340947/167725236-d0fb702c-da44-4db2-b731-ec6370aba12a.png">

