### PR TITLE
9400 Use geosearch v2

### DIFF
--- a/client/config/environment.js
+++ b/client/config/environment.js
@@ -34,7 +34,7 @@ module.exports = function(environment) {
     'labs-search': {
       host: 'https://search-api-production.herokuapp.com',
       route: 'search',
-      helpers: ['geosearch', 'bbl'],
+      helpers: ['geosearch-v2', 'bbl'],
     },
   };
 

--- a/client/mirage/config.js
+++ b/client/mirage/config.js
@@ -3,6 +3,7 @@ import ENV from '../config/environment';
 
 export default function() {
   this.passthrough('https://search-api-production.herokuapp.com/**');
+  this.passthrough('https://search-api-staging.herokuapp.com/**');
   this.passthrough('/account/**');
   this.passthrough('https://d3hb14vkzrxvla.cloudfront.net/**');
 

--- a/client/package.json
+++ b/client/package.json
@@ -79,7 +79,7 @@
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-node": "^11.0.0",
     "husky": "^6.0.0",
-    "labs-ember-search": "^3.1.2",
+    "labs-ember-search": "3.1.5",
     "labs-ui": "^1.1.0",
     "lint-staged": ">=10",
     "loader.js": "^4.7.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -10230,10 +10230,10 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
-labs-ember-search@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/labs-ember-search/-/labs-ember-search-3.1.2.tgz#9b054d4912aef5ba4393a4af8743b5e5b60c78ee"
-  integrity sha512-+qZQ5rnaBATKT6NZlOQrzdD9809HsXag/hCacXFTgjXycb6SYVlDue7/b+qLM2H6qg+aymJhAlf5Nxx5amlQHg==
+labs-ember-search@3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/labs-ember-search/-/labs-ember-search-3.1.5.tgz#dfc240b74da07b4b133448f23d9cea1843d3e6cd"
+  integrity sha512-Is3ZGrQNfU0z6iBtqjsxplqEvOR1EnGpWCtJ1yS/obMhwbJaENgJKd3Ovu4KRJ28tnLQedQsq56eeyqMNnCzoQ==
   dependencies:
     "@fortawesome/ember-fontawesome" "^0.1.9"
     "@fortawesome/free-regular-svg-icons" "^5.7.1"


### PR DESCRIPTION
Blocked by/Depends on Depends on https://github.com/NYCPlanning/labs-search-api/pull/58
(Rerun Tests  after  https://github.com/NYCPlanning/labs-search-api/pull/58 is merged)

Fixes [AB#9400](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/9400) 