### PR TITLE
1497 added urban design guidance to projects to show array

### DIFF
--- a/client/app/components/project/milestones/milestone-group-item.js
+++ b/client/app/components/project/milestones/milestone-group-item.js
@@ -24,6 +24,7 @@ export default class ProjectMilestonesMilestoneGroupItemComponent extends Compon
     'Review Filed EAS',
     'DEIS Public Scoping Meeting',
     'Prepare and Review DEIS',
+    'Urban Design Guidance',
   ]
 
   get showProject() {


### PR DESCRIPTION
### Summary
For milestones to appear in the milestones group list, the milestone must be listed in the `projectToShow` array in the `milestone-group-item.js`.  There is probably a way to populate this array with additional ad hoc milestone without needing to add them manually but that is beyond the scope of this bug ticket.

#### Tasks/Bug Numbers
 - Fixes [AB#1497](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/1497)

#### BEFORE:
![before_udg_milesstone](https://user-images.githubusercontent.com/11340947/183756676-2f97724c-c105-4fdc-9e7a-907dc6d8620c.png)

####AFTER:
<img width="864" alt="after_udg_milesstone" src="https://user-images.githubusercontent.com/11340947/183756927-12e60888-4ecc-4489-9b70-1216d06644c6.png">


