### PR TITLE
Remove code related to new Green Fast Track CEQR Type 2 eligibility to unblock release of Sharepoint Graph API conversion

### DIFF
--- a/client/app/components/packages/pas-form/project-area.hbs
+++ b/client/app/components/packages/pas-form/project-area.hbs
@@ -105,22 +105,6 @@
 
     <Ui::Question as |Q|>
       <Q.Legend>
-        Is the applicant seeking to pursue Type II eligibility pursuant to <Ui::ExternalLink href="https://www.nyc.gov/html/oec/downloads/pdf/ceqr/CEQR%20Rules-%2062%20RCNY%20Chapter%205.pdf">62 RCNY 5-05(e) - Green Fast Track for housing?</Ui::ExternalLink>
-      </Q.Legend>
-
-      <form.Field
-        @attribute="dcpPursuetype2eligibility"
-        @type="radio-group"
-        as |RadioGroup|
-      >
-        <RadioGroup
-          @options={{optionset 'pasForm' 'dcpPursuetype2eligibility' 'list'}}>
-        </RadioGroup>
-      </form.Field>
-    </Ui::Question>
-
-    <Ui::Question as |Q|>
-      <Q.Legend>
         Is the proposed Project Area in an <Ui::ExternalLink href="https://zola.planning.nyc.gov/">Industrial Business Zone</Ui::ExternalLink>?
       </Q.Legend>
 

--- a/client/app/components/packages/rwcds-form/proposed-project-actions.hbs
+++ b/client/app/components/packages/rwcds-form/proposed-project-actions.hbs
@@ -88,21 +88,6 @@
         </form.Field>
       </Ui::Question>
 
-      <Ui::Question as |Q|>
-        <Q.Legend>
-          Is the applicant seeking to pursue Type II eligibility pursuant to <Ui::ExternalLink href="https://www.nyc.gov/html/oec/downloads/pdf/ceqr/CEQR%20Rules-%2062%20RCNY%20Chapter%205.pdf">62 RCNY 5-05(e) - Green Fast Track for housing?</Ui::ExternalLink>
-        </Q.Legend>
-
-        <form.Field
-          @attribute="dcpApplicantpursuetype2eligibility"
-          @type="radio-group"
-          as |RadioGroup|>
-
-          <RadioGroup
-            @options={{optionset 'rwcdsForm' 'dcpApplicantpursuetype2eligibility' 'list'}}>
-          </RadioGroup>
-        </form.Field>
-      </Ui::Question>
     </div>
   </form.Section>
 {{/let}}

--- a/client/app/components/packages/rwcds-form/show.hbs
+++ b/client/app/components/packages/rwcds-form/show.hbs
@@ -285,15 +285,6 @@
       {{/if}}
     </section>
 
-    <Ui::Answer @beside={{true}} as |A|>
-      <A.Prompt>
-        Is the applicant seeking to pursue Type II eligibility pursuant to 62 RCNY 5-05(e) - Green Fast Track for housing? 
-      </A.Prompt>
-      <A.Field>
-        {{optionset 'rwcdsForm' 'dcpApplicantpursuetype2eligibility' 'label' @package.rwcdsForm.dcpApplicantpursuetype2eligibility}}
-      </A.Field>
-    </Ui::Answer>
-
     <section class="form-section">
       <h2 class="section-header">
         <span id="analysis" class="section-anchor"></span>

