### PR TITLE
Add additional logging to nycid service

### DIFF
--- a/server/src/contact/nycid/nycid.service.ts
+++ b/server/src/contact/nycid/nycid.service.ts
@@ -49,6 +49,7 @@ export class NycidService {
         is_nycid_validated: body.validated,
       };
     } catch (e) {
+      console.log(e);
       if (e.response.body.ERRORS['cpui.unknownGuid']) {
         return {
           is_nycid_validated: true,
@@ -74,6 +75,7 @@ export class NycidService {
         email,
       });
     } catch (e) {
+      console.log(e);
       errors = e.response.body.ERRORS;
     }
 


### PR DESCRIPTION
### Summary
This PR adds some logging to nycid service to help with a production outage we are experiencing.