### PR TITLE
8650 removed unnecessary copy from auto response in racial equity section

### DIFF
--- a/client/app/components/packages/equitable-development-reporting.hbs
+++ b/client/app/components/packages/equitable-development-reporting.hbs
@@ -306,8 +306,8 @@
               <a
                 href="https://www1.nyc.gov/site/planning/data-maps/edde/edde-overview.page"
                 alt="NYC Department of City Planning Equitable Development Data Explorer overview page">
-                DCP's website (URL)
-              </a>
+                DCP's website
+              </a>.
             </h3>
           {{/unless}}
     {{/let}}


### PR DESCRIPTION
### Summary
cleaned up some copy that was not meant to be included.

#### Tasks/Bug Numbers
 - Fixes [AB#8650](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8650)
 - Related [AB#8617](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8617)

<img width="699" alt="Screen Shot 2022-05-16 at 3 08 28 PM" src="https://user-images.githubusercontent.com/11340947/168669048-1890b1f8-8dd6-4381-a1ea-1a358ced4326.png">

