### PR TITLE
auto response copy for ‘not subject to racial equity report' to racial equity section questions

### DIFF
--- a/client/app/components/packages/equitable-development-reporting.hbs
+++ b/client/app/components/packages/equitable-development-reporting.hbs
@@ -297,8 +297,13 @@
           {{/if}}
 
           {{#unless isEquityReportRequired}}
-            <h3>
-              This project is not subject to requirements to submit a Racial Equity Report on Housing and Opportunity under Local Law 78 of 2021.
+            <h3 class="equity-auto-response">
+              Based on your answers, you are not required to submit a Racial Equity Report. To learn more contact your Lead Planner or visit
+              <a
+                href="https://www1.nyc.gov/site/planning/data-maps/edde/edde-overview.page"
+                alt="NYC Department of City Planning Equitable Development Data Explorer overview page">
+                DCP's website (URL)
+              </a>
             </h3>
           {{/unless}}
     {{/let}}

--- a/client/app/styles/app.scss
+++ b/client/app/styles/app.scss
@@ -46,6 +46,8 @@ $small-font-size: 81.25%; // TODO: update Style Guide so that <small> matches .t
 
 @import "modules/_powerselect-overrides"; // TODO: move to Labs UI (if necessary)
 
+$orange: #AE5620;
+
 .site-header {
   @include breakpoint(large) {
     position: sticky;
@@ -185,6 +187,14 @@ $sticky-sidebar-offset: 6rem + rem-calc(20);
       height: 13.33px;
       width: 13.33px;
       margin-bottom: 5px;
+    }
+  }
+
+  .equity-auto-response {
+    color: $orange;
+
+    a {
+      text-decoration: underline;
     }
   }
 }


### PR DESCRIPTION
 on PAS and LU forms

### Summary
Updated copy of auto response to:  ‘Subject to Racial Equity Report’ Auto-Response to Equitable Development questions on PAS and Land Use form

#### Tasks/Bug Numbers
 - Fixes [AB#8617](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8617)
 - Related [AB#7024](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7024)
 - 
<img width="883" alt="Screen Shot 2022-05-13 at 12 27 59 PM" src="https://user-images.githubusercontent.com/11340947/168332830-4135513f-0638-4ae2-a3c5-4118567db195.png">

