### PR TITLE
989 add check to see if PAS was submitted and inactive, then redirecting to show page if true

### DIFF
--- a/client/app/routes/pas-form/edit.js
+++ b/client/app/routes/pas-form/edit.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
-import { STATUSCODE, STATECODE } from '../../optionsets/package';
+import { STATUSCODE, STATECODE } from 'client/optionsets/package';
 
 export default class PasFormEditRoute extends Route.extend(AuthenticatedRouteMixin) {
   @service router;

--- a/client/app/routes/pas-form/edit.js
+++ b/client/app/routes/pas-form/edit.js
@@ -1,0 +1,14 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import { STATUSCODE, STATECODE } from '../../optionsets/package';
+
+export default class PasFormEditRoute extends Route.extend(AuthenticatedRouteMixin) {
+  @service router;
+
+  afterModel(model) {
+    if (model.statuscode === STATUSCODE.SUBMITTED.code && model.statecode === STATECODE.INACTIVE.code) {
+      return this.router.replaceWith('pas-form');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
added class to check for project status and state codes and redirects to the PAS show page if package was submitted and marked inactive

added `client/app/routes/pas-form/edit.js` to intercept the default edit route to check for package status.

#### Tasks/Bug Numbers
 - Fixes [AB#989](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/989)
