### PR TITLE
8664 update copy on lu conditional question

### DIFF
--- a/client/app/components/packages/landuse-form/proposed-action-editor.hbs
+++ b/client/app/components/packages/landuse-form/proposed-action-editor.hbs
@@ -215,7 +215,7 @@
     {{#if this.chosenDcpPreviouslyapprovedactioncode.code}}
       <Ui::Question as |dcpPreviouslyapprovedapplicationnumbersQ|>
         <dcpPreviouslyapprovedapplicationnumbersQ.Label>
-          Previously Approved Application Number(s)*
+          If this is a follow-up Action, indicate the ULURP or CP number of previous approval
         </dcpPreviouslyapprovedapplicationnumbersQ.Label>
 
         <landuseActionForm.Field

--- a/client/app/components/packages/landuse-form/show.hbs
+++ b/client/app/components/packages/landuse-form/show.hbs
@@ -616,7 +616,7 @@
 
               <Ui::Answer @beside={{true}} as |A|>
                 <A.Prompt>
-                  Previously Approved Application Number(s)*
+                  If this is a follow-up Action, indicate the ULURP or CP number of previous approval
                 </A.Prompt>
                 <A.Field>
                   {{landuseAction.dcpPreviouslyapprovedapplicationnumbers}}


### PR DESCRIPTION
### Summary
 update copy from "Previously Approved Application Number(s)*" to  "If this is a follow-up Action, indicate the ULURP or CP number of previous approval"

#### Tasks/Bug Numbers
 - Fixes [AB#8664](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8664)
 - Related [AB#8201](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8201)
 - U.S [AB#3896](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/3896)

#### Before:
![old](https://user-images.githubusercontent.com/11340947/168842510-6af9bce8-237c-47c3-8c0d-24653742ffa9.png)

#### After:
<img width="734" alt="Screen Shot 2022-05-17 at 10 53 11 AM" src="https://user-images.githubusercontent.com/11340947/168842609-875a5580-40f4-47e1-a6a3-b5fa6b1bca10.png">

