### PR TITLE
5372 updated previously approved action code option set

### DIFF
--- a/client/app/optionsets/landuse-action.js
+++ b/client/app/optionsets/landuse-action.js
@@ -47,6 +47,10 @@ export const DCPPREVIOUSLYAPPROVEDACTIONCODE = {
     code: 717170005,
     label: 'SD',
   },
+  ZA: {
+    code: 717170004,
+    label: 'ZA',
+  },
   ZC: {
     code: 717170003,
     label: 'ZC',


### PR DESCRIPTION
### Summary
the ZA code was not appearing as an option for the question: `If this is a follow-up Action, indicate the previously approved Action Code` in the  **Proposed Actions** section of the LU package.

#### Tasks/Bug Numbers
 - Fixes ([AB#5372](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5372))[https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/5372]

### Technical Explanation
Added ZA to the landuse option set

#### Before:
![before-za](https://user-images.githubusercontent.com/11340947/204365032-a733277b-b973-4402-b89d-8cbb8b149a37.png)

#### After:
![after-za_1](https://user-images.githubusercontent.com/11340947/204365307-420a83d4-44d8-4618-9637-59a1fc6182ab.png)

![after-za_2](https://user-images.githubusercontent.com/11340947/204365345-69427b9f-8b0d-47b3-8c87-0b65d08354fd.png)


