### PR TITLE
8125 additional logging in RWDCS form service to catch errors

### DIFF
--- a/server/src/packages/packages.service.ts
+++ b/server/src/packages/packages.service.ts
@@ -151,7 +151,6 @@ export class PackagesService {
         || firstPackage.dcp_packagetype === PACKAGE_TYPE_OPTIONSET['POST_CERT_LU'].code
       ) {
         formData = await this.fetchPackageForm(firstPackage);
-        console.log('from package.service.ts - firstPackage', firstPackage);
       }
 
       // below query filters by Racial Equity Report file type. 

--- a/server/src/packages/packages.service.ts
+++ b/server/src/packages/packages.service.ts
@@ -151,6 +151,7 @@ export class PackagesService {
         || firstPackage.dcp_packagetype === PACKAGE_TYPE_OPTIONSET['POST_CERT_LU'].code
       ) {
         formData = await this.fetchPackageForm(firstPackage);
+        console.log('from package.service.ts - firstPackage', firstPackage);
       }
 
       // below query filters by Racial Equity Report file type. 
@@ -177,7 +178,7 @@ export class PackagesService {
       try {
         firstArtifactWithDocuments = await this.artifactService.artifactWithDocuments(firstArtifactWithDocuments);
       } catch (e) {
-        console.log(e);
+        console.log('firstArtifactWithDocuments error', e);
       }
 
       dcp_project.artifact = firstArtifactWithDocuments;
@@ -196,7 +197,9 @@ export class PackagesService {
     } catch (e) {
       // relay lower-level exceptions, like from crmServce.get(),
       // or sharepoint document retrieval.
+      console.log('dcp_project.artifact error', e);
       if (e instanceof HttpException) {
+        console.log('dcp_project.artifact HttpException', e);
         throw e;
       } else {
         throw new HttpException({
@@ -237,7 +240,9 @@ export class PackagesService {
         detail: 'Requested package has invalid type.',
       }, HttpStatus.BAD_REQUEST);
     } catch (e) {
+      console.log('fetchPackageForm error', e);
       if (e instanceof HttpException) {
+        console.log('fetchPackageForm HttpException error', e);
         throw e;
       } else {
         throw new HttpException({

--- a/server/src/packages/packages.service.ts
+++ b/server/src/packages/packages.service.ts
@@ -196,9 +196,9 @@ export class PackagesService {
     } catch (e) {
       // relay lower-level exceptions, like from crmServce.get(),
       // or sharepoint document retrieval.
-      console.log('dcp_project.artifact error', e);
+      console.log('Error retrieving package in getPackage', e);
       if (e instanceof HttpException) {
-        console.log('dcp_project.artifact HttpException', e);
+        console.log('Error retrieving package in getPackage HttpException', e);
         throw e;
       } else {
         throw new HttpException({


### PR DESCRIPTION
### Summary
Addinal error logging in RWCDS form service
bug was caused my CMS input field that awsa too long. Attached photos have details.

### app logs with new try / catch blocks detailing error state
![zrmodifyingzrtxt_length_error_ado_copy](https://user-images.githubusercontent.com/11340947/183489021-caaadb79-e6b2-4795-8287-77019c3168bd.png)

#### form field that cause above error (after we shortened the text input)
![Screen Shot 2022-08-05 at 1 45 37 PM](https://user-images.githubusercontent.com/11340947/183489115-04d5f991-0173-4bf0-897c-88166fb23a14.png)


#### Tasks/Bug Numbers
 - Fixes [AB#8125](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8125)




