### PR TITLE
8334 Limit file uploads to 100mb. 

### DIFF
--- a/client/app/components/packages/attachments.hbs
+++ b/client/app/components/packages/attachments.hbs
@@ -126,7 +126,7 @@
     </FileUpload>
 
     <p class="text-small tiny-margin-bottom text-dark-gray">
-      The size limit for each file is 50 MB. You can upload up to 1 GB of files.
+      The size limit for each file is 100 MB. You can upload up to 1 GB of files.
     </p>
   </fieldset>
 </div>

--- a/client/app/components/packages/deis/attached-documents.hbs
+++ b/client/app/components/packages/deis/attached-documents.hbs
@@ -5,7 +5,7 @@
     To complete this submission, attach the completed draft
     Environmental Impact Statement (DEIS) and Final Scope of Work.
     Upload all chapters and appendices as individual files.
-    The maximum size for a document is 50MB
+    The maximum size for a document is 100MB
   </p>
 
   <Packages::Attachments

--- a/client/app/components/packages/feis/attached-documents.hbs
+++ b/client/app/components/packages/feis/attached-documents.hbs
@@ -4,7 +4,7 @@
   <p>
     To complete this submission, attach the completed Final Environmental
     Impact Statement (FEIS). Upload all chapters and appendices as individual
-    files. The maximum size for a document is 50MB.
+    files. The maximum size for a document is 100MB.
   </p>
 
   <Packages::Attachments 


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
The file limit is implemented on the sharepoint side and has already been updated.  This simply updates the site text to reflect the limit.

#### Tasks/Bug Numbers
 - Completes [AB#8334](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8334)
