### PR TITLE
8718 correct copy for tooltip

### DIFF
--- a/client/app/components/packages/equitable-development-reporting.hbs
+++ b/client/app/components/packages/equitable-development-reporting.hbs
@@ -91,7 +91,7 @@
             <FaIcon @icon="info-circle" @prefix="fas" class="ember-tooltip-target"/>
             <EmberTooltip @event="hover" @side="bottom-end">
               <p>
-                Proposed change in permitted zoning square feet (residential) in entire project area (includes development site and any other sites affected).
+                Change in permitted zoning square feet (non-residential) in entire project area (includes development site and any other sites affected).
               </p>
               <p>
                 To get permitted zoning square feet, multiply area of all sites affected by applicable Floor Area Ratio. Zoning Handbook or Urban Renewal Plan can help with identifying floor area ratio.


### PR DESCRIPTION
### Summary
Correct copy from `Proposed change in permitted zoning square feet (residential)` to `Change in permitted zoning square feet (non-residential)` in the tooltip for `Increase permitted non-residential floor area by at least 200,000 zoning square feet`

line 94 in the `equitable-development-reporting.hbs`

#### Tasks/Bug Numbers
 - Fixes [AB#8718](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8718)
 - Correction to [AB#8426](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8426)
 
<img width="741" alt="Screen Shot 2022-05-18 at 12 50 04 PM" src="https://user-images.githubusercontent.com/11340947/169114034-740c5359-b42e-4892-ae94-7dac1317b06e.png">


