### PR TITLE
1964 corrected reversed package fields in lu show page

### DIFF
--- a/client/app/components/packages/landuse-form/show.hbs
+++ b/client/app/components/packages/landuse-form/show.hbs
@@ -870,7 +870,7 @@
               Is the type of disposition HA (Urban Development Action Area - UDAAP)?
             </A.Prompt>
             <A.Field>
-              {{optionset 'landuseForm' 'dcpHddispositionofurbanrenewalsite' 'label' @package.landuseForm.dcpHddispositionofurbanrenewalsite}}
+              {{optionset 'landuseForm' 'dcpHaurbandevelopmentactionareaudaap' 'label' @package.landuseForm.dcpHaurbandevelopmentactionareaudaap}}
             </A.Field>
           </Ui::Answer>
 
@@ -879,7 +879,7 @@
               Is the type of disposition HD (Disposition of Urban Renewal Site)?
             </A.Prompt>
             <A.Field>
-              {{optionset 'landuseForm' 'dcpHaurbandevelopmentactionareaudaap' 'label' @package.landuseForm.dcpHaurbandevelopmentactionareaudaap}}
+              {{optionset 'landuseForm' 'dcpHddispositionofurbanrenewalsite' 'label' @package.landuseForm.dcpHddispositionofurbanrenewalsite}}
             </A.Field>
           </Ui::Answer>
 


### PR DESCRIPTION
### Summary
The answers to the following  questions on the LU form were being reversed:
Is the type of disposition HA (Urban Development Action Area - UDAAP)?
Is the type of disposition HD (Disposition of Urban Renewal Site)?

The reason is that the package fields for each CRM column were paired with the wrong question. I corrected that and the fields now display the correct response for the question.

#### Tasks/Bug Numbers
 - Fixes [AB#1964](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/1964)
