### PR TITLE
Support the creation of contacts

### DIFF
--- a/server/src/contact/contact.controller.ts
+++ b/server/src/contact/contact.controller.ts
@@ -11,6 +11,7 @@ import {
   UsePipes,
   Body,
   Param,
+  Post,
 } from '@nestjs/common';
 import { ContactService } from './contact.service';
 import { JsonApiSerializeInterceptor } from '../json-api-serialize.interceptor';
@@ -41,7 +42,7 @@ export class ContactController {
   ) {}
 
   @Get('/')
-  async getContact(@Session() session, @Query('me') me, @Query('email') email) {
+  async getContact(@Session() session, @Query('me') me, @Query('email') email, @Query('includeAllStatusCodes') includeAllStatusCodes = 'false') {
     // if this is a self-check, lookup the contact id from session
     if (me) {
       const { contactId } = session;
@@ -55,8 +56,15 @@ export class ContactController {
         return this.contactService.findOneById(contactId);
       }
     } else {
-      return this.contactService.findOneByEmail(email);
+      return this.contactService.findOneByEmail(email, includeAllStatusCodes === 'true');
     }
+  }
+
+  @UseGuards(AuthenticateGuard)
+  @UsePipes(JsonApiDeserializePipe)
+  @Post('/')
+  async create(@Body() body) {
+    return await this.contactService.create(body); 
   }
 
   @UseGuards(AuthenticateGuard)

--- a/server/src/contact/contact.service.ts
+++ b/server/src/contact/contact.service.ts
@@ -77,9 +77,10 @@ export class ContactService {
    * Uses the CRM Web API to query and return a Contact entity for given email
    *
    * @param      {string}  email      Email matching a CRM Contact Entity's emailaddress1 property
+   * @param      {boolean} includeAllStatusCodes A boolean on whether to only return active contacts. defaults to false.
    * @return     {object}             Object representing a CRM contact
    */
-  public async findOneByEmail(email: string) {
+  public async findOneByEmail(email: string, includeAllStatusCodes = false) {
     try {
       const {
         records: [firstRecord = GHOST_CONTACT],
@@ -88,7 +89,7 @@ export class ContactService {
         `
         $select=${CONTACT_ATTRS.join(',')}
         &$filter=startswith(emailaddress1, '${email}')
-          and statuscode eq ${ACTIVE_CODE}
+          ${includeAllStatusCodes ? '' : `and statuscode eq ${ACTIVE_CODE}`}
         &$top=1
       `,
       );


### PR DESCRIPTION
Add a POST endpoint to the contacts controller to access the contact creation service

closes #1247 

Updates the "get contact" endpoint to support finding all contacts, regardless of status code. This allows the finding of inactive contacts. The behavior is opt-in, to preserve behavior that relies on only seeing active records.