### PR TITLE
auto response copy update for ‘subject to racial equity report' to racial equity section questions

### DIFF
--- a/client/app/components/packages/equitable-development-reporting.hbs
+++ b/client/app/components/packages/equitable-development-reporting.hbs
@@ -286,13 +286,8 @@
         as |isEquityReportRequired|}}
 
           {{#if isEquityReportRequired}}
-            <h3>
-              This project IS subject to requirements to submit a Racial Equity Report on
-              Housing and Opportunity under Local
-              <a href="https://legistar.council.nyc.gov/LegislationDetail.aspx?ID=3963886&GUID=D2C9A25B-0036-416E-87CD-C3AED208AE1B">
-                Law 78 of 2021 </a>.
-              The EDDE can be used to generate the data needed for the report. A template can be found <a href="">here</a>.
-              Submit the report as a PDF <a href="#">here</a>.
+            <h3 class="equity-auto-response">
+              Based on your answers, you will be required to submit a Racial Equity Report before Public Review begins.
             </h3>
           {{/if}}
 


### PR DESCRIPTION
### Summary
Update copy for auto-response for ‘Subject to Racial Equity Report’ to Equitable Development questions on PAS and Land Use form

#### Tasks/Bug Numbers
 - Fixes [AB#8623](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8623)

<img width="786" alt="Screen Shot 2022-05-13 at 3 32 17 PM" src="https://user-images.githubusercontent.com/11340947/168377137-184da640-07cc-441b-b96c-1d3d918be3b5.png">

