### PR TITLE
1836 project disposition proposed question defaults to yes if HA or HA are present in lu package actions

### DIFF
--- a/client/app/components/packages/landuse-form/housing-plans.hbs
+++ b/client/app/components/packages/landuse-form/housing-plans.hbs
@@ -6,7 +6,7 @@
     <p>
       The following questions relate to Housing Plans,
       Urban Renewal Areas, and Urban Development Action
-      Areas Program (UDAAP) and the follwoing Actions: HA,
+      Areas Program (UDAAP) and the following Actions: HA,
       HC, HD, HG, HN, HO, HP, HU
 
     </p>

--- a/client/app/components/packages/landuse-form/housing-plans.js
+++ b/client/app/components/packages/landuse-form/housing-plans.js
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
-
 export default class PackagesLanduseFormHousingPlansComponent extends Component {
   // The following properties represent lists of fields
   // dependent on the value of a respective radio group.

--- a/client/app/routes/landuse-form/edit.js
+++ b/client/app/routes/landuse-form/edit.js
@@ -8,7 +8,7 @@ export default class LanduseFormEditRoute extends Route.extend(AuthenticatedRout
   afterModel(model) {
     const formpackage = model.package;
     const { landuseForm } = formpackage;
-    const { landuseActions } = formpackage.landuseForm;
+    const { landuseActions } = landuseForm;
     const projectDispositionCodes = ['HA', 'HD'];
 
     const luPackageActionCodes = landuseActions.currentState.map((landuseAction) => landuseAction.__recordData.__data.dcpActioncode);


### PR DESCRIPTION
### Summary
On the draft land use form, the question: “Is a Disposition being proposed?"  in the Housing Plans section should default to yes when there is HA or HD actions on the land use project package.

#### Tasks/Bug Numbers
 - Fixes [AB#1836](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/1836)
### Technical Explanation
The boolean project attribute `dcpDisposition`, determines whether the "Disposition" question defaults to yes as well as displaying follow up questions if `dcpDisposition` is true. I used the `afterModel` hook  to access information on the model and  get the package lu actions and compare then to the disposition codes (HA, HD) and set the `dcpDisposition` to true if there is a match.