### PR TITLE
14456 enable the submit button only if the entire form is saveable AN…

### DIFF
--- a/client/app/components/packages/rwcds-form/edit.hbs
+++ b/client/app/components/packages/rwcds-form/edit.hbs
@@ -1,11 +1,11 @@
-<div class="maintenance-wrapper notification-banner">
+<div class="maintenance-wrapper notification-banner  {{if isBannerClosed 'hide-banner'}}">
   <div>
     <FaIcon @icon="info-circle" @size="1x" id="information-icon"/>
     <h4>Attention </h4>
       <button
         type="button"
         aria-label="dismiss notification banner"
-        class="dismiss-notification"
+        class="dismiss-banner-button"
         {{on "click" this.closeBanner}}>
           <FaIcon @icon="times" @size="1x" class="close-icon" />
       </button>
@@ -93,8 +93,8 @@
             class="secondary"
             data-test-submit-button
           />
-        </saveableRwcdsForm.PageNav>
 
+        </saveableRwcdsForm.PageNav>
         <saveablePackageForm.ConfirmationModal
           @action={{component saveableRwcdsForm.SubmitButton
             onClick=this.submitPackage

--- a/client/app/components/packages/rwcds-form/edit.js
+++ b/client/app/components/packages/rwcds-form/edit.js
@@ -28,7 +28,7 @@ export default class PackagesRwcdsFormEditComponent extends Component {
   router;
 
   @tracked
-  isBannerOpen = true;
+  isBannerClosed = false;
 
   get rwcdsForm() {
     return this.args.package.rwcdsForm || {};
@@ -55,7 +55,7 @@ export default class PackagesRwcdsFormEditComponent extends Component {
 
   @action
   closeBanner() {
-    this.isBannerOpen = false;
+    this.isBannerClosed = true;
   }
 
   get isNotificationBannerPeriod() {

--- a/client/app/styles/app.scss
+++ b/client/app/styles/app.scss
@@ -44,7 +44,7 @@ $small-font-size: 81.25%; // TODO: update Style Guide so that <small> matches .t
 @import "modules/_animations";
 @import "modules/_m-actions-milestones";
 @import "modules/_rwcds-style-overrides";
-@import "modules/_notification-banner";
+@import "modules/_banner-styles";
 
 @import "modules/_powerselect-overrides"; // TODO: move to Labs UI (if necessary)
 
@@ -177,13 +177,7 @@ $sticky-sidebar-offset: 6rem + rem-calc(20);
   color: $red-dark;
 }
 
-.maintenance-wrapper {
-  background-color: #E5E5E5;
 
-  p {
-    padding: 3px 5px 0 5px;
-  }
-}
 
 // Styling for tooltip "i" info icons and tooltip copy container
 .equitable-development-reporting {

--- a/client/app/styles/modules/_banner-styles.scss
+++ b/client/app/styles/modules/_banner-styles.scss
@@ -1,3 +1,11 @@
+.maintenance-wrapper {
+  background-color: #E5E5E5;
+
+  p {
+    padding: 3px 5px 0 5px;
+  }
+}
+
 .notification-banner {
   padding: 0.5rem;
   margin-bottom: 1rem;
@@ -20,7 +28,7 @@
       margin: 0.3125rem 0 0 0.3125rem;
     }
 
-    .dismiss-notification {
+    .dismiss-banner-button {
       padding: 0;
       margin: 0;
       align-self: flex-start;
@@ -28,4 +36,8 @@
       margin-right: 1rem;
     }
   }
+}
+
+.hide-banner {
+  display: none;
 }

--- a/client/app/validations/saveable-project-form.js
+++ b/client/app/validations/saveable-project-form.js
@@ -1,6 +1,7 @@
 import {
   validateLength,
   validateNumber,
+  validatePresence,
 } from 'ember-changeset-validations/validators';
 
 export default {
@@ -12,6 +13,10 @@ export default {
     }),
   ],
   dcpNumberofnewdwellingunits: [
+    validatePresence({
+      presence: true,
+      message: 'This field is required',
+    }),
     validateLength({
       min: 0,
       max: 10,
@@ -24,6 +29,10 @@ export default {
     }),
   ],
   dcpIncrementhousingunits: [
+    validatePresence({
+      presence: true,
+      message: 'This field is required',
+    }),
     validateLength({
       min: 0,
       max: 10,
@@ -36,6 +45,10 @@ export default {
     }),
   ],
   dcpActionaffordabledwellingunits: [
+    validatePresence({
+      presence: true,
+      message: 'This field is required',
+    }),
     validateLength({
       min: 0,
       max: 10,
@@ -48,6 +61,10 @@ export default {
     }),
   ],
   dcpIncrementalaffordabledwellingunits: [
+    validatePresence({
+      presence: true,
+      message: 'This field is required',
+    }),
     validateLength({
       min: 0,
       max: 10,
@@ -60,6 +77,10 @@ export default {
     }),
   ],
   dcpResidentialsqft: [
+    validatePresence({
+      presence: true,
+      message: 'This field is required',
+    }),
     validateLength({
       min: 0,
       max: 10,
@@ -72,6 +93,10 @@ export default {
     }),
   ],
   dcpNewcommercialsqft: [
+    validatePresence({
+      presence: true,
+      message: 'This field is required',
+    }),
     validateLength({
       min: 0,
       max: 10,
@@ -84,6 +109,10 @@ export default {
     }),
   ],
   dcpNewindustrialsqft: [
+    validatePresence({
+      presence: true,
+      message: 'This field is required',
+    }),
     validateLength({
       min: 0,
       max: 10,
@@ -96,6 +125,10 @@ export default {
     }),
   ],
   dcpNewcommunityfacilitysqft: [
+    validatePresence({
+      presence: true,
+      message: 'This field is required',
+    }),
     validateLength({
       min: 0,
       max: 10,

--- a/client/app/validations/submittable-project-form.js
+++ b/client/app/validations/submittable-project-form.js
@@ -1,56 +1,5 @@
-import {
-  validatePresence,
-} from 'ember-changeset-validations/validators';
 import SaveableProjectForm from './saveable-project-form';
 
 export default {
   ...SaveableProjectForm,
-  dcpNumberofnewdwellingunits: [
-    validatePresence({
-      presence: true,
-      message: 'This field is required',
-    }),
-  ],
-  dcpIncrementhousingunits: [
-    validatePresence({
-      presence: true,
-      message: 'This field is required',
-    }),
-  ],
-  dcpActionaffordabledwellingunits: [
-    validatePresence({
-      presence: true,
-      message: 'This field is required',
-    }),
-  ],
-  dcpIncrementalaffordabledwellingunits: [
-    validatePresence({
-      presence: true,
-      message: 'This field is required',
-    }),
-  ],
-  dcpResidentialsqft: [
-    validatePresence({
-      presence: true,
-      message: 'This field is required',
-    }),
-  ],
-  dcpNewcommercialsqft: [
-    validatePresence({
-      presence: true,
-      message: 'This field is required',
-    }),
-  ],
-  dcpNewindustrialsqft: [
-    validatePresence({
-      presence: true,
-      message: 'This field is required',
-    }),
-  ],
-  dcpNewcommunityfacilitysqft: [
-    validatePresence({
-      presence: true,
-      message: 'This field is required',
-    }),
-  ],
 };


### PR DESCRIPTION
 bug-fix: enable the submit button only if the entire form is saveable and submittable (#1188)

### Summary
* 14456 Only enable the submit button if the form is saveable, all PAUSF (Project Area Units and Square Footage) and RWCDS form fields are filled out and no error state, and is submittable
* 14066 moved validatePresence validation from submittable-project to saveable-project to prevent the SUBMIT button being enabled if the project area units questions are blank.
* bug/14561 fixed the notification banner not closing bug