--- a/client/app/helpers/optionset.js
+++ b/client/app/helpers/optionset.js
@@ -123,7 +123,6 @@ const OPTIONSET_LOOKUP = {
     dcpIncludezoningtextamendment: YES_NO_DONT_KNOW,
     dcpIsplannigondevelopingaffordablehousing: YES_NO,
     dcpIsapplicantseekingaction: YES_NO_DONT_KNOW,
-    dcpApplicantpursuetype2eligibility: YES_NO_UNSURE_LONGINT,
   },
   pasForm: {
     dcpProposedprojectorportionconstruction: YES_NO_UNSURE,
@@ -139,7 +138,6 @@ const OPTIONSET_LOOKUP = {
     dcpIsinclusionaryhousingdesignatedarea: YES_NO,
     dcpDiscressionaryfundingforffordablehousing: YES_NO_UNSURE,
     dcpHousingunittype: DCPHOUSINGUNITTYPE,
-    dcpPursuetype2eligibility: YES_NO_UNSURE_LONGINT,
   },
   affectedZoningResolution: {
     actions: AFFECTED_ZONING_RESOLUTION_ACTION,

--- a/client/app/models/pas-form.js
+++ b/client/app/models/pas-form.js
@@ -717,8 +717,6 @@ export default class PasFormModel extends Model {
 
   @attr('number') dcpLanduseactiontype2;
 
-  @attr('number') dcpPursuetype2eligibility;
-
   @attr('number') dcpProposedprojectorportionconstruction;
 
   @attr('number') dcpProcommunityfacilitygrosssqft;
@@ -806,9 +804,7 @@ export default class PasFormModel extends Model {
 
   async saveDirtyBbls() {
     return Promise.all(
-      this.bbls
-        .filter((bbl) => bbl.hasDirtyAttributes)
-        .map((bbl) => bbl.save()),
+      this.bbls.filter((bbl) => bbl.hasDirtyAttributes).map((bbl) => bbl.save())
     );
   }
 
@@ -816,7 +812,7 @@ export default class PasFormModel extends Model {
     return Promise.all(
       this.applicants
         .filter((applicant) => applicant.hasDirtyAttributes)
-        .map((applicant) => applicant.save()),
+        .map((applicant) => applicant.save())
     );
   }
 
@@ -837,7 +833,9 @@ export default class PasFormModel extends Model {
   }
 
   get isApplicantsDirty() {
-    const dirtyApplicants = this.applicants.filter((applicant) => applicant.hasDirtyAttributes);
+    const dirtyApplicants = this.applicants.filter(
+      (applicant) => applicant.hasDirtyAttributes
+    );
 
     return dirtyApplicants.length > 0;
   }

--- a/client/app/models/rwcds-form.js
+++ b/client/app/models/rwcds-form.js
@@ -36,8 +36,6 @@ export default class RwcdsFormModel extends Model {
 
   @attr('string') dcpWhichactionsfromotheragenciesaresought;
 
-  @attr('number') dcpApplicantpursuetype2eligibility;
-
   @attr('string') dcpProposedprojectdevelopmentdescription;
 
   @attr('number') dcpVersion;
@@ -98,12 +96,14 @@ export default class RwcdsFormModel extends Model {
     return Promise.all(
       this.affectedZoningResolutions
         .filter((zoningResolution) => zoningResolution.hasDirtyAttributes)
-        .map((zoningResolution) => zoningResolution.save()),
+        .map((zoningResolution) => zoningResolution.save())
     );
   }
 
   get isAffectedZoningResolutionsDirty() {
-    const dirtyZrs = this.affectedZoningResolutions.filter((zr) => zr.hasDirtyAttributes);
+    const dirtyZrs = this.affectedZoningResolutions.filter(
+      (zr) => zr.hasDirtyAttributes
+    );
 
     return dirtyZrs.length > 0;
   }

--- a/server/src/packages/pas-form/pas-form.attrs.ts
+++ b/server/src/packages/pas-form/pas-form.attrs.ts
@@ -83,7 +83,6 @@ export const PAS_FORM_ATTRS = [
   'dcp_restrictivedeclaration',
   'dcp_cityregisterfilenumber',
   'dcp_restrictivedeclarationrequired',
-  'dcp_pursuetype2eligibility',
 
   // Proposed Development Site
   'dcp_estimatedcompletiondate',

--- a/server/src/packages/rwcds-form/rwcds-form.attrs.ts
+++ b/server/src/packages/rwcds-form/rwcds-form.attrs.ts
@@ -19,7 +19,6 @@ export const RWCDS_FORM_ATTRS = [
   'dcp_purposeandneedfortheproposedaction',
   'dcp_describethenoactionscenario',
   'dcp_applicant',
-  'dcp_applicantpursuetype2eligibility',
   'dcp_hasprojectchangedsincesubmissionofthepas',
   'traversedpath',
   'statuscode',


### PR DESCRIPTION
This PR removes code #1203 #1204 and #1218 related to the new questions for Green Fast Track CEQR type 2 eligibility. We have to do this so that we can release the changes in #1224 for converting to MSFT's Graph API for Sharepoint. We will revert this PR once the Green Fast Track changes are due to be released to prod. 