### PR TITLE
8915 Strip package file names

### DIFF
--- a/server/src/document/document.controller.ts
+++ b/server/src/document/document.controller.ts
@@ -63,10 +63,12 @@ export class DocumentController {
     // previous revision documents and one for current revision documents).
     const folderName = `${packageName}_${instanceId.toUpperCase().replace(/-/g, '')}`;
 
+    const strippedFileName =  file.originalname.replace(/[^-a-zA-Z0-9._]/g, '-');
+
     return this.documentService.uploadDocument('dcp_package',
       instanceId,
       folderName,
-      file.originalname,
+      strippedFileName,
       encodedBase64File,
       true,
       headers


### PR DESCRIPTION
Fixes [AB#8915](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8915)

Recently we stripped all uploaded Artifact document names of special characters to prevent complications when downloading and removing the files. Here we do the same for package  documents. 