### PR TITLE
8735 correct copy for tooltip, update local law link to document

### DIFF
--- a/client/app/components/packages/equitable-development-reporting.hbs
+++ b/client/app/components/packages/equitable-development-reporting.hbs
@@ -2,7 +2,7 @@
   <form.SaveableForm @model={{@package.project}} as |projectForm|>
     <form.Section @title="Racial Equity Report" class="equitable-development-reporting">
       <p>
-        Certain projects are subject to requirements to submit a Racial Equity Report on Housing and Opportunity under <Ui::ExternalLink href="https://legistar.council.nyc.gov/LegislationDetail.aspx?ID=3963886&GUID=D2C9A25B-0036-416E-87CD-C3AED208AE1B">Local Law 78 of 2021</Ui::ExternalLink>. The below questions are to help identify whether your project is. 
+        Certain projects are subject to requirements to submit a Racial Equity Report on Housing and Opportunity under <Ui::ExternalLink href="https://www1.nyc.gov/assets/planning/download/pdf/data-maps/edde/local-law-78.pdf">Local Law 78 of 2021</Ui::ExternalLink>. The below questions are to help identify whether your project is.
       </p>
 
       <p class="text-weight-bold text-large">
@@ -195,6 +195,9 @@
           <span>
             <FaIcon @icon="info-circle" @prefix="fas" class="ember-tooltip-target"/>
             <EmberTooltip @event="hover" @side="bottom-end">
+              <p class="q-help">
+                Data points needed:
+              </p>
               <ol class="text-small" type="a">
                 <li>
                   Change in permitted zoning square feet in portion of project area (includes development site and any other sites affected) that is within a Manufacturing District. To get permitted zoning square feet, multiply area of all sites affected by applicable Floor Area Ratio. Zoning Handbook or Urban Renewal Plan can help with identifying floor area ratio.


### PR DESCRIPTION
### Summary
#### add additional copy ( `Data points needed:` ) to tooltip for `I am applying for a Special Permit (ZS, RS), Zoning Map Amendment (ZM)`
<img width="731" alt="Screen Shot 2022-05-18 at 3 35 52 PM" src="https://user-images.githubusercontent.com/11340947/169143041-a36b375c-c5fa-4aae-944a-6fadd12306cb.png">

#### update URL for `Local Law 78 of 2021` link
<img width="706" alt="Screen Shot 2022-05-18 at 3 31 59 PM" src="https://user-images.githubusercontent.com/11340947/169143207-566a81c6-a7d6-4cfc-b802-e61b37234e8b.png">


#### Tasks/Bug Numbers
 - Fixes [AB#8735](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8735)
