### PR TITLE
Release 9400 search api geosearchv2 upgrade to production

### DIFF
--- a/client/config/environment.js
+++ b/client/config/environment.js
@@ -34,7 +34,7 @@ module.exports = function(environment) {
     'labs-search': {
       host: 'https://search-api-production.herokuapp.com',
       route: 'search',
-      helpers: ['geosearch', 'bbl'],
+      helpers: ['geosearch-v2', 'bbl'],
     },
   };
 

--- a/client/mirage/config.js
+++ b/client/mirage/config.js
@@ -3,6 +3,7 @@ import ENV from '../config/environment';
 
 export default function() {
   this.passthrough('https://search-api-production.herokuapp.com/**');
+  this.passthrough('https://search-api-staging.herokuapp.com/**');
   this.passthrough('/account/**');
   this.passthrough('https://d3hb14vkzrxvla.cloudfront.net/**');
 

--- a/client/package.json
+++ b/client/package.json
@@ -79,7 +79,7 @@
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-node": "^11.0.0",
     "husky": "^6.0.0",
-    "labs-ember-search": "3.1.5",
+    "labs-ember-search": "3.1.6",
     "labs-ui": "^1.1.0",
     "lint-staged": ">=10",
     "loader.js": "^4.7.0",

--- a/client/package.json
+++ b/client/package.json
@@ -79,7 +79,7 @@
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-node": "^11.0.0",
     "husky": "^6.0.0",
-    "labs-ember-search": "^3.1.2",
+    "labs-ember-search": "3.1.5",
     "labs-ui": "^1.1.0",
     "lint-staged": ">=10",
     "loader.js": "^4.7.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -10230,10 +10230,10 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
-labs-ember-search@3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/labs-ember-search/-/labs-ember-search-3.1.5.tgz#dfc240b74da07b4b133448f23d9cea1843d3e6cd"
-  integrity sha512-Is3ZGrQNfU0z6iBtqjsxplqEvOR1EnGpWCtJ1yS/obMhwbJaENgJKd3Ovu4KRJ28tnLQedQsq56eeyqMNnCzoQ==
+labs-ember-search@3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/labs-ember-search/-/labs-ember-search-3.1.6.tgz#18891fe83fca585655d3e19433e5907228f209f1"
+  integrity sha512-DeyuRHjb0Le+3GqYcdiJWBvNFVZ5p//+fo4d9YlkJWacIQuDWOjSQ2fS/FVRe/9ySCdQiLFVOa+PukvFzgyJ3Q==
   dependencies:
     "@fortawesome/ember-fontawesome" "^0.1.9"
     "@fortawesome/free-regular-svg-icons" "^5.7.1"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -10230,10 +10230,10 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
-labs-ember-search@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/labs-ember-search/-/labs-ember-search-3.1.2.tgz#9b054d4912aef5ba4393a4af8743b5e5b60c78ee"
-  integrity sha512-+qZQ5rnaBATKT6NZlOQrzdD9809HsXag/hCacXFTgjXycb6SYVlDue7/b+qLM2H6qg+aymJhAlf5Nxx5amlQHg==
+labs-ember-search@3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/labs-ember-search/-/labs-ember-search-3.1.5.tgz#dfc240b74da07b4b133448f23d9cea1843d3e6cd"
+  integrity sha512-Is3ZGrQNfU0z6iBtqjsxplqEvOR1EnGpWCtJ1yS/obMhwbJaENgJKd3Ovu4KRJ28tnLQedQsq56eeyqMNnCzoQ==
   dependencies:
     "@fortawesome/ember-fontawesome" "^0.1.9"
     "@fortawesome/free-regular-svg-icons" "^5.7.1"


### PR DESCRIPTION
### Summary
This PR merges a feature branch into master that switches the app to use the Geosearch v2 helper and upgrades to the most recent version of `labs-ember-search`. This is being done via a feature branch into master because `develop` and `qa` branches already have other changes that aren't ready for master.
