### PR TITLE
9912 state select dropdown fails to autocomplete

### DIFF
--- a/client/app/components/packages/applicant-fieldset.hbs
+++ b/client/app/components/packages/applicant-fieldset.hbs
@@ -94,15 +94,16 @@
         <label data-test-applicant-state-dropdown>
           State
           <PowerSelect
+            @searchEnabled={{false}}
             supportsDataTestProperties={{true}}
             @selected={{@applicant.dcpState}}
             @placeholder="state"
-            @searchEnabled={{true}}
             @searchField="label"
             @options={{map-by 'code' (optionset 'applicant' 'dcpState' 'list')}}
             @onChange={{fn (mut @applicant.dcpState)}}
             @allowClear={{true}}
           as |stateCode|>
+
             {{optionset 'applicant' 'dcpState' 'label' stateCode}}
           </PowerSelect>
         </label>


### PR DESCRIPTION
### Summary
Removed the search box for the state drop down.

#### Tasks/Bug Numbers
 - Fixes [AB#9912](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/9912)

### Technical Explanation
 PowerSelect expects a string array for type-a-head functionality but is getting an object containing objects. The LOE to fix this is greater than the value for 2 letter inputs.

#### Before
<img width="457" alt="Screen Shot 2023-09-25 at 10 51 17 AM" src="https://github.com/NYCPlanning/labs-applicant-portal/assets/11340947/a9216e8e-86db-476e-ab9d-4b9e7d969514">

#### After
<img width="391" alt="Screen Shot 2023-09-25 at 10 50 51 AM" src="https://github.com/NYCPlanning/labs-applicant-portal/assets/11340947/d0952b47-8e84-407e-9111-e6c4c7641a45">

