### PR TITLE
Add and use new optionset for Type II eligibility question

### DIFF
--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -5,6 +5,7 @@ import COMMON_OPTIONSETS, {
   YES_NO,
   YES_NO_UNSURE,
   YES_NO_UNSURE_SMALLINT,
+  YES_NO_UNSURE_LONGINT,
   YES_NO_DONT_KNOW,
 } from '../optionsets/common';
 import APPLICANT_OPTIONSETS from '../optionsets/applicant';
@@ -122,7 +123,7 @@ const OPTIONSET_LOOKUP = {
     dcpIncludezoningtextamendment: YES_NO_DONT_KNOW,
     dcpIsplannigondevelopingaffordablehousing: YES_NO,
     dcpIsapplicantseekingaction: YES_NO_DONT_KNOW,
-    dcpApplicantpursuetype2eligibility: YES_NO_UNSURE_SMALLINT,
+    dcpApplicantpursuetype2eligibility: YES_NO_UNSURE_LONGINT,
   },
   pasForm: {
     dcpProposedprojectorportionconstruction: YES_NO_UNSURE,
@@ -138,7 +139,7 @@ const OPTIONSET_LOOKUP = {
     dcpIsinclusionaryhousingdesignatedarea: YES_NO,
     dcpDiscressionaryfundingforffordablehousing: YES_NO_UNSURE,
     dcpHousingunittype: DCPHOUSINGUNITTYPE,
-    dcpPursuetype2eligibility: YES_NO_UNSURE_SMALLINT,
+    dcpPursuetype2eligibility: YES_NO_UNSURE_LONGINT,
   },
   affectedZoningResolution: {
     actions: AFFECTED_ZONING_RESOLUTION_ACTION,

--- a/client/app/optionsets/common.js
+++ b/client/app/optionsets/common.js
@@ -64,6 +64,21 @@ export const YES_NO_UNSURE_SMALLINT = {
   },
 };
 
+export const YES_NO_UNSURE_LONGINT = {
+  YES: {
+    code: 717170000,
+    label: 'Yes',
+  },
+  NO: {
+    code: 717170001,
+    label: 'No',
+  },
+  UNSURE: {
+    code: null,
+    label: 'Unsure at this time',
+  },
+};
+
 export const YES_NO_DONT_KNOW = {
   YES: {
     code: 717170000,
@@ -85,6 +100,7 @@ const COMMON_OPTIONSETS = {
   YES_NO_PICKLIST_CODE,
   YES_NO_DONT_KNOW,
   YES_NO_INTEGER,
+  YES_NO_UNSURE_LONGINT
 };
 
 export default COMMON_OPTIONSETS;


### PR DESCRIPTION
This PR solves a bug where users could not save the PAS or RWDCS forms when selecting an answer other than "Unsure" for the Type II eligibility question. It seems our server was expecting different codes than those assigned to the answers in the YES_NO_UNSURE_SMALLINT optionset. This solution adds a new optionset and instead uses those for the question in both forms.